### PR TITLE
perf: replace per-message useSubAgents hook with shared Zustand store

### DIFF
--- a/ui/components/Chat/MessageItem.tsx
+++ b/ui/components/Chat/MessageItem.tsx
@@ -27,7 +27,7 @@ import { Markdown } from "../common/Markdown";
 import { getToolDisplayLabel } from "../../utils/toolDisplay";
 import { useJobLiveLogsStore } from "../../stores/jobLiveLogsStore";
 import { useSubagentJobStore } from "../../stores/subagentJobStore";
-import { useSubAgents } from "../../hooks/useSubAgents";
+import { useSubAgentNameStore } from "../../stores/subAgentNameStore";
 import "./MessageItem.css";
 
 interface MessageItemProps {
@@ -531,10 +531,8 @@ const MessageItemInner: React.FC<MessageItemProps> = ({ chatId, message }) => {
     s.getJobIdForChat(chatId),
   );
 
-  // Resolve sub-agent name for delegation cards
-  const { agents } = useSubAgents();
-  const getAgentName = (agentId: string) =>
-    agents.find((a) => a.id === agentId)?.name ?? agentId;
+  // Resolve sub-agent name for delegation cards (shared store — single IPC subscription)
+  const getAgentName = useSubAgentNameStore((s) => s.getAgentName);
 
   // Check if message has V1-style sequence
   const hasSequence = message.sequence && message.sequence.length > 0;

--- a/ui/stores/subAgentNameStore.ts
+++ b/ui/stores/subAgentNameStore.ts
@@ -1,0 +1,79 @@
+/**
+ * SubAgent Name Store — Lightweight Zustand store for resolving agent names.
+ *
+ * WHY THIS EXISTS:
+ * Previously, every <MessageItem> called the `useSubAgents()` hook, which
+ * created its own useState + setInterval per instance.  In a chat with 300+
+ * messages that meant 300+ independent IPC round-trips on mount and 600+
+ * polling calls every 15 s — enough to starve the main thread and make
+ * typing visibly laggy.
+ *
+ * This store replaces that pattern with a single shared subscription:
+ *   • One gateway call on first access
+ *   • One 30 s polling interval (agent names rarely change)
+ *   • All components read from the same Zustand slice — zero extra re-renders
+ *     unless the agent list actually changes
+ */
+
+import { create } from "zustand";
+import { gateway } from "../src/lib/gateway";
+
+interface SubAgentNameState {
+  /** Map of agentId → display name (populated lazily) */
+  agentNames: Map<string, string>;
+  /** Whether the initial load has completed */
+  loaded: boolean;
+  /** Resolve an agent ID to its display name, falling back to the raw ID */
+  getAgentName: (agentId: string) => string;
+}
+
+/** Singleton polling handle so we never start two intervals */
+let pollingTimer: ReturnType<typeof setInterval> | null = null;
+
+async function fetchAgentNames(): Promise<Map<string, string>> {
+  try {
+    const response = (await gateway.send("subagent:list")) as {
+      agents?: Array<{ id: string; name: string }>;
+    };
+    const map = new Map<string, string>();
+    if (Array.isArray(response?.agents)) {
+      for (const a of response.agents) {
+        map.set(a.id, a.name);
+      }
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
+export const useSubAgentNameStore = create<SubAgentNameState>((set, get) => {
+  // Kick off the first load + polling immediately when the store is created
+  // (store creation is lazy — happens on first import/use)
+  void fetchAgentNames().then((names) => {
+    set({ agentNames: names, loaded: true });
+  });
+
+  if (!pollingTimer) {
+    pollingTimer = setInterval(() => {
+      void fetchAgentNames().then((names) => {
+        const prev = get().agentNames;
+        // Only update if something actually changed (avoids unnecessary re-renders)
+        if (
+          names.size !== prev.size ||
+          [...names].some(([k, v]) => prev.get(k) !== v)
+        ) {
+          set({ agentNames: names });
+        }
+      });
+    }, 30_000);
+  }
+
+  return {
+    agentNames: new Map(),
+    loaded: false,
+    getAgentName: (agentId: string) => {
+      return get().agentNames.get(agentId) ?? agentId;
+    },
+  };
+});


### PR DESCRIPTION
## Problem

Typing in the chat input is slow/laggy, especially in long conversations (300+ messages).

## Root Cause

Every `<MessageItem>` component calls `useSubAgents()`, which internally creates:
- Its own `useState` for agents, runs, and dashboard data
- Its own `useEffect` that fires **3 IPC gateway calls** on mount (`subagent:list`, `subagent:runs`, `subagent:dashboard`)
- Its own `setInterval` polling every **15 seconds** with 2 more IPC calls

In a chat with 300 messages, this means:
- **~900 IPC calls on mount** (3 × 300)
- **~600 IPC calls every 15s** (2 × 300)
- **300 independent `setInterval` timers**
- Each API response triggers `setState` → re-renders that **bypass `React.memo`** (because they're internal state changes, not prop changes)

This floods the event loop and starves the main thread, making keystroke handling visibly delayed.

## Fix

Replace the per-instance `useSubAgents()` hook in `MessageItem` with a new `useSubAgentNameStore` (Zustand):

- **1 gateway call** on first access (vs 900)
- **1 polling interval** every 30s (vs 300 intervals × 15s)
- All MessageItem instances share the same store slice
- Only re-renders if the agent name list actually changes (shallow equality check)
- `getAgentName()` reads from the store via `get()` — no extra subscriptions

### Before → After
| Metric | Before | After |
|--------|--------|-------|
| IPC calls on mount | ~900 | 1 |
| Polling calls/15s | ~600 | 0 |
| Polling calls/30s | 0 | 1 |
| setInterval timers | 300 | 1 |
| Re-renders from polling | 300/cycle | 0 (unless data changes) |

## Files Changed

- **`ui/stores/subAgentNameStore.ts`** — New lightweight Zustand store
- **`ui/components/Chat/MessageItem.tsx`** — Swap `useSubAgents()` → `useSubAgentNameStore`

## Testing

- `tsc --noEmit` passes with zero errors
- Agent name resolution still works (falls back to raw ID if store hasn't loaded yet)
- Existing `useSubAgents` hook is untouched — still used by AgentsView components where the full hook is appropriate