### PR TITLE
UI: Liquid Glass design system, sidebar, apps, command palette, and icon consistency

### DIFF
--- a/src/core/tools/paprMemory.ts
+++ b/src/core/tools/paprMemory.ts
@@ -107,6 +107,7 @@ export const searchAgentMemoryTool = createTool({
       max_memories: args.maxMemories ?? 20,
       max_nodes: 15,
       enable_agentic_graph: true,
+      rank_results: true,
       response_format: "toon", // 30-60% token reduction for LLM contexts
     });
     return { success: true, data: response };

--- a/src/electron/index.cjs
+++ b/src/electron/index.cjs
@@ -308,6 +308,8 @@ function createMainWindow() {
     trafficLightPosition: { x: 16, y: 16 },
     transparent: true, // Enable window transparency for Liquid Glass
     backgroundColor: "#00000000", // Fully transparent background
+    vibrancy: "under-window", // macOS native blur of desktop behind window
+    visualEffectState: "active", // Keep blur active even when window loses focus
   });
 
   // Hide default menu

--- a/src/resources/skills/paprwork-design-system.md
+++ b/src/resources/skills/paprwork-design-system.md
@@ -122,6 +122,29 @@ Use the token system below. Build from primitives (Button, Card, Header, Modal, 
 
 Stop when the primary action is obvious in 2 seconds.
 
+### Apple Liquid Glass Guidelines (WWDC 2025)
+
+The "water drop" effect — translucent, not transparent or opaque:
+- **Background alpha: 5-20%** white/dark tint on the surface itself
+- **backdrop-filter: blur(20px) saturate(180%)** — makes background visible as soft color tint but unreadable
+- **Layered glass**: sidebar, content, and panels each add their own tint on top of the base
+- **Never fully opaque** — desktop wallpaper should bleed through as subtle color
+- **Never fully transparent** — text must remain readable (WCAG AA contrast)
+
+**Opacity ranges by element:**
+| Element | Light Mode | Dark Mode | Blur |
+|---------|-----------|-----------|------|
+| App background gradient | 72-78% | 72-78% | 20px |
+| Sidebar | 55% white | 55% black | 20px |
+| Content pane | 10% white | 10% black | 8px |
+| Glass panel | 65% white | 55% dark | 14-20px |
+| Active tab | 88% | 88% | 30px |
+| Inactive tab | 65% | 65% | 20px |
+| **Popover/Dropdown** | **88% white** | **88% dark** | **40px** |
+| **Modal overlay** | **varies** | **varies** | **24px** |
+
+**Popovers & dropdowns** overlay content, so they need stronger glass (88% + blur 40px) to ensure text is fully readable. Add `inset 0 0.5px 0 rgba(255,255,255,0.50)` for the Apple inner-shine edge. Use `border-radius: 14px` for popover containers.
+
 ### Design Tokens
 
 ```css
@@ -134,8 +157,10 @@ Stop when the primary action is obvious in 2 seconds.
   --ease: cubic-bezier(.2,.8,.2,1);
   --accent: #0161E0; --accent-2: #4f46e5;
 
-  /* Light */
-  --bg: #ffffff; --bg-2: #fafbfc; --text: #14161a; --muted: #667085;
+  /* Light — Liquid Glass */
+  --bg: linear-gradient(135deg, rgba(232,234,240,0.78), rgba(255,255,255,0.72), rgba(229,232,240,0.78));
+  --bg-2: rgba(249,249,249,0.78);
+  --text: #14161a; --muted: #667085;
   --border: rgba(15,23,42,0.10);
   --glass: rgba(255,255,255,0.65); --glass-2: rgba(255,255,255,0.45);
   --glass-border: rgba(15,23,42,0.12);
@@ -144,7 +169,8 @@ Stop when the primary action is obvious in 2 seconds.
 
 @media (prefers-color-scheme: dark){
   :root{
-    --bg: #05070b; --bg-2: rgba(255,255,255,0.03);
+    --bg: linear-gradient(135deg, rgba(10,12,16,0.78), rgba(20,22,28,0.72), rgba(18,20,26,0.78));
+    --bg-2: rgba(28,28,30,0.78);
     --text: rgba(255,255,255,0.92); --muted: rgba(255,255,255,0.55);
     --border: rgba(255,255,255,0.10);
     --glass: rgba(14,18,28,0.55); --glass-2: rgba(14,18,28,0.35);
@@ -162,8 +188,38 @@ Stop when the primary action is obvious in 2 seconds.
   background: var(--glass);
   border: 1px solid var(--glass-border);
   box-shadow: var(--shadow-1);
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+}
+```
+
+**App Icon Glass Orb** (used in tabs, favorites, command palette)
+```css
+.glass-orb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(1,97,224,0.40), rgba(12,205,255,0.30), rgba(0,254,254,0.25));
+  border: 0.5px solid rgba(12,205,255,0.30);
+  box-shadow: 0 1px 3px rgba(1,97,224,0.20), inset 0 1px 1px rgba(255,255,255,0.35);
+  overflow: hidden;
+  position: relative;
+}
+.glass-orb::after {
+  content: '';
+  position: absolute;
+  top: 1px; left: 15%; width: 70%; height: 40%;
+  background: linear-gradient(to bottom, rgba(255,255,255,0.45), transparent);
+  border-radius: 50%;
+  pointer-events: none;
+}
+.glass-orb__icon {
+  width: 10px; height: 10px;
+  color: rgba(255,255,255,0.95);
+  position: relative; z-index: 1;
 }
 ```
 

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -8,6 +8,7 @@ import { AppLayout } from "./components/Layout/AppLayout";
 import { Sidebar } from "./components/Sidebar/Sidebar";
 import { TabBar } from "./components/Tabs/TabBar";
 import { ContentArea } from "./components/Layout/ContentArea";
+import { CommandPalette } from "./components/CommandPalette/CommandPalette";
 import { useChat } from "./hooks/useChat";
 import { useTabs } from "./hooks/useTabs";
 import { useTabStore } from "./stores/tabStore";
@@ -27,6 +28,19 @@ export function App() {
   const { activeTabId, activeLeftTab } = useTabStore();
   const { activeRequest, claimedByChat, respond } = usePermissionStore();
   const [hydrated, setHydrated] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+
+  // Cmd+K to open command palette
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setCommandPaletteOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   // Initialize the Electron IPC permission listener once
   useEffect(() => {
@@ -181,6 +195,10 @@ export function App() {
       {activeRequest && !claimedByChat && (
         <KeyPermissionModal request={activeRequest} onResponse={respond} />
       )}
+      <CommandPalette
+        isOpen={commandPaletteOpen}
+        onClose={() => setCommandPaletteOpen(false)}
+      />
     </>
   );
 }

--- a/ui/components/Apps/AppCard.css
+++ b/ui/components/Apps/AppCard.css
@@ -1,0 +1,315 @@
+/**
+ * AppCard Styles - Wabi-inspired Liquid Glass Orb Design
+ * Default orb uses Papr brand gradient: #0161E0 → #0CCDFF → #00FEFE
+ */
+
+.app-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  /* True Liquid Glass: translucent card with blur */
+  background: rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(20px) saturate(150%);
+  -webkit-backdrop-filter: blur(20px) saturate(150%);
+  border: 1px solid rgba(255, 255, 255, 0.30);
+  border-radius: 18px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 220ms var(--ease, cubic-bezier(.2,.8,.2,1)),
+              box-shadow 220ms var(--ease, cubic-bezier(.2,.8,.2,1)),
+              background 220ms ease;
+}
+
+.app-card:hover {
+  transform: translateY(-3px) scale(1.01);
+  background: rgba(255, 255, 255, 0.45);
+  box-shadow:
+    0 12px 40px rgba(0, 0, 0, 0.08),
+    0 0 0 1px rgba(255, 255, 255, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.30);
+}
+
+/* Featured card variant */
+.app-card--featured {
+  grid-column: 1 / -1;
+  flex-direction: row;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.40);
+}
+
+.app-card--featured:hover {
+  background: rgba(255, 255, 255, 0.50);
+}
+
+.app-card--featured .app-card__preview {
+  width: 280px;
+  min-width: 280px;
+  height: auto;
+  min-height: 200px;
+}
+
+.app-card--featured .app-card__orb {
+  width: 140px;
+  height: 140px;
+}
+
+.app-card--featured .app-card__orb-icon svg {
+  width: 56px;
+  height: 56px;
+}
+
+.app-card--featured .app-card__content {
+  padding: 32px;
+  justify-content: center;
+}
+
+.app-card--featured .app-card__title {
+  font-size: 22px;
+}
+
+.app-card--featured .app-card__description {
+  font-size: 15px;
+  -webkit-line-clamp: 3;
+}
+
+/* Preview area with glass orb */
+.app-card__preview {
+  width: 100%;
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+}
+
+/* Glass orb - Papr brand gradient default */
+.app-card__orb {
+  position: relative;
+  width: 110px;
+  height: 110px;
+  border-radius: 50%;
+  /* Papr brand gradient: Blue → Cyan → Teal */
+  background: linear-gradient(
+    135deg,
+    rgba(1, 97, 224, 0.45) 0%,
+    rgba(12, 205, 255, 0.35) 60%,
+    rgba(0, 254, 254, 0.30) 100%
+  );
+  backdrop-filter: blur(16px) saturate(140%);
+  -webkit-backdrop-filter: blur(16px) saturate(140%);
+  border: 1px solid rgba(12, 205, 255, 0.35);
+  box-shadow:
+    0 6px 24px rgba(1, 97, 224, 0.18),
+    0 2px 8px rgba(0, 254, 254, 0.10),
+    inset 0 1px 2px rgba(255, 255, 255, 0.45);
+  transition: transform 220ms var(--ease, cubic-bezier(.2,.8,.2,1)),
+              box-shadow 220ms var(--ease, cubic-bezier(.2,.8,.2,1));
+}
+
+.app-card:hover .app-card__orb {
+  transform: scale(1.06);
+  box-shadow:
+    0 10px 36px rgba(1, 97, 224, 0.25),
+    0 4px 12px rgba(0, 254, 254, 0.15),
+    inset 0 1px 3px rgba(255, 255, 255, 0.55);
+}
+
+/* Orb inner: centers the icon */
+.app-card__orb-inner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(1, 97, 224, 0.80);
+}
+
+/* Refraction highlight on top of orb - glass lensing effect */
+.app-card__orb-highlight {
+  position: absolute;
+  top: 8px;
+  left: 14px;
+  right: 14px;
+  height: 40%;
+  border-radius: 50%;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.55) 0%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  pointer-events: none;
+}
+
+/* Icon inside orb */
+.app-card__orb-icon {
+  width: 56px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.app-card__orb-icon svg {
+  width: 44px;
+  height: 44px;
+}
+
+/* Content area */
+.app-card__content {
+  padding: 16px 20px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.app-card__title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  letter-spacing: -0.01em;
+}
+
+.app-card__title-input {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  border: none;
+  border-bottom: 2px solid var(--accent);
+  background: transparent;
+  outline: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.app-card__description {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.app-card__date {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-top: 4px;
+}
+
+/* Hover actions */
+.app-card__actions {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.app-card__actions--visible {
+  opacity: 1;
+}
+
+.app-card__action {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--glass-bg);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border: 1px solid var(--glass-border, var(--border));
+  border-radius: 8px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.app-card__action:hover {
+  background: var(--glass-bg-hover);
+  color: var(--text-primary);
+}
+
+.app-card__action--favorited {
+  color: #FFD700;
+}
+
+.app-card__action--delete:hover {
+  background: var(--error);
+  border-color: var(--error);
+  color: white;
+}
+
+/* Drag state */
+.app-card[draggable="true"] {
+  cursor: grab;
+}
+
+.app-card[draggable="true"]:active {
+  cursor: grabbing;
+  opacity: 0.7;
+}
+
+/* Dark mode adjustments */
+@media (prefers-color-scheme: dark) {
+  .app-card {
+    background: rgba(20, 22, 28, 0.40);
+    border-color: rgba(255, 255, 255, 0.10);
+  }
+
+  .app-card:hover {
+    background: rgba(20, 22, 28, 0.55);
+    box-shadow:
+      0 12px 40px rgba(0, 0, 0, 0.30),
+      0 0 0 1px rgba(255, 255, 255, 0.08),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  }
+
+  .app-card--featured {
+    background: rgba(20, 22, 28, 0.45);
+  }
+
+  .app-card__orb {
+    /* Papr brand gradient - dark mode: deeper tones */
+    background: linear-gradient(
+      135deg,
+      rgba(1, 97, 224, 0.50) 0%,
+      rgba(12, 205, 255, 0.35) 60%,
+      rgba(0, 254, 254, 0.25) 100%
+    );
+    border-color: rgba(12, 205, 255, 0.25);
+    box-shadow:
+      0 6px 24px rgba(1, 97, 224, 0.30),
+      0 2px 8px rgba(0, 254, 254, 0.12),
+      inset 0 1px 1px rgba(255, 255, 255, 0.12);
+  }
+
+  .app-card:hover .app-card__orb {
+    box-shadow:
+      0 10px 36px rgba(1, 97, 224, 0.40),
+      0 4px 12px rgba(0, 254, 254, 0.18),
+      inset 0 1px 2px rgba(255, 255, 255, 0.18);
+  }
+
+  .app-card__orb-inner {
+    color: rgba(12, 205, 255, 0.90);
+  }
+
+  .app-card__orb-highlight {
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.18) 0%,
+      rgba(255, 255, 255, 0) 100%
+    );
+  }
+}

--- a/ui/components/Apps/AppCard.tsx
+++ b/ui/components/Apps/AppCard.tsx
@@ -1,0 +1,244 @@
+/**
+ * AppCard - Wabi-inspired app card with Liquid Glass orb icon
+ */
+
+import React, { useState, useRef, useCallback } from "react";
+import type { Artifact } from "../../stores/artifactsStore";
+import "./AppCard.css";
+
+interface AppCardProps {
+  artifact: Artifact;
+  featured?: boolean;
+  onDelete: () => void;
+  onToggleFavorite: () => void;
+  onOpen: () => void;
+  onRename?: (newTitle: string) => void;
+}
+
+
+export function AppCard({
+  artifact,
+  featured = false,
+  onDelete,
+  onToggleFavorite,
+  onOpen,
+  onRename,
+}: AppCardProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState(artifact.title);
+  const titleInputRef = useRef<HTMLInputElement>(null);
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diff = now.getTime() - date.getTime();
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+    if (days === 0) return "Today";
+    if (days === 1) return "Yesterday";
+    if (days < 7) return `${days} days ago`;
+    if (days < 30) return `${Math.floor(days / 7)} weeks ago`;
+    return date.toLocaleDateString();
+  };
+
+  const startRename = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setIsEditing(true);
+      setEditTitle(artifact.title);
+      setTimeout(() => titleInputRef.current?.select(), 0);
+    },
+    [artifact.title],
+  );
+
+  const commitRename = useCallback(() => {
+    setIsEditing(false);
+    const trimmed = editTitle.trim();
+    if (trimmed && trimmed !== artifact.title) {
+      onRename?.(trimmed);
+    }
+  }, [editTitle, artifact.title, onRename]);
+
+  const handleTitleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commitRename();
+      } else if (e.key === "Escape") {
+        setIsEditing(false);
+        setEditTitle(artifact.title);
+      }
+    },
+    [commitRename, artifact.title],
+  );
+
+  const handleDragStart = useCallback(
+    (e: React.DragEvent) => {
+      e.dataTransfer.setData(
+        "application/json",
+        JSON.stringify({
+          id: artifact.id,
+          type: artifact.type,
+          title: artifact.title,
+          ...(artifact.icon ? { icon: artifact.icon } : {}),
+        }),
+      );
+      e.dataTransfer.effectAllowed = "copy";
+    },
+    [artifact.id, artifact.type, artifact.title, artifact.icon],
+  );
+
+  const renderIcon = () => {
+    if (artifact.icon) {
+      return (
+        <span
+          className="app-card__orb-icon"
+          dangerouslySetInnerHTML={{ __html: artifact.icon }}
+        />
+      );
+    }
+
+    // Default grid icon for apps without custom icons
+    return (
+      <svg
+        className="app-card__orb-icon"
+        width="48"
+        height="48"
+        viewBox="0 0 24 24"
+        fill="none"
+      >
+        <rect
+          x="3"
+          y="3"
+          width="7"
+          height="7"
+          rx="2"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="14"
+          y="3"
+          width="7"
+          height="7"
+          rx="2"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="3"
+          y="14"
+          width="7"
+          height="7"
+          rx="2"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="14"
+          y="14"
+          width="7"
+          height="7"
+          rx="2"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        />
+      </svg>
+    );
+  };
+
+  return (
+    <div
+      className={`app-card ${featured ? "app-card--featured" : ""}`}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onClick={onOpen}
+      draggable
+      onDragStart={handleDragStart}
+    >
+      {/* Glass orb preview */}
+      <div className="app-card__preview">
+        <div className="app-card__orb">
+          <div className="app-card__orb-inner">{renderIcon()}</div>
+          <div className="app-card__orb-highlight" />
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="app-card__content">
+        {isEditing ? (
+          <input
+            ref={titleInputRef}
+            className="app-card__title-input"
+            value={editTitle}
+            onChange={(e) => setEditTitle(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={handleTitleKeyDown}
+            onClick={(e) => e.stopPropagation()}
+            autoFocus
+          />
+        ) : (
+          <h3
+            className="app-card__title"
+            onDoubleClick={startRename}
+            title="Double-click to rename"
+          >
+            {artifact.title}
+          </h3>
+        )}
+        {artifact.description && (
+          <p className="app-card__description">{artifact.description}</p>
+        )}
+        <span className="app-card__date">{formatDate(artifact.updatedAt)}</span>
+      </div>
+
+      {/* Actions */}
+      <div
+        className={`app-card__actions ${isHovered ? "app-card__actions--visible" : ""}`}
+      >
+        <button
+          className={`app-card__action ${artifact.favorite ? "app-card__action--favorited" : ""}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleFavorite();
+          }}
+          aria-label="Toggle favorite"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill={artifact.favorite ? "currentColor" : "none"}
+          >
+            <path
+              d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+        <button
+          className="app-card__action app-card__action--delete"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          aria-label="Delete"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+            <path
+              d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6h14z"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/Apps/AppsView.css
+++ b/ui/components/Apps/AppsView.css
@@ -1,0 +1,234 @@
+/**
+ * AppsView Styles - Wabi-inspired minimal design with Liquid Glass
+ */
+
+.apps-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  background: transparent;
+  overflow: hidden;
+}
+
+/* Header */
+.apps-view__header {
+  padding: 24px 32px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.apps-view__title {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.apps-view__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.apps-view__search {
+  width: 220px;
+  padding: 8px 14px;
+  background: var(--glass-bg);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border: 1px solid var(--glass-border, var(--border));
+  border-radius: 10px;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-family: var(--font-body);
+  transition: all 160ms var(--ease, cubic-bezier(.2,.8,.2,1));
+}
+
+.apps-view__search:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(var(--accent-rgb, 0,113,227), 0.12);
+  width: 280px;
+}
+
+.apps-view__search::placeholder {
+  color: var(--text-tertiary);
+}
+
+/* Create bar */
+.apps-view__create {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 32px;
+}
+
+.apps-view__create-input {
+  flex: 1;
+  max-width: 320px;
+  padding: 10px 16px;
+  background: var(--glass-bg);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border: 1px solid var(--glass-border, var(--border));
+  border-radius: 12px;
+  color: var(--text-primary);
+  font-size: 15px;
+  font-family: var(--font-body);
+  transition: all 160ms var(--ease, cubic-bezier(.2,.8,.2,1));
+}
+
+.apps-view__create-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(var(--accent-rgb, 0,113,227), 0.12);
+}
+
+.apps-view__create-input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.apps-view__create-btn {
+  height: 40px;
+  padding: 0 20px;
+  background: linear-gradient(135deg, var(--accent, #0071E3), var(--accent-color, #4f46e5));
+  border: none;
+  border-radius: 12px;
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 160ms var(--ease, cubic-bezier(.2,.8,.2,1)),
+              box-shadow 160ms var(--ease, cubic-bezier(.2,.8,.2,1)),
+              opacity 160ms ease;
+  white-space: nowrap;
+}
+
+.apps-view__create-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(0, 113, 227, 0.25);
+}
+
+.apps-view__create-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* Sort controls */
+.apps-view__controls {
+  padding: 0 32px 8px;
+}
+
+.apps-view__sort {
+  display: flex;
+  gap: 4px;
+}
+
+.apps-view__sort-btn {
+  padding: 6px 14px;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: var(--text-tertiary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.apps-view__sort-btn:hover {
+  color: var(--text-secondary);
+  background: var(--hover);
+}
+
+.apps-view__sort-btn--active {
+  color: var(--text-primary);
+  background: var(--glass-bg);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+/* Scrollable content */
+.apps-view__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 32px 32px;
+}
+
+/* Section labels */
+.apps-view__section-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+
+/* Featured section */
+.apps-view__featured {
+  margin-bottom: 32px;
+}
+
+/* App grid section */
+.apps-view__section {
+  margin-bottom: 32px;
+}
+
+.apps-view__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+/* Empty state */
+.apps-view__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 300px;
+  color: var(--text-secondary);
+  gap: 12px;
+}
+
+.apps-view__empty-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.apps-view__empty-subtitle {
+  font-size: 14px;
+  color: var(--text-tertiary);
+  margin: 0;
+  max-width: 300px;
+  text-align: center;
+  line-height: 1.5;
+}
+
+/* Scrollbar */
+.apps-view__content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.apps-view__content::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.apps-view__content::-webkit-scrollbar-thumb {
+  background: var(--text-tertiary);
+  border-radius: 3px;
+  opacity: 0.3;
+}
+
+.apps-view__content::-webkit-scrollbar-thumb:hover {
+  background: var(--text-secondary);
+}

--- a/ui/components/Apps/AppsView.tsx
+++ b/ui/components/Apps/AppsView.tsx
@@ -1,0 +1,312 @@
+/**
+ * AppsView - Wabi-inspired app gallery with Liquid Glass design
+ * Clean, minimal interface focused on app discovery and creation
+ */
+
+import React, { useState, useCallback, useMemo } from "react";
+import { useArtifacts } from "../../hooks/useArtifacts";
+import { useTabs } from "../../hooks/useTabs";
+import { gateway } from "../../src/lib/gateway";
+import { AppCard } from "./AppCard";
+import type { Artifact } from "../../stores/artifactsStore";
+import "./AppsView.css";
+
+type SortOption = "recent" | "name" | "favorites";
+
+export function AppsView() {
+  const {
+    filteredArtifacts,
+    loading,
+    error,
+    searchQuery,
+    setSearchQuery,
+    deleteArtifact,
+    toggleFavorite,
+    createApp,
+    loadArtifacts,
+  } = useArtifacts();
+  const { createTab, switchToTab } = useTabs();
+
+  const [sortBy, setSortBy] = useState<SortOption>("recent");
+  const [newAppTitle, setNewAppTitle] = useState("");
+
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (confirm("Are you sure you want to delete this app?")) {
+      await deleteArtifact(id, "app");
+    }
+  };
+
+  const handleToggleFavorite = async (id: string) => {
+    await toggleFavorite(id, "app");
+  };
+
+  const handleOpen = (id: string, title: string, icon?: string) => {
+    const tabId = createTab("app", id, title, icon ? { icon } : {});
+    switchToTab(tabId);
+  };
+
+  const handleRename = useCallback(
+    async (id: string, newTitle: string) => {
+      await gateway.send("app:update", { appId: id, title: newTitle });
+      loadArtifacts();
+    },
+    [loadArtifacts],
+  );
+
+  const handleCreateApp = async () => {
+    const title = newAppTitle.trim();
+    if (!title) return;
+
+    const app = await createApp(
+      title,
+      "Generated mini app",
+      [
+        {
+          filename: "index.html",
+          content: `<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${title}</title>
+    <style>
+      body { font-family: -apple-system, sans-serif; margin: 24px; color: #1d1d1f; }
+      h1 { margin: 0 0 12px; }
+    </style>
+  </head>
+  <body>
+    <h1>${title}</h1>
+    <p>New Papr mini-app</p>
+  </body>
+</html>`,
+        },
+      ],
+    );
+    if (app) {
+      setNewAppTitle("");
+      handleOpen(app.id, app.title);
+    }
+  };
+
+  // Filter to apps only, then sort
+  const apps = useMemo(() => {
+    let result = filteredArtifacts.filter((a) => a.type === "app");
+
+    switch (sortBy) {
+      case "name":
+        result = [...result].sort((a, b) => a.title.localeCompare(b.title));
+        break;
+      case "favorites":
+        result = [...result].sort((a, b) => {
+          if (a.favorite && !b.favorite) return -1;
+          if (!a.favorite && b.favorite) return 1;
+          return (
+            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+          );
+        });
+        break;
+      case "recent":
+      default:
+        result = [...result].sort(
+          (a, b) =>
+            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+        );
+    }
+
+    return result;
+  }, [filteredArtifacts, sortBy]);
+
+  // Featured app: most recent favorited, or just most recent
+  const featuredApp = useMemo(() => {
+    if (apps.length === 0) return null;
+    const favorited = apps.find((a) => a.favorite);
+    return favorited || apps[0];
+  }, [apps]);
+
+  const remainingApps = useMemo(
+    () => (featuredApp ? apps.filter((a) => a.id !== featuredApp.id) : apps),
+    [apps, featuredApp],
+  );
+
+  return (
+    <div className="apps-view">
+      {/* Header */}
+      <div className="apps-view__header">
+        <h2 className="apps-view__title">Apps</h2>
+
+        <div className="apps-view__header-actions">
+          <input
+            type="text"
+            className="apps-view__search"
+            placeholder="Search apps..."
+            value={searchQuery}
+            onChange={handleSearch}
+          />
+        </div>
+      </div>
+
+      {/* Create bar */}
+      <div className="apps-view__create">
+        <input
+          type="text"
+          className="apps-view__create-input"
+          placeholder="New app name..."
+          value={newAppTitle}
+          onChange={(e) => setNewAppTitle(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleCreateApp();
+          }}
+        />
+        <button
+          className="apps-view__create-btn"
+          onClick={() => void handleCreateApp()}
+          disabled={!newAppTitle.trim()}
+        >
+          Create
+        </button>
+      </div>
+
+      {/* Sort controls */}
+      <div className="apps-view__controls">
+        <div className="apps-view__sort">
+          {(["recent", "name", "favorites"] as SortOption[]).map((option) => (
+            <button
+              key={option}
+              className={`apps-view__sort-btn ${sortBy === option ? "apps-view__sort-btn--active" : ""}`}
+              onClick={() => setSortBy(option)}
+            >
+              {option === "recent"
+                ? "Recent"
+                : option === "name"
+                  ? "Name"
+                  : "Favorites"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="apps-view__content">
+        {loading && (
+          <div className="apps-view__empty">
+            <p>Loading apps...</p>
+          </div>
+        )}
+
+        {error && (
+          <div className="apps-view__empty">
+            <p style={{ color: "var(--error)" }}>{error}</p>
+            <button className="apps-view__create-btn" onClick={loadArtifacts}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {!loading && !error && apps.length === 0 && (
+          <div className="apps-view__empty">
+            <svg
+              width="64"
+              height="64"
+              viewBox="0 0 24 24"
+              fill="none"
+              opacity="0.2"
+            >
+              <rect
+                x="3"
+                y="3"
+                width="7"
+                height="7"
+                rx="2"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              />
+              <rect
+                x="14"
+                y="3"
+                width="7"
+                height="7"
+                rx="2"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              />
+              <rect
+                x="3"
+                y="14"
+                width="7"
+                height="7"
+                rx="2"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              />
+              <rect
+                x="14"
+                y="14"
+                width="7"
+                height="7"
+                rx="2"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              />
+            </svg>
+            <p className="apps-view__empty-title">No apps yet</p>
+            <p className="apps-view__empty-subtitle">
+              Ask the AI to build one for you, or create one above.
+            </p>
+          </div>
+        )}
+
+        {!loading && !error && apps.length > 0 && (
+          <>
+            {/* Featured app */}
+            {featuredApp && (
+              <div className="apps-view__featured">
+                <span className="apps-view__section-label">Featured</span>
+                <AppCard
+                  artifact={featuredApp}
+                  featured
+                  onDelete={() => handleDelete(featuredApp.id)}
+                  onToggleFavorite={() =>
+                    handleToggleFavorite(featuredApp.id)
+                  }
+                  onOpen={() =>
+                    handleOpen(
+                      featuredApp.id,
+                      featuredApp.title,
+                      featuredApp.icon,
+                    )
+                  }
+                  onRename={(title) => handleRename(featuredApp.id, title)}
+                />
+              </div>
+            )}
+
+            {/* All apps grid */}
+            {remainingApps.length > 0 && (
+              <div className="apps-view__section">
+                <span className="apps-view__section-label">All Apps</span>
+                <div className="apps-view__grid">
+                  {remainingApps.map((app) => (
+                    <AppCard
+                      key={app.id}
+                      artifact={app}
+                      onDelete={() => handleDelete(app.id)}
+                      onToggleFavorite={() => handleToggleFavorite(app.id)}
+                      onOpen={() =>
+                        handleOpen(app.id, app.title, app.icon)
+                      }
+                      onRename={(title) => handleRename(app.id, title)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/components/Chat/ChatContainer.tsx
+++ b/ui/components/Chat/ChatContainer.tsx
@@ -18,7 +18,7 @@ import { gateway } from "../../src/lib/gateway";
 import { JobPermissionBanner } from "./JobPermissionBanner";
 import "./ChatContainer.css";
 
-const DEFAULT_SYSTEM_PROMPT = `You're Papr, an AI assistant running in Paprwork—a native Mac AI workspace.
+const DEFAULT_SYSTEM_PROMPT = `You're Pen, an AI assistant running in Paprwork—a native Mac AI workspace.
 
 ## Core Truths
 

--- a/ui/components/Chat/InputBar.css
+++ b/ui/components/Chat/InputBar.css
@@ -198,15 +198,21 @@
   background: var(--error-hover, #c0392b);
 }
 
-/* Model Picker Dropdown */
+/* Model Picker Dropdown — Apple Liquid Glass "popover" variant:
+   Popovers use stronger glass (higher opacity + blur) since they overlay content */
 .model-picker-dropdown {
   position: absolute;
   bottom: calc(100% + 8px); /* Position above the button with gap */
   left: 0;
-  background: var(--background-color);
-  border: 1px solid var(--border-color);
-  border-radius: 10px;
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.18);
+  background: rgba(255, 255, 255, 0.88);
+  backdrop-filter: blur(40px) saturate(180%);
+  -webkit-backdrop-filter: blur(40px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.30);
+  border-radius: 14px;
+  box-shadow:
+    0 8px 30px rgba(0, 0, 0, 0.18),
+    0 0 0 0.5px rgba(0, 0, 0, 0.06),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.50);
   min-width: 260px;
   max-width: 320px;
   max-height: 420px;
@@ -328,4 +334,16 @@
 
 .model-picker-item--selected .model-picker-item-desc {
   color: rgba(255, 255, 255, 0.75);
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .model-picker-dropdown {
+    background: rgba(28, 28, 30, 0.88);
+    border-color: rgba(255, 255, 255, 0.10);
+    box-shadow:
+      0 8px 30px rgba(0, 0, 0, 0.50),
+      0 0 0 0.5px rgba(255, 255, 255, 0.06),
+      inset 0 0.5px 0 rgba(255, 255, 255, 0.10);
+  }
 }

--- a/ui/components/Chat/MessageItem.css
+++ b/ui/components/Chat/MessageItem.css
@@ -31,6 +31,18 @@
   object-fit: cover;
 }
 
+/* Initials fallback when no profile photo */
+.message-avatar-user--initials {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #0161E0, #0CCDFF);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: var(--font-body);
+}
+
 /* Assistant Avatar - ring border + background */
 .message-avatar-assistant {
   width: 32px;
@@ -55,6 +67,14 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.message-sender-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1;
+  margin-bottom: 2px;
 }
 
 .message-tool-calls {

--- a/ui/components/Chat/MessageItem.tsx
+++ b/ui/components/Chat/MessageItem.tsx
@@ -4,8 +4,9 @@
  * Matches Paprwork v1 design with sequence-based rendering
  */
 
-import React from "react";
+import React, { useEffect } from "react";
 import type { ChatMessage } from "../../stores/chatStore";
+import { useProfileStore } from "../../stores/profileStore";
 import { ThinkingCard } from "./ThinkingCard";
 import { ExploringCard } from "./ExploringCard";
 import { PlanCard, parsePlanFromToolResult } from "./PlanCard";
@@ -258,8 +259,9 @@ export const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
     ? message.streamingReasoning || message.reasoning
     : message.reasoning;
 
-  // TODO: Get user info from session/settings
-  const userEmail = "user@example.com"; // Placeholder
+  // Load user profile from settings
+  const { name: userName, email: userEmail, imageUrl: userImageUrl, loadProfile } = useProfileStore();
+  useEffect(() => { loadProfile(); }, [loadProfile]);
 
   // Check if message has V1-style sequence
   const hasSequence = message.sequence && message.sequence.length > 0;
@@ -282,12 +284,18 @@ export const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
       {/* Avatar - matches v1 exactly */}
       <div className="message-avatar-container">
         {isUser ? (
-          // User avatar - uses Vercel avatar service as fallback
-          <img
-            src={`https://avatar.vercel.sh/${userEmail}`}
-            alt="User Avatar"
-            className="message-avatar-user"
-          />
+          // User avatar - profile photo or initials fallback
+          userImageUrl ? (
+            <img
+              src={userImageUrl}
+              alt={userName || "User"}
+              className="message-avatar-user"
+            />
+          ) : (
+            <div className="message-avatar-user message-avatar-user--initials">
+              {(userName || userEmail || "U").charAt(0).toUpperCase()}
+            </div>
+          )
         ) : (
           // Assistant avatar - Papr logo (actual v1 logo)
           <div className="message-avatar-assistant">
@@ -327,6 +335,10 @@ export const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
 
       {/* Message content */}
       <div className="message-content">
+        {/* Name label */}
+        <span className="message-sender-name">
+          {isUser ? (userName || "You") : "Pen"}
+        </span>
         {/* V1-STYLE SEQUENCE RENDERING */}
         {hasSequence && !isUser ? (
           renderSequence(message.sequence!, message)

--- a/ui/components/CommandPalette/CommandPalette.css
+++ b/ui/components/CommandPalette/CommandPalette.css
@@ -1,0 +1,280 @@
+/**
+ * CommandPalette Styles - Liquid Glass overlay
+ */
+
+/* Overlay */
+.cmd-palette__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 20vh;
+  animation: cmd-overlay-in 150ms ease;
+}
+
+@keyframes cmd-overlay-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Palette container */
+.cmd-palette {
+  width: 520px;
+  max-height: 420px;
+  background: var(--glass-bg);
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  border: 1px solid var(--glass-border, var(--border));
+  border-radius: 16px;
+  box-shadow:
+    0 24px 80px rgba(0, 0, 0, 0.18),
+    0 0 0 1px rgba(255, 255, 255, 0.10) inset;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: cmd-palette-in 200ms var(--ease, cubic-bezier(.2,.8,.2,1));
+}
+
+@keyframes cmd-palette-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Search input area */
+.cmd-palette__input-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.cmd-palette__search-icon {
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+.cmd-palette__input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 16px;
+  font-family: var(--font-body);
+  outline: none;
+}
+
+.cmd-palette__input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.cmd-palette__esc {
+  padding: 2px 8px;
+  background: var(--hover);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-family: var(--font-body);
+  line-height: 1.4;
+}
+
+/* Commands list */
+.cmd-palette__list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px;
+}
+
+.cmd-palette__list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.cmd-palette__list::-webkit-scrollbar-thumb {
+  background: var(--text-tertiary);
+  border-radius: 2px;
+}
+
+.cmd-palette__empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--text-tertiary);
+  font-size: 14px;
+}
+
+/* Command item */
+.cmd-palette__item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: transparent;
+  border: none;
+  border-radius: 10px;
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
+  transition: background 100ms ease;
+}
+
+.cmd-palette__item:hover,
+.cmd-palette__item--selected {
+  background: var(--hover);
+}
+
+.cmd-palette__item--selected {
+  background: rgba(var(--accent-rgb, 0,113,227), 0.08);
+}
+
+.cmd-palette__item-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--glass-bg);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid var(--glass-border, var(--border));
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.cmd-palette__item--selected .cmd-palette__item-icon {
+  color: var(--accent);
+  border-color: rgba(var(--accent-rgb, 0,113,227), 0.20);
+}
+
+.cmd-palette__item-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.cmd-palette__item-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.cmd-palette__item-desc {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Liquid Glass Orb for App entries (matches Tab & Favorites orb) */
+.cmd-palette__app-orb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: linear-gradient(
+    135deg,
+    rgba(1, 97, 224, 0.40),
+    rgba(12, 205, 255, 0.30),
+    rgba(0, 254, 254, 0.25)
+  );
+  border: 0.5px solid rgba(12, 205, 255, 0.30);
+  box-shadow:
+    0 1px 3px rgba(1, 97, 224, 0.20),
+    inset 0 1px 1px rgba(255, 255, 255, 0.35);
+  position: relative;
+  overflow: hidden;
+}
+
+.cmd-palette__app-orb::after {
+  content: '';
+  position: absolute;
+  top: 1px;
+  left: 15%;
+  width: 70%;
+  height: 40%;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.45), transparent);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.cmd-palette__app-orb-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  color: rgba(255, 255, 255, 0.95);
+  position: relative;
+  z-index: 1;
+}
+
+.cmd-palette__app-orb-icon svg {
+  width: 12px;
+  height: 12px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .cmd-palette__app-orb {
+    background: linear-gradient(
+      135deg,
+      rgba(1, 97, 224, 0.50),
+      rgba(12, 205, 255, 0.40),
+      rgba(0, 254, 254, 0.30)
+    );
+    border-color: rgba(12, 205, 255, 0.40);
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.30),
+      inset 0 1px 1px rgba(255, 255, 255, 0.20);
+  }
+}
+
+.cmd-palette__section-label {
+  padding: 8px 12px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.cmd-palette__shortcut {
+  padding: 2px 8px;
+  background: var(--hover);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-family: var(--font-body);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Dark mode adjustments */
+@media (prefers-color-scheme: dark) {
+  .cmd-palette__overlay {
+    background: rgba(0, 0, 0, 0.50);
+  }
+
+  .cmd-palette {
+    box-shadow:
+      0 24px 80px rgba(0, 0, 0, 0.50),
+      0 0 0 1px rgba(255, 255, 255, 0.06) inset;
+  }
+}

--- a/ui/components/CommandPalette/CommandPalette.tsx
+++ b/ui/components/CommandPalette/CommandPalette.tsx
@@ -1,0 +1,354 @@
+/**
+ * CommandPalette - Cmd+K power user interface
+ * Provides quick access to all internal features (Artifacts, Views, Meetings, Agents, Jobs, Skills)
+ */
+
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useTabs } from "../../hooks/useTabs";
+import { useArtifactsStore } from "../../stores/artifactsStore";
+import { useArtifacts } from "../../hooks/useArtifacts";
+import type { TabType } from "../../types/tabs";
+import "./CommandPalette.css";
+
+interface CommandItem {
+  id: string;
+  label: string;
+  description: string;
+  tabType: TabType;
+  entityId: string;
+  shortcut?: string;
+  icon: React.ReactNode;
+}
+
+interface CommandPaletteProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const COMMANDS: CommandItem[] = [
+  {
+    id: "artifacts",
+    label: "Documents & Artifacts",
+    description: "Browse all documents and artifacts",
+    tabType: "artifacts",
+    entityId: "artifacts",
+    shortcut: "\u2318D",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+        <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M14 2v6h6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+  },
+  {
+    id: "views",
+    label: "Views",
+    description: "Data views and tables",
+    tabType: "views",
+    entityId: "views",
+    shortcut: "\u2318\u21e7V",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+        <rect x="3" y="3" width="7" height="7" stroke="currentColor" strokeWidth="1.5" />
+        <rect x="14" y="3" width="7" height="7" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="3" y1="14" x2="10" y2="14" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="14" y1="14" x2="21" y2="14" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="3" y1="18" x2="10" y2="18" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="14" y1="18" x2="21" y2="18" stroke="currentColor" strokeWidth="1.5" />
+      </svg>
+    ),
+  },
+  {
+    id: "meetings",
+    label: "Meetings",
+    description: "Meeting management and notes",
+    tabType: "meetings",
+    entityId: "meetings",
+    shortcut: "\u2318M",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+        <rect x="3" y="4" width="18" height="18" rx="2" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="3" y1="10" x2="21" y2="10" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="8" y1="2" x2="8" y2="6" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="16" y1="2" x2="16" y2="6" stroke="currentColor" strokeWidth="1.5" />
+      </svg>
+    ),
+  },
+  {
+    id: "agents",
+    label: "Agents",
+    description: "AI agents and sub-agents",
+    tabType: "agents",
+    entityId: "agents",
+    shortcut: "\u2318\u21e7A",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+        <circle cx="12" cy="8" r="4" stroke="currentColor" strokeWidth="1.5" />
+        <path d="M6 21v-2a4 4 0 014-4h4a4 4 0 014 4v2" stroke="currentColor" strokeWidth="1.5" />
+      </svg>
+    ),
+  },
+  {
+    id: "jobs",
+    label: "Jobs",
+    description: "Scheduled jobs and automation",
+    tabType: "jobs",
+    entityId: "jobs",
+    shortcut: "\u2318J",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+        <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="1.5" />
+        <path d="M12 1v6m0 6v6M4.22 4.22l4.24 4.24m5.08 5.08l4.24 4.24M1 12h6m6 0h6M4.22 19.78l4.24-4.24m5.08-5.08l4.24-4.24" stroke="currentColor" strokeWidth="1.5" />
+      </svg>
+    ),
+  },
+  {
+    id: "skills",
+    label: "Skills",
+    description: "Skills marketplace and management",
+    tabType: "skills",
+    entityId: "skills",
+    shortcut: "\u2318\u21e7S",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+        <path d="M13 2L3 14h8l-1 8 10-12h-8l1-8z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+  },
+  {
+    id: "settings",
+    label: "Settings",
+    description: "App preferences and configuration",
+    tabType: "settings",
+    entityId: "settings",
+    shortcut: "\u2318,",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+        <path d="M12.22 2h-.44a2 2 0 00-2 2v.18a2 2 0 01-1 1.73l-.43.25a2 2 0 01-2 0l-.15-.08a2 2 0 00-2.73.73l-.22.38a2 2 0 00.73 2.73l.15.1a2 2 0 011 1.72v.51a2 2 0 01-1 1.74l-.15.09a2 2 0 00-.73 2.73l.22.38a2 2 0 002.73.73l.15-.08a2 2 0 012 0l.43.25a2 2 0 011 1.73V20a2 2 0 002 2h.44a2 2 0 002-2v-.18a2 2 0 011-1.73l.43-.25a2 2 0 012 0l.15.08a2 2 0 002.73-.73l.22-.39a2 2 0 00-.73-2.73l-.15-.08a2 2 0 01-1-1.74v-.5a2 2 0 011-1.74l.15-.09a2 2 0 00.73-2.73l-.22-.38a2 2 0 00-2.73-.73l-.15.08a2 2 0 01-2 0l-.43-.25a2 2 0 01-1-1.73V4a2 2 0 00-2-2z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="1.5" />
+      </svg>
+    ),
+  },
+];
+
+export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const { createTab, switchToTab } = useTabs();
+  const artifacts = useArtifactsStore((s) => s.artifacts);
+  const { loadArtifacts } = useArtifacts();
+
+  // Load apps when palette opens
+  useEffect(() => {
+    if (isOpen) loadArtifacts();
+  }, [isOpen, loadArtifacts]);
+
+  // Build dynamic app commands from artifacts store
+  const appCommands: CommandItem[] = useMemo(
+    () =>
+      artifacts
+        .filter((a) => a.type === "app")
+        .map((app) => ({
+          id: `app-${app.id}`,
+          label: app.title || "Untitled App",
+          description: "Open app",
+          tabType: "app" as TabType,
+          entityId: app.id,
+          icon: (
+            <span className="cmd-palette__app-orb">
+              {app.icon ? (
+                <span className="cmd-palette__app-orb-icon" dangerouslySetInnerHTML={{ __html: app.icon }} />
+              ) : (
+                <svg className="cmd-palette__app-orb-icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
+                  <rect x="3" y="3" width="7" height="7" rx="2" stroke="currentColor" strokeWidth="1.5"/>
+                  <rect x="14" y="3" width="7" height="7" rx="2" stroke="currentColor" strokeWidth="1.5"/>
+                  <rect x="3" y="14" width="7" height="7" rx="2" stroke="currentColor" strokeWidth="1.5"/>
+                  <rect x="14" y="14" width="7" height="7" rx="2" stroke="currentColor" strokeWidth="1.5"/>
+                </svg>
+              )}
+            </span>
+          ),
+        })),
+    [artifacts],
+  );
+
+  // Filter commands + apps based on query
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase().trim();
+    const filteredCommands = q
+      ? COMMANDS.filter(
+          (cmd) =>
+            cmd.label.toLowerCase().includes(q) ||
+            cmd.description.toLowerCase().includes(q),
+        )
+      : COMMANDS;
+    const filteredApps = q
+      ? appCommands.filter(
+          (cmd) =>
+            cmd.label.toLowerCase().includes(q) ||
+            cmd.description.toLowerCase().includes(q),
+        )
+      : appCommands;
+    return { commands: filteredCommands, apps: filteredApps };
+  }, [query, appCommands]);
+
+  // Flat list for keyboard navigation
+  const allItems = useMemo(
+    () => [...filtered.commands, ...filtered.apps],
+    [filtered],
+  );
+
+  // Reset state when opened
+  useEffect(() => {
+    if (isOpen) {
+      setQuery("");
+      setSelectedIndex(0);
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [isOpen]);
+
+  // Keep selected index in bounds
+  useEffect(() => {
+    if (selectedIndex >= allItems.length) {
+      setSelectedIndex(Math.max(0, allItems.length - 1));
+    }
+  }, [allItems.length, selectedIndex]);
+
+  const executeCommand = useCallback(
+    (cmd: CommandItem) => {
+      const tabId = createTab(cmd.tabType, cmd.entityId, cmd.label);
+      switchToTab(tabId);
+      onClose();
+    },
+    [createTab, switchToTab, onClose],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setSelectedIndex((i) => Math.min(i + 1, allItems.length - 1));
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setSelectedIndex((i) => Math.max(i - 1, 0));
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (allItems[selectedIndex]) {
+            executeCommand(allItems[selectedIndex]);
+          }
+          break;
+        case "Escape":
+          e.preventDefault();
+          onClose();
+          break;
+      }
+    },
+    [allItems, selectedIndex, executeCommand, onClose],
+  );
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const item = list.querySelector(`[data-cmd-index="${selectedIndex}"]`) as HTMLElement;
+    if (item) {
+      item.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedIndex]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="cmd-palette__overlay" onClick={onClose}>
+      <div
+        className="cmd-palette"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        {/* Search input */}
+        <div className="cmd-palette__input-wrapper">
+          <svg
+            className="cmd-palette__search-icon"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+          >
+            <circle cx="11" cy="11" r="8" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M21 21l-4.35-4.35" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+          <input
+            ref={inputRef}
+            className="cmd-palette__input"
+            type="text"
+            placeholder="Search commands..."
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setSelectedIndex(0);
+            }}
+          />
+          <kbd className="cmd-palette__esc">esc</kbd>
+        </div>
+
+        {/* Commands list */}
+        <div className="cmd-palette__list" ref={listRef}>
+          {allItems.length === 0 && (
+            <div className="cmd-palette__empty">No results found</div>
+          )}
+          {filtered.commands.map((cmd) => {
+            const flatIndex = allItems.indexOf(cmd);
+            return (
+              <button
+                key={cmd.id}
+                data-cmd-index={flatIndex}
+                className={`cmd-palette__item ${flatIndex === selectedIndex ? "cmd-palette__item--selected" : ""}`}
+                onClick={() => executeCommand(cmd)}
+                onMouseEnter={() => setSelectedIndex(flatIndex)}
+              >
+                <span className="cmd-palette__item-icon">{cmd.icon}</span>
+                <div className="cmd-palette__item-text">
+                  <span className="cmd-palette__item-label">{cmd.label}</span>
+                  <span className="cmd-palette__item-desc">
+                    {cmd.description}
+                  </span>
+                </div>
+                {cmd.shortcut && (
+                  <kbd className="cmd-palette__shortcut">{cmd.shortcut}</kbd>
+                )}
+              </button>
+            );
+          })}
+          {filtered.apps.length > 0 && (
+            <div className="cmd-palette__section-label">Apps</div>
+          )}
+          {filtered.apps.map((cmd) => {
+            const flatIndex = allItems.indexOf(cmd);
+            return (
+              <button
+                key={cmd.id}
+                data-cmd-index={flatIndex}
+                className={`cmd-palette__item ${flatIndex === selectedIndex ? "cmd-palette__item--selected" : ""}`}
+                onClick={() => executeCommand(cmd)}
+                onMouseEnter={() => setSelectedIndex(flatIndex)}
+              >
+                <span className="cmd-palette__item-icon">{cmd.icon}</span>
+                <div className="cmd-palette__item-text">
+                  <span className="cmd-palette__item-label">{cmd.label}</span>
+                  <span className="cmd-palette__item-desc">
+                    {cmd.description}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/Layout/AppLayout.css
+++ b/ui/components/Layout/AppLayout.css
@@ -12,8 +12,8 @@
   background: var(--background-color);
   background-attachment: fixed; /* Keep gradient fixed */
   /* Subtle backdrop blur for glass aesthetic without compromising readability */
-  backdrop-filter: blur(40px) saturate(180%) brightness(1.02);
-  -webkit-backdrop-filter: blur(40px) saturate(180%) brightness(1.02);
+  backdrop-filter: blur(20px) saturate(180%) brightness(1.02);
+  -webkit-backdrop-filter: blur(20px) saturate(180%) brightness(1.02);
 }
 
 .app-layout__sidebar {
@@ -22,10 +22,12 @@
   max-width: 400px;
   height: 100%;
   border-right: 1px solid var(--sidebar-border);
-  /* Subtle tint overlay (not full background) - shows app-layout through */
-  background: rgba(0, 0, 0, 0.02);
-  /* Apple guideline: Add shadow for depth and separation */
-  box-shadow: 2px 0 12px rgba(0, 0, 0, 0.08);
+  /* Apple Liquid Glass: translucent tint with blur for depth */
+  background: rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  /* Depth shadow */
+  box-shadow: 2px 0 16px rgba(0, 0, 0, 0.06), inset -1px 0 0 rgba(255, 255, 255, 0.20);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -35,7 +37,8 @@
 /* Dark mode sidebar tint */
 @media (prefers-color-scheme: dark) {
   .app-layout__sidebar {
-    background: rgba(255, 255, 255, 0.02);
+    background: rgba(0, 0, 0, 0.55);
+    box-shadow: 2px 0 16px rgba(0, 0, 0, 0.20), inset -1px 0 0 rgba(255, 255, 255, 0.06);
   }
 }
 

--- a/ui/components/Layout/ContentArea.css
+++ b/ui/components/Layout/ContentArea.css
@@ -21,8 +21,10 @@
   overflow: auto;
   display: flex;
   flex-direction: column;
-  /* Fully transparent - shows app-layout background through */
-  background: transparent;
+  /* Subtle frosted glass — shows app-layout background with soft tint */
+  background: rgba(255, 255, 255, 0.10);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 }
 
 .content-pane--full {
@@ -99,6 +101,10 @@ body.resizing .content-area__resize-line {
 
 /* Dark mode */
 @media (prefers-color-scheme: dark) {
+  .content-pane {
+    background: rgba(0, 0, 0, 0.10);
+  }
+
   .content-area__resize-handle:hover {
     background: rgba(255, 255, 255, 0.03);
   }

--- a/ui/components/Layout/ContentArea.tsx
+++ b/ui/components/Layout/ContentArea.tsx
@@ -7,6 +7,7 @@ import React, { useRef, useCallback, useEffect } from "react";
 import { useTabs } from "../../hooks/useTabs";
 import { ChatContainer } from "../Chat/ChatContainer";
 import { ArtifactsView } from "../Artifacts/ArtifactsView";
+import { AppsView } from "../Apps/AppsView";
 import { DocumentView } from "../Documents/DocumentView";
 import { SettingsView } from "../Settings/SettingsView";
 import { JobsView } from "../Jobs/JobsView";
@@ -157,6 +158,8 @@ export function ContentArea() {
         return <ChatContainer chatId={tab.entityId} />;
       case "document":
         return <DocumentView documentId={tab.entityId} />;
+      case "apps":
+        return <AppsView />;
       case "artifacts":
         return <ArtifactsView />;
       case "views":

--- a/ui/components/Settings/SettingsView.css
+++ b/ui/components/Settings/SettingsView.css
@@ -1363,3 +1363,82 @@
   align-items: center;
   flex-wrap: wrap;
 }
+
+/* Profile Photo Upload */
+.profile-photo-upload {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.profile-photo-preview {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  overflow: hidden;
+  cursor: pointer;
+  position: relative;
+  background: var(--background-secondary);
+  border: 2px solid var(--border-color);
+  transition: border-color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.profile-photo-preview:hover {
+  border-color: #0161E0;
+}
+
+.profile-photo-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-photo-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+}
+
+.profile-photo-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  color: white;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  border-radius: 50%;
+}
+
+.profile-photo-preview:hover .profile-photo-overlay {
+  opacity: 1;
+}
+
+.profile-photo-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-btn--ghost {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: all 0.15s ease;
+}
+
+.settings-btn--ghost:hover {
+  color: #ff3b30;
+  background: rgba(255, 59, 48, 0.1);
+}
+

--- a/ui/components/Settings/SettingsView.tsx
+++ b/ui/components/Settings/SettingsView.tsx
@@ -3,8 +3,9 @@
  * Reference: Paprwork v1 settings modal
  */
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import { useCustomKeys } from "../../hooks/useCustomKeys";
+import { useProfileStore } from "../../stores/profileStore";
 import { gateway } from "../../src/lib/gateway";
 import type { CustomKeyInput, SettingsTab } from "../../types/settings";
 import { OAuthSection } from "./OAuthSection";
@@ -709,6 +710,8 @@ function ProfileTab() {
   const [imageUrl, setImageUrl] = useState("");
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const profileStore = useProfileStore();
 
   // Load profile on mount
   useEffect(() => {
@@ -731,10 +734,37 @@ function ProfileTab() {
     })();
   }, []);
 
+  const handlePhotoUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Validate file type and size
+    if (!file.type.startsWith("image/")) return;
+    if (file.size > 5 * 1024 * 1024) {
+      alert("Image must be under 5MB");
+      return;
+    }
+
+    // Convert to base64 data URL for storage
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      setImageUrl(dataUrl);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemovePhoto = () => {
+    setImageUrl("");
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
   const handleSave = async () => {
     setSaving(true);
     try {
       await gateway.send("settings:save-profile", { name, email, imageUrl });
+      // Update the global profile store so chat reflects changes immediately
+      profileStore.setProfile({ name, email, imageUrl });
     } catch (err) {
       console.error("[ProfileTab] Save error:", err);
     } finally {
@@ -755,8 +785,59 @@ function ProfileTab() {
       <div className="settings-section">
         <h2 className="settings-section__title">Your Profile</h2>
         <p className="settings-section__description">
-          This information helps personalize your experience
+          This information helps personalize your experience and chat messages
         </p>
+
+        {/* Profile Photo Upload */}
+        <div className="form-group">
+          <label className="form-label">Profile Photo</label>
+          <div className="profile-photo-upload">
+            <div
+              className="profile-photo-preview"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              {imageUrl ? (
+                <img src={imageUrl} alt="Profile" className="profile-photo-img" />
+              ) : (
+                <div className="profile-photo-placeholder">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                    <circle cx="12" cy="7" r="4" />
+                  </svg>
+                </div>
+              )}
+              <div className="profile-photo-overlay">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+                  <circle cx="12" cy="13" r="4" />
+                </svg>
+              </div>
+            </div>
+            <div className="profile-photo-actions">
+              <button
+                className="settings-btn settings-btn--secondary"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {imageUrl ? "Change Photo" : "Upload Photo"}
+              </button>
+              {imageUrl && (
+                <button
+                  className="settings-btn settings-btn--ghost"
+                  onClick={handleRemovePhoto}
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handlePhotoUpload}
+              style={{ display: "none" }}
+            />
+          </div>
+        </div>
 
         <div className="form-group">
           <label className="form-label">Name</label>
@@ -779,20 +860,6 @@ function ProfileTab() {
             placeholder="your@email.com"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-          />
-        </div>
-
-        <div className="form-group">
-          <label className="form-label">
-            Profile Image URL{" "}
-            <span className="form-label__optional">(optional)</span>
-          </label>
-          <input
-            type="url"
-            className="form-input"
-            placeholder="https://..."
-            value={imageUrl}
-            onChange={(e) => setImageUrl(e.target.value)}
           />
         </div>
       </div>

--- a/ui/components/Sidebar/FavoritesList.css
+++ b/ui/components/Sidebar/FavoritesList.css
@@ -97,6 +97,78 @@
   color: var(--text-tertiary);
 }
 
+/* Expand icon container when glass orb is present */
+.favorite-item__icon:has(.favorite-item__glass-orb) {
+  width: 20px;
+  height: 20px;
+}
+
+/* Mini Liquid Glass Orb for App Favorites (matches Tab.tsx glass orb) */
+.favorite-item__glass-orb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: linear-gradient(
+    135deg,
+    rgba(1, 97, 224, 0.40),
+    rgba(12, 205, 255, 0.30),
+    rgba(0, 254, 254, 0.25)
+  );
+  border: 0.5px solid rgba(12, 205, 255, 0.30);
+  box-shadow:
+    0 1px 3px rgba(1, 97, 224, 0.20),
+    inset 0 1px 1px rgba(255, 255, 255, 0.35);
+  flex-shrink: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.favorite-item__glass-orb::after {
+  content: '';
+  position: absolute;
+  top: 1px;
+  left: 15%;
+  width: 70%;
+  height: 40%;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.45), transparent);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.favorite-item__orb-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 10px;
+  height: 10px;
+  color: rgba(255, 255, 255, 0.95);
+  position: relative;
+  z-index: 1;
+}
+
+.favorite-item__orb-icon svg {
+  width: 10px;
+  height: 10px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .favorite-item__glass-orb {
+    background: linear-gradient(
+      135deg,
+      rgba(1, 97, 224, 0.50),
+      rgba(12, 205, 255, 0.40),
+      rgba(0, 254, 254, 0.30)
+    );
+    border-color: rgba(12, 205, 255, 0.40);
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.30),
+      inset 0 1px 1px rgba(255, 255, 255, 0.20);
+  }
+}
+
 .favorite-item__title {
   flex: 1;
   font-size: 13px;

--- a/ui/components/Sidebar/FavoritesList.tsx
+++ b/ui/components/Sidebar/FavoritesList.tsx
@@ -47,7 +47,7 @@ export function FavoritesList() {
     (fav: Favorite) => {
       const tabType =
         fav.type === "chat" ? "chat" : fav.type === "app" ? "app" : "document";
-      const tabId = createTab(tabType, fav.id, fav.title);
+      const tabId = createTab(tabType, fav.id, fav.title, fav.icon ? { icon: fav.icon } : {});
       switchToTab(tabId);
     },
     [createTab, switchToTab],
@@ -118,6 +118,35 @@ export function FavoritesList() {
   );
 
   const getIcon = (favorite: Favorite) => {
+    // App-type favorites: wrap icon in liquid glass orb (matches Tab.tsx)
+    if (favorite.type === "app") {
+      const innerIcon = favorite.icon ? (
+        <span
+          className="favorite-item__orb-icon"
+          dangerouslySetInnerHTML={{ __html: favorite.icon }}
+        />
+      ) : (
+        <svg
+          className="favorite-item__orb-icon"
+          width="10"
+          height="10"
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <rect x="3" y="3" width="7" height="7" rx="2" stroke="currentColor" strokeWidth="1.5" />
+          <rect x="14" y="3" width="7" height="7" rx="2" stroke="currentColor" strokeWidth="1.5" />
+          <rect x="3" y="14" width="7" height="7" rx="2" stroke="currentColor" strokeWidth="1.5" />
+          <rect x="14" y="14" width="7" height="7" rx="2" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      );
+
+      return (
+        <span className="favorite-item__glass-orb">
+          {innerIcon}
+        </span>
+      );
+    }
+
     if (favorite.icon) {
       return <span dangerouslySetInnerHTML={{ __html: favorite.icon }} />;
     }
@@ -126,10 +155,9 @@ export function FavoritesList() {
       chat: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="currentColor" stroke-width="1.5"/></svg>',
       document:
         '<svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" stroke="currentColor" stroke-width="1.5"/><path d="M14 2v6h6" stroke="currentColor" stroke-width="1.5"/></svg>',
-      app: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none"><rect x="3" y="3" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/><rect x="14" y="3" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/><rect x="3" y="14" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/><rect x="14" y="14" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/></svg>',
     };
 
-    return <span dangerouslySetInnerHTML={{ __html: icons[favorite.type] }} />;
+    return <span dangerouslySetInnerHTML={{ __html: icons[favorite.type] || icons.document }} />;
   };
 
   return (

--- a/ui/components/Sidebar/NewChatButton.css
+++ b/ui/components/Sidebar/NewChatButton.css
@@ -9,25 +9,28 @@
   gap: 8px;
   width: calc(100% - 24px);
   margin: 0 12px 16px 12px;
-  padding: 8px 16px;
-  background: #1C1C1E;
+  padding: 10px 16px;
+  background: #0161E0;
   border: none;
-  border-radius: 8px;
+  border-radius: 10px;
   color: #FFFFFF;
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
   cursor: pointer;
-  transition: background-color 0.15s var(--ease), transform 0.15s var(--ease);
+  transition: background-color 0.15s var(--ease), transform 0.15s var(--ease), box-shadow 0.15s var(--ease);
+  box-shadow: 0 2px 8px rgba(1, 97, 224, 0.25);
 }
 
 .new-chat-button:hover {
-  background: #2C2C2E;
+  background: #0050C0;
   transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(1, 97, 224, 0.35);
 }
 
 .new-chat-button:active {
   transform: translateY(0);
+  box-shadow: 0 1px 4px rgba(1, 97, 224, 0.20);
 }
 
 .new-chat-button__icon {
@@ -40,14 +43,16 @@
   font-weight: 600;
 }
 
-/* Dark mode */
+/* Dark mode - keep brand blue */
 @media (prefers-color-scheme: dark) {
   .new-chat-button {
-    background: #F2F2F7;
-    color: #1C1C1E;
+    background: #0161E0;
+    color: #FFFFFF;
+    box-shadow: 0 2px 8px rgba(1, 97, 224, 0.35);
   }
-  
+
   .new-chat-button:hover {
-    background: #E5E5EA;
+    background: #0C7AFF;
+    box-shadow: 0 4px 14px rgba(1, 97, 224, 0.45);
   }
 }

--- a/ui/components/Sidebar/NewChatButton.tsx
+++ b/ui/components/Sidebar/NewChatButton.tsx
@@ -26,7 +26,7 @@ export function NewChatButton({ onClick }: NewChatButtonProps) {
           strokeLinecap="round"
         />
       </svg>
-      <span className="new-chat-button__label">New Note</span>
+      <span className="new-chat-button__label">New App</span>
     </button>
   );
 }

--- a/ui/components/Sidebar/Sidebar.tsx
+++ b/ui/components/Sidebar/Sidebar.tsx
@@ -15,35 +15,15 @@ import { NewChatButton } from "./NewChatButton.tsx";
 import { OnboardingCard } from "./OnboardingCard.tsx";
 import "./Sidebar.css";
 
-type View =
-  | "chat"
-  | "artifacts"
-  | "views"
-  | "meetings"
-  | "agents"
-  | "jobs"
-  | "skills";
+type View = "chat" | "apps";
 
 /** Map tab types to sidebar nav views */
 function tabTypeToView(type: TabType | undefined): View {
   switch (type) {
-    case "chat":
-      return "chat";
-    case "document":
     case "app":
-    case "artifacts":
-      return "artifacts";
-    case "views":
-    case "view":
-      return "views";
-    case "meetings":
-      return "meetings";
-    case "agents":
-      return "agents";
-    case "jobs":
-      return "jobs";
-    case "skills":
-      return "skills";
+    case "apps":
+      return "apps";
+    case "chat":
     default:
       return "chat";
   }
@@ -112,27 +92,14 @@ export function Sidebar() {
   );
 
   const handleNavClick = (view: View) => {
-    // Create appropriate tab when clicking navigation and switch to it
     let tabId: string | undefined;
-    if (view === "artifacts") {
-      tabId = createTab("artifacts", "artifacts", "Artifacts");
-    } else if (view === "agents") {
-      tabId = createTab("agents", "agents", "Agents");
-    } else if (view === "meetings") {
-      tabId = createTab("meetings", "meetings", "Meetings");
-    } else if (view === "jobs") {
-      tabId = createTab("jobs", "jobs", "Jobs");
-    } else if (view === "skills") {
-      tabId = createTab("skills", "skills", "Skills");
-    } else if (view === "views") {
-      tabId = createTab("views", "views", "Views");
+    if (view === "apps") {
+      tabId = createTab("apps" as TabType, "apps", "Apps");
     } else if (view === "chat") {
-      // For chat, create a new chat
       handleNewChat();
       return;
     }
 
-    // Switch to the created tab
     if (tabId) {
       switchToTab(tabId);
     }
@@ -147,7 +114,7 @@ export function Sidebar() {
       <div className="sidebar__content">
         <WeatherWidget />
 
-        <NewChatButton onClick={handleNewChat} />
+        <NewChatButton onClick={() => handleNavClick("apps")} />
 
         <div className="sidebar__nav">
           <NavButton
@@ -169,228 +136,53 @@ export function Sidebar() {
           <NavButton
             icon={
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
-                <path
-                  d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M14 2v6h6"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            }
-            label="Artifacts"
-            isActive={activeView === "artifacts"}
-            onClick={() => handleNavClick("artifacts")}
-          />
-          <NavButton
-            icon={
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
                 <rect
                   x="3"
                   y="3"
                   width="7"
                   height="7"
+                  rx="2"
                   stroke="currentColor"
                   strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
                 />
                 <rect
                   x="14"
                   y="3"
                   width="7"
                   height="7"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <line
-                  x1="3"
-                  y1="14"
-                  x2="10"
-                  y2="14"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-                <line
-                  x1="14"
-                  y1="14"
-                  x2="21"
-                  y2="14"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-                <line
-                  x1="3"
-                  y1="18"
-                  x2="10"
-                  y2="18"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-                <line
-                  x1="14"
-                  y1="18"
-                  x2="21"
-                  y2="18"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-              </svg>
-            }
-            label="Views"
-            isActive={activeView === "views"}
-            onClick={() => handleNavClick("views")}
-          />
-          <NavButton
-            icon={
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
-                <rect
-                  x="3"
-                  y="4"
-                  width="18"
-                  height="18"
                   rx="2"
                   stroke="currentColor"
                   strokeWidth="1.5"
                 />
-                <line
-                  x1="3"
-                  y1="10"
-                  x2="21"
-                  y2="10"
+                <rect
+                  x="3"
+                  y="14"
+                  width="7"
+                  height="7"
+                  rx="2"
                   stroke="currentColor"
                   strokeWidth="1.5"
                 />
-                <line
-                  x1="8"
-                  y1="2"
-                  x2="8"
-                  y2="6"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-                <line
-                  x1="16"
-                  y1="2"
-                  x2="16"
-                  y2="6"
+                <rect
+                  x="14"
+                  y="14"
+                  width="7"
+                  height="7"
+                  rx="2"
                   stroke="currentColor"
                   strokeWidth="1.5"
                 />
               </svg>
             }
-            label="Meetings"
-            isActive={activeView === "meetings"}
-            onClick={() => handleNavClick("meetings")}
-          />
-          <NavButton
-            icon={
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
-                <circle
-                  cx="12"
-                  cy="8"
-                  r="4"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-                <path
-                  d="M6 21v-2a4 4 0 014-4h4a4 4 0 014 4v2"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-              </svg>
-            }
-            label="Agents"
-            isActive={activeView === "agents"}
-            onClick={() => handleNavClick("agents")}
-          />
-          <NavButton
-            icon={
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
-                <circle
-                  cx="12"
-                  cy="12"
-                  r="3"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-                <path
-                  d="M12 1v6m0 6v6M4.22 4.22l4.24 4.24m5.08 5.08l4.24 4.24M1 12h6m6 0h6M4.22 19.78l4.24-4.24m5.08-5.08l4.24-4.24"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-              </svg>
-            }
-            label="Jobs"
-            isActive={activeView === "jobs"}
-            onClick={() => handleNavClick("jobs")}
-          />
-          <NavButton
-            icon={
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
-                <path
-                  d="M13 2L3 14h8l-1 8 10-12h-8l1-8z"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            }
-            label="Skills"
-            isActive={activeView === "skills"}
-            onClick={() => handleNavClick("skills")}
+            label="Apps"
+            isActive={activeView === "apps"}
+            onClick={() => handleNavClick("apps")}
           />
         </div>
 
         <FavoritesList />
 
-        {/* Don't show chat list when in chat mode - chats are in tabs */}
-        {activeView !== "chat" && activeView === "artifacts" && (
-          <div className="section-divider" />
-        )}
-        {activeView === "artifacts" && (
-          <div
-            style={{
-              padding: "16px",
-              color: "var(--text-secondary)",
-              fontSize: "13px",
-            }}
-          >
-            Click a tab above to view artifacts
-          </div>
-        )}
-        {activeView === "views" && (
-          <div
-            style={{
-              padding: "16px",
-              color: "var(--text-secondary)",
-              fontSize: "13px",
-            }}
-          >
-            Click a table card to view data
-          </div>
-        )}
-        {activeView === "meetings" && (
-          <div
-            style={{
-              padding: "16px",
-              color: "var(--text-secondary)",
-              fontSize: "13px",
-            }}
-          >
-            Coming soon
-          </div>
-        )}
+        {/* Spacer between nav and favorites */}
       </div>
 
       <div className="sidebar__footer">

--- a/ui/components/Tabs/Tab.css
+++ b/ui/components/Tabs/Tab.css
@@ -114,6 +114,78 @@
   color: var(--text-primary);
 }
 
+/* Mini Liquid Glass Orb for App Tabs */
+.tab__glass-orb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: linear-gradient(
+    135deg,
+    rgba(1, 97, 224, 0.40),
+    rgba(12, 205, 255, 0.30),
+    rgba(0, 254, 254, 0.25)
+  );
+  border: 0.5px solid rgba(12, 205, 255, 0.30);
+  box-shadow:
+    0 1px 3px rgba(1, 97, 224, 0.20),
+    inset 0 1px 1px rgba(255, 255, 255, 0.35);
+  flex-shrink: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.tab__glass-orb::after {
+  content: '';
+  position: absolute;
+  top: 1px;
+  left: 15%;
+  width: 70%;
+  height: 40%;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.45), transparent);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.tab__glass-orb .tab__orb-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 10px;
+  height: 10px;
+  color: rgba(255, 255, 255, 0.95);
+  position: relative;
+  z-index: 1;
+}
+
+.tab__glass-orb .tab__orb-icon svg {
+  width: 10px;
+  height: 10px;
+}
+
+/* When tab has glass orb, expand icon container */
+.tab__icon:has(.tab__glass-orb) {
+  width: 20px;
+  height: 20px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .tab__glass-orb {
+    background: linear-gradient(
+      135deg,
+      rgba(1, 97, 224, 0.50),
+      rgba(12, 205, 255, 0.40),
+      rgba(0, 254, 254, 0.30)
+    );
+    border-color: rgba(12, 205, 255, 0.40);
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.30),
+      inset 0 1px 1px rgba(255, 255, 255, 0.20);
+  }
+}
+
 /* Title */
 .tab__title {
   flex: 1;

--- a/ui/components/Tabs/Tab.tsx
+++ b/ui/components/Tabs/Tab.tsx
@@ -83,6 +83,7 @@ export function Tab({
         type: tab.type,
         title: tab.title,
         tabId: tab.id,
+        icon: tab.icon || undefined,
       }),
     );
 
@@ -161,6 +162,35 @@ export function Tab({
 
   // Get icon for tab type
   const getIcon = () => {
+    // App tabs: wrap icon in a mini liquid glass orb
+    if (tab.type === "app") {
+      const innerIcon = tab.icon ? (
+        <span
+          className="tab__orb-icon"
+          dangerouslySetInnerHTML={{ __html: tab.icon }}
+        />
+      ) : (
+        <svg
+          className="tab__orb-icon"
+          width="10"
+          height="10"
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <rect x="3" y="3" width="7" height="7" rx="2" stroke="currentColor" strokeWidth="1.5" />
+          <rect x="14" y="3" width="7" height="7" rx="2" stroke="currentColor" strokeWidth="1.5" />
+          <rect x="3" y="14" width="7" height="7" rx="2" stroke="currentColor" strokeWidth="1.5" />
+          <rect x="14" y="14" width="7" height="7" rx="2" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      );
+
+      return (
+        <span className="tab__glass-orb">
+          {innerIcon}
+        </span>
+      );
+    }
+
     if (tab.icon)
       return <span dangerouslySetInnerHTML={{ __html: tab.icon }} />;
 
@@ -169,7 +199,8 @@ export function Tab({
       chat: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>',
       document:
         '<svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M14 2v6h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>',
-      app: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none"><rect x="3" y="3" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/><rect x="14" y="3" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/><rect x="3" y="14" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/><rect x="14" y="14" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/></svg>',
+      app: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none"><rect x="3" y="3" width="7" height="7" rx="2" stroke="currentColor" stroke-width="1.5"/><rect x="14" y="3" width="7" height="7" rx="2" stroke="currentColor" stroke-width="1.5"/><rect x="3" y="14" width="7" height="7" rx="2" stroke="currentColor" stroke-width="1.5"/><rect x="14" y="14" width="7" height="7" rx="2" stroke="currentColor" stroke-width="1.5"/></svg>',
+      apps: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none"><rect x="3" y="3" width="7" height="7" rx="2" stroke="currentColor" stroke-width="1.5"/><rect x="14" y="3" width="7" height="7" rx="2" stroke="currentColor" stroke-width="1.5"/><rect x="3" y="14" width="7" height="7" rx="2" stroke="currentColor" stroke-width="1.5"/><rect x="14" y="14" width="7" height="7" rx="2" stroke="currentColor" stroke-width="1.5"/></svg>',
       artifacts:
         '<svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" stroke="currentColor" stroke-width="1.5"/><path d="M14 2v6h6" stroke="currentColor" stroke-width="1.5"/><line x1="8" y1="13" x2="16" y2="13" stroke="currentColor" stroke-width="1.5"/><line x1="8" y1="17" x2="13" y2="17" stroke="currentColor" stroke-width="1.5"/></svg>',
       views:

--- a/ui/stores/profileStore.ts
+++ b/ui/stores/profileStore.ts
@@ -1,0 +1,53 @@
+/**
+ * Profile Store - User profile data available across the app
+ */
+
+import { create } from "zustand";
+import { gateway } from "../src/lib/gateway";
+
+interface ProfileState {
+  name: string;
+  email: string;
+  imageUrl: string;
+  loaded: boolean;
+  loadProfile: () => Promise<void>;
+  setProfile: (profile: { name?: string; email?: string; imageUrl?: string }) => void;
+}
+
+export const useProfileStore = create<ProfileState>((set, get) => ({
+  name: "",
+  email: "",
+  imageUrl: "",
+  loaded: false,
+
+  loadProfile: async () => {
+    if (get().loaded) return;
+    try {
+      const response = await gateway.send("settings:get");
+      const data = response.data as {
+        profile?: { name?: string; email?: string; imageUrl?: string };
+      };
+      if (data?.profile) {
+        set({
+          name: data.profile.name ?? "",
+          email: data.profile.email ?? "",
+          imageUrl: data.profile.imageUrl ?? "",
+          loaded: true,
+        });
+      } else {
+        set({ loaded: true });
+      }
+    } catch (err) {
+      console.error("[ProfileStore] Load error:", err);
+      set({ loaded: true });
+    }
+  },
+
+  setProfile: (profile) => {
+    set({
+      name: profile.name ?? get().name,
+      email: profile.email ?? get().email,
+      imageUrl: profile.imageUrl ?? get().imageUrl,
+    });
+  },
+}));

--- a/ui/styles/liquid-glass.css
+++ b/ui/styles/liquid-glass.css
@@ -11,38 +11,35 @@
   --text-tertiary: #8E8E93;
   --text-muted: rgba(29, 29, 31, 0.6);
   
-  /* Background Colors - Near-opaque for WCAG compliance with subtle glass effect */
-  /* Best practice: 98-99.5% opacity for main content surfaces (WCAG contrast ratio) */
-  /* Backdrop blur provides glass aesthetic without sacrificing readability */
+  /* Apple Liquid Glass: translucent surface + blur(20px) = wallpaper visible as soft color tint */
   --background-color: linear-gradient(
     135deg,
-    rgba(232, 234, 240, 0.99) 0%,
-    rgba(245, 247, 250, 0.985) 25%,
-    rgba(255, 255, 255, 0.98) 50%,
-    rgba(240, 242, 248, 0.985) 75%,
-    rgba(229, 232, 240, 0.99) 100%
+    rgba(232, 234, 240, 0.78) 0%,
+    rgba(245, 247, 250, 0.75) 25%,
+    rgba(255, 255, 255, 0.72) 50%,
+    rgba(240, 242, 248, 0.75) 75%,
+    rgba(229, 232, 240, 0.78) 100%
   );
-  --background-hover: rgba(249, 249, 249, 0.99);
-  --background-selected: rgba(245, 245, 247, 1.0);
-  --background-secondary: rgba(249, 249, 249, 0.98);
-  --background-tertiary: rgba(245, 245, 247, 0.98);
-  --bg: linear-gradient(135deg, rgba(232, 234, 240, 0.99) 0%, rgba(245, 247, 250, 0.985) 25%, rgba(255, 255, 255, 0.98) 50%, rgba(240, 242, 248, 0.985) 75%, rgba(229, 232, 240, 0.99) 100%);
-  --bg-secondary: rgba(245, 245, 247, 0.98);
-  
-  /* Glass Effect - Near-opaque for readability (WCAG best practice) */
-  /* Navigation layer: 5-20% transparency max, blur provides glass aesthetic */
-  --glass-bg: rgba(255, 255, 255, 0.92);
-  --glass-bg-hover: rgba(255, 255, 255, 0.96);
-  --glass-bg-active: rgba(255, 255, 255, 0.98);
-  
-  /* Sidebar - Minimal transparency with blur for glass effect */
-  --sidebar-bg: rgba(247, 247, 247, 0.96);
-  --sidebar-border: rgba(229, 229, 229, 0.90);
-  
-  /* Content panels - Near-solid for optimal readability */
-  --panel-bg: rgba(236, 236, 236, 0.98);
-  --panel-bg-hover: rgba(224, 224, 224, 0.99);
-  --panel-bg-active: rgba(255, 255, 255, 1.0);
+  --background-hover: rgba(249, 249, 249, 0.80);
+  --background-selected: rgba(245, 245, 247, 0.82);
+  --background-secondary: rgba(249, 249, 249, 0.78);
+  --background-tertiary: rgba(245, 245, 247, 0.78);
+  --bg: linear-gradient(135deg, rgba(232, 234, 240, 0.78) 0%, rgba(245, 247, 250, 0.75) 25%, rgba(255, 255, 255, 0.72) 50%, rgba(240, 242, 248, 0.75) 75%, rgba(229, 232, 240, 0.78) 100%);
+  --bg-secondary: rgba(245, 245, 247, 0.78);
+
+  /* Glass Effect - Apple Liquid Glass: ~65% opacity + blur(14px) */
+  --glass-bg: rgba(255, 255, 255, 0.65);
+  --glass-bg-hover: rgba(255, 255, 255, 0.75);
+  --glass-bg-active: rgba(255, 255, 255, 0.85);
+
+  /* Sidebar - Translucent with blur for true glass depth */
+  --sidebar-bg: rgba(247, 247, 247, 0.70);
+  --sidebar-border: rgba(229, 229, 229, 0.60);
+
+  /* Content panels - Slightly more opaque for readability */
+  --panel-bg: rgba(236, 236, 236, 0.75);
+  --panel-bg-hover: rgba(224, 224, 224, 0.80);
+  --panel-bg-active: rgba(255, 255, 255, 0.90);
   
   /* Borders - Liquid Glass */
   --border-color: rgba(0, 0, 0, 0.08);
@@ -142,34 +139,33 @@
     --text-tertiary: #8E8E93;
     --text-muted: rgba(242, 242, 247, 0.6);
     
-    /* Dark mode: Near-opaque for WCAG compliance with subtle glass effect */
-    /* Best practice: 98-99.5% opacity for main content surfaces (WCAG contrast ratio) */
+    /* Dark mode: Apple Liquid Glass - translucent dark surfaces */
     --background-color: linear-gradient(
       135deg,
-      rgba(10, 12, 16, 0.99) 0%,
-      rgba(26, 28, 32, 0.985) 25%,
-      rgba(20, 22, 28, 0.98) 50%,
-      rgba(28, 30, 36, 0.985) 75%,
-      rgba(18, 20, 26, 0.99) 100%
+      rgba(10, 12, 16, 0.78) 0%,
+      rgba(26, 28, 32, 0.75) 25%,
+      rgba(20, 22, 28, 0.72) 50%,
+      rgba(28, 30, 36, 0.75) 75%,
+      rgba(18, 20, 26, 0.78) 100%
     );
-    --background-hover: rgba(28, 28, 30, 0.99);
-    --background-selected: rgba(44, 44, 46, 1.0);
-    --background-secondary: rgba(28, 28, 30, 0.98);
-    --background-tertiary: rgba(44, 44, 46, 0.98);
-    --bg: linear-gradient(135deg, rgba(10, 12, 16, 0.99) 0%, rgba(26, 28, 32, 0.985) 25%, rgba(20, 22, 28, 0.98) 50%, rgba(28, 30, 36, 0.985) 75%, rgba(18, 20, 26, 0.99) 100%);
-    --bg-secondary: rgba(28, 28, 30, 0.98);
-    
-    --glass-bg: rgba(28, 28, 30, 0.92);
-    --glass-bg-hover: rgba(28, 28, 30, 0.96);
-    --glass-bg-active: rgba(28, 28, 30, 0.98);
-    
-    --sidebar-bg: rgba(28, 28, 30, 0.96);
-    --sidebar-border: rgba(44, 44, 46, 0.90);
-    
-    /* Content panels - Near-solid for optimal readability (dark mode) */
-    --panel-bg: rgba(44, 44, 46, 0.98);
-    --panel-bg-hover: rgba(58, 58, 60, 0.99);
-    --panel-bg-active: rgba(28, 28, 30, 1.0);
+    --background-hover: rgba(28, 28, 30, 0.80);
+    --background-selected: rgba(44, 44, 46, 0.82);
+    --background-secondary: rgba(28, 28, 30, 0.78);
+    --background-tertiary: rgba(44, 44, 46, 0.78);
+    --bg: linear-gradient(135deg, rgba(10, 12, 16, 0.78) 0%, rgba(26, 28, 32, 0.75) 25%, rgba(20, 22, 28, 0.72) 50%, rgba(28, 30, 36, 0.75) 75%, rgba(18, 20, 26, 0.78) 100%);
+    --bg-secondary: rgba(28, 28, 30, 0.78);
+
+    --glass-bg: rgba(14, 18, 28, 0.55);
+    --glass-bg-hover: rgba(14, 18, 28, 0.65);
+    --glass-bg-active: rgba(14, 18, 28, 0.75);
+
+    --sidebar-bg: rgba(28, 28, 30, 0.70);
+    --sidebar-border: rgba(44, 44, 46, 0.60);
+
+    /* Content panels - Dark glass */
+    --panel-bg: rgba(44, 44, 46, 0.75);
+    --panel-bg-hover: rgba(58, 58, 60, 0.80);
+    --panel-bg-active: rgba(28, 28, 30, 0.90);
     
     --border-color: rgba(255, 255, 255, 0.08);
     --border-light: #2C2C2E;

--- a/ui/types/tabs.ts
+++ b/ui/types/tabs.ts
@@ -6,6 +6,7 @@ export type TabType =
   | "chat"
   | "document"
   | "app"
+  | "apps"
   | "artifacts"
   | "views"
   | "view"

--- a/ui/utils/tabIcons.tsx
+++ b/ui/utils/tabIcons.tsx
@@ -86,6 +86,56 @@ export function getTabIcon(type: TabType): React.ReactNode {
         </svg>
       );
 
+    case "apps":
+      return (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+          <rect
+            x="3"
+            y="3"
+            width="7"
+            height="7"
+            rx="2"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <rect
+            x="14"
+            y="3"
+            width="7"
+            height="7"
+            rx="2"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <rect
+            x="3"
+            y="14"
+            width="7"
+            height="7"
+            rx="2"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <rect
+            x="14"
+            y="14"
+            width="7"
+            height="7"
+            rx="2"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+
     case "home":
       return (
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none">


### PR DESCRIPTION
## Summary

- **Apple Liquid Glass** (WWDC 2025): background 72-78% opacity + blur(20px) for translucent surfaces, sidebar 55%, content pane 10% frosted overlay, popovers 88% + blur(40px) for readability
- **Sidebar simplification**: streamlined nav (Chat, Apps), collapsible Favorites with drag-and-drop, New App button with glass styling
- **Chat name labels**: "Pen" for assistant, user's saved name for user messages, profile photo or initials avatar
- **Icon consistency**: glass orb wrapping for app icons across Tabs, Favorites, and Command Palette — Tab drag payload now includes icon metadata, FavoritesList passes icon to createTab
- **Command Palette** (Cmd+K): static commands + dynamic user apps from artifactsStore with section separator
- **AppsView**: new component for browsing/managing user apps with AppCard grid
- **Model picker dropdown**: fixed unreadable text — now uses popover-grade glass (88% + blur 40px + inner shine)
- **Design system skill**: updated with Apple Liquid Glass guidelines, opacity table, popover spec, glass orb pattern

## Files changed (29 files)

| Area | Files | What |
|------|-------|------|
| Liquid Glass | `liquid-glass.css`, `AppLayout.css`, `ContentArea.css` | Opacity/blur tuning per Apple guidelines |
| Chat | `MessageItem.tsx/css`, `InputBar.css`, `ChatContainer.tsx` | Name labels, avatar, model picker glass |
| Sidebar | `Sidebar.tsx`, `FavoritesList.tsx/css`, `NewChatButton.tsx/css` | Simplified nav, glass orb favorites |
| Tabs | `Tab.tsx/css` | Icon in drag payload, glass orb for apps |
| Command Palette | `CommandPalette.tsx/css` (new) | Cmd+K with apps from artifactsStore |
| Apps | `AppsView.tsx/css`, `AppCard.tsx/css` (new) | App grid view |
| Settings | `SettingsView.tsx/css` | Profile settings UI |
| Stores | `profileStore.ts` (new) | User profile state |
| Design System | `paprwork-design-system.md` | Liquid Glass guidelines + glass orb pattern |

## Test plan

- [ ] Liquid Glass: sidebar and main area show desktop wallpaper as subtle color tint (not readable content, not solid white)
- [ ] Chat: "Pen" above assistant messages, user name above user messages
- [ ] Icons: drag app tab to Favorites → glass orb icon preserved; open from Favorites → icon in new tab
- [ ] Command Palette: Cmd+K → type app name → user apps appear with glass orb icons
- [ ] Model picker: dropdown text fully readable over chat content
- [ ] Dark mode: all glass surfaces render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)