### PR TITLE
Improve memory search defaults: Cohere reranking + better tool descriptions

### DIFF
--- a/src/core/tools/paprMemory.ts
+++ b/src/core/tools/paprMemory.ts
@@ -64,7 +64,13 @@ const searchMemorySchema = z.object({
     .string()
     .min(1)
     .describe(
-      "2-3 sentence query for best results. Include specific details, context, and time frame.",
+      "Detailed search query describing what you're looking for. For best results, write 2-3 sentences " +
+      "that include specific details, context, and time frame. Use specific nouns over vague ones " +
+      "(e.g. 'graph-aware embedding architecture' beats 'how it works'). " +
+      "Examples: " +
+      "'Find recurring customer complaints about API performance from the last month, focusing on timeout errors.' " +
+      "'What are the main blockers in my current projects? Focus on technical challenges and timeline impacts.' " +
+      "'Papr architecture: graph-aware embeddings, predictive memory layer, technical design decisions.'",
     ),
   maxMemories: z
     .number()
@@ -73,7 +79,9 @@ const searchMemorySchema = z.object({
     .max(30)
     .optional()
     .describe(
-      "Number of memories to return. Default 20. Use 15-20 for comprehensive results.",
+      "Number of memories to return (max 30). Default 20. " +
+      "Use 25-30 for architecture/concept queries where breadth and reranking matter most. " +
+      "Use 10-15 for narrow lookups where you know exactly what you want.",
     ),
   category: z
     .enum(["agent_memory", "code"])
@@ -293,7 +301,14 @@ export const searchAgentMemoryTool = createTool({
         max_memories: args.maxMemories ?? 20,
         max_nodes: 15,
         enable_agentic_graph: true,
-        rank_results: true,
+        // Migrated from deprecated rank_results: true to reranking_config.
+        // Cohere rerank-v3.5 is a purpose-built cross-encoder: faster than LLM
+        // reranking and SOTA on retrieval benchmarks. Production-ready on Papr backend.
+        reranking_config: {
+          reranking_enabled: true,
+          reranking_provider: "cohere",
+          reranking_model: "rerank-v3.5",
+        },
         response_format: "toon",
         ...(holographicConfig && { holographic_config: holographicConfig }),
         // Pass filters via SDK's metadata.customMetadata + category


### PR DESCRIPTION
## Summary

Three improvements to `src/core/tools/paprMemory.ts` so every agent using `search_agent_memory` gets sharper retrieval results by default. Driven by real-world agent search behavior in a fundraise context — and grounded in the Papr SDK's own recommended patterns.

## Why

While searching memory for Papr's architecture during an investor email session, two calls with identical params returned wildly different quality results — the difference was **query phrasing**, not parameter tuning. Digging into the tool config revealed:

1. The `maxMemories` description **discouraged** going above 20 ("Use 15-20 for comprehensive results"), but architecture/concept queries get materially better results at 25-30 because reranking has more candidates.
2. We were using `rank_results: true`, which the Papr SDK has marked **deprecated** in favor of `reranking_config` with Cohere `rerank-v3.5`.
3. The `query` description was vague ("2-3 sentence query for best results"). The SDK's own description includes concrete examples that teach agents how to phrase queries well — and query phrasing turns out to be the single highest-leverage lever.

## Changes

### A) Better `maxMemories` description (line ~70)

**Before:** "Default 20. Use 15-20 for comprehensive results."

**After:** "Default 20 (max 30). Use 25-30 for architecture/concept queries where breadth and reranking matter most. Use 10-15 for narrow lookups where you know exactly what you want."

### B) Migrate `rank_results: true` → `reranking_config` with Cohere `rerank-v3.5` (line ~301)

**Before:**
```ts
rank_results: true,
```

**After:**
```ts
// Migrated from deprecated rank_results: true to reranking_config.
// Cohere rerank-v3.5 is a purpose-built cross-encoder: faster than LLM
// reranking and SOTA on retrieval benchmarks. Production-ready on Papr backend.
reranking_config: {
  reranking_enabled: true,
  reranking_provider: "cohere",
  reranking_model: "rerank-v3.5",
},
```

Cohere's cross-encoder is purpose-built for reranking — faster than LLM reranking and SOTA on retrieval benchmarks. Already production-ready on the Papr backend.

### C) Better `query` description with concrete examples (line ~64)

**Before:** "2-3 sentence query for best results. Include specific details, context, and time frame."

**After:** Adopted the SDK's pattern with three concrete examples + a one-liner on specific nouns vs vague phrases ("'graph-aware embedding architecture' beats 'how it works'").

## Risk

- **A & C** are description-only — zero behavior change, pure agent guidance improvements.
- **B** swaps reranking from default (OpenAI) → Cohere `rerank-v3.5`. The SDK explicitly recommends this migration and Cohere is live on the Papr backend. Result quality will shift — expected to be net better for retrieval-style queries (which is most of what this tool is used for).

## Verification

- `npx tsc --noEmit --project tsconfig.gateway.json` — clean, no errors
- `RerankingConfig` interface confirmed in `papr-TypescriptSDK/src/resources/memory.ts:1605`
- `reranking_config` field confirmed accepted on `MemorySearchParams` at line 1498
- TOON response format already enabled (line 297) — no change needed there

## Files changed

- `src/core/tools/paprMemory.ts` — 3 sections (+18 / -3)
