### PR TITLE
Fix browser_wait_for hang, payload limit, and memory search

### DIFF
--- a/src/core/tools/bash.ts
+++ b/src/core/tools/bash.ts
@@ -178,7 +178,6 @@ async function searchPaprMemoryForCode(pattern: string): Promise<string | null> 
       rank_results: true,
       response_format: 'toon',
       metadata: {
-        category: 'learning',
         customMetadata: {
           source: 'code_indexer'
         }

--- a/src/core/tools/browser.ts
+++ b/src/core/tools/browser.ts
@@ -448,40 +448,55 @@ export const browserWaitForTool = createTool({
     await requestBrowserPermission("wait_for");
     const session = await getBrowserSession();
 
+    // Cap timeout to 10s to prevent long hangs
+    const timeout = Math.min(args.timeout ?? 30000, 10000);
+
     if (args.time) {
-      await new Promise((resolve) => setTimeout(resolve, args.time! * 1000));
-      return { success: true, data: { waited: args.time, unit: "seconds" } };
+      const waitTime = Math.min(args.time, 10);
+      await new Promise((resolve) => setTimeout(resolve, waitTime * 1000));
+      return { success: true, data: { waited: waitTime, unit: "seconds" } };
     }
 
-    if (args.text) {
-      await session.page.waitForFunction(
-        (text: string) => {
-          // @ts-expect-error - This function runs in browser context
-          return document.body.innerText.includes(text);
+    try {
+      if (args.text) {
+        await session.page.waitForFunction(
+          (text: string) => {
+            // @ts-expect-error - This function runs in browser context
+            return document.body.innerText.includes(text);
+          },
+          args.text,
+          { timeout },
+        );
+        return { success: true, data: { found: args.text } };
+      }
+
+      if (args.textGone) {
+        await session.page.waitForFunction(
+          (text: string) => {
+            // @ts-expect-error - This function runs in browser context
+            return !document.body.innerText.includes(text);
+          },
+          args.textGone,
+          { timeout },
+        );
+        return { success: true, data: { gone: args.textGone } };
+      }
+
+      if (args.selector) {
+        await session.page.waitForSelector(args.selector, {
+          timeout,
+        });
+        return { success: true, data: { found: args.selector } };
+      }
+    } catch (error) {
+      const target = args.text || args.textGone || args.selector || "unknown";
+      return {
+        success: false,
+        data: {
+          error: `Timed out after ${timeout}ms waiting for: ${target}`,
+          timedOut: true,
         },
-        args.text,
-        { timeout: args.timeout },
-      );
-      return { success: true, data: { found: args.text } };
-    }
-
-    if (args.textGone) {
-      await session.page.waitForFunction(
-        (text: string) => {
-          // @ts-expect-error - This function runs in browser context
-          return !document.body.innerText.includes(text);
-        },
-        args.textGone,
-        { timeout: args.timeout },
-      );
-      return { success: true, data: { gone: args.textGone } };
-    }
-
-    if (args.selector) {
-      await session.page.waitForSelector(args.selector, {
-        timeout: args.timeout,
-      });
-      return { success: true, data: { found: args.selector } };
+      };
     }
 
     throw new Error("Must specify text, textGone, selector, or time");

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -319,7 +319,7 @@ async function startGateway(): Promise<void> {
       );
     }
 
-    app.use(express.json());
+    app.use(express.json({ limit: "50mb" }));
 
     app.get("/api/db/schema", async (req, res) => {
       try {


### PR DESCRIPTION
## Summary
- **browser_wait_for**: Cap timeout at 10s (was 30s) and return graceful `{ success: false, timedOut: true }` instead of hanging/throwing unhandled error
- **PayloadTooLargeError**: Increase `express.json()` limit from default 100KB to 50MB for large DB query results
- **Papr Memory 422**: Remove `category: 'learning'` from search metadata (requires `role` field that wasn't provided)

## Test plan
- [ ] browser_wait_for with non-existent selector returns error within 10s
- [ ] Large DB query results (1000+ rows) no longer cause PayloadTooLargeError
- [ ] Bash tool grep in Papr folders no longer triggers 422 memory search error

🤖 Generated with [Claude Code](https://claude.com/claude-code)