### PR TITLE
fix: self-heal job logs/ dir + preserve doc scroll on refresh

### DIFF
--- a/src/gateway/services/JobsService.ts
+++ b/src/gateway/services/JobsService.ts
@@ -925,10 +925,34 @@ export class JobsService {
   private async appendLog(jobId: string, line: string): Promise<void> {
     const logPath = this.getJobLogPath(jobId);
     const stamped = `[${new Date().toISOString()}] ${line}\n`;
-    await fs.appendFile(logPath, stamped, "utf8");
+    try {
+      await fs.appendFile(logPath, stamped, "utf8");
+    } catch (err: unknown) {
+      // Self-heal: if the logs/ directory was deleted or never created
+      // (older jobs, manual cleanup), create it and retry once. We must
+      // NEVER let a logging failure crash a job run or scheduler tick.
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code === "ENOENT") {
+        try {
+          await fs.mkdir(path.dirname(logPath), { recursive: true });
+          await fs.appendFile(logPath, stamped, "utf8");
+        } catch (retryErr) {
+          console.warn(
+            `[JobsService] appendLog retry failed for ${jobId}:`,
+            retryErr,
+          );
+        }
+      } else {
+        console.warn(`[JobsService] appendLog failed for ${jobId}:`, err);
+      }
+    }
 
-    // Prune log file if it exceeds 2MB
-    await this.pruneJobLog(jobId);
+    // Prune log file if it exceeds 2MB (best-effort)
+    try {
+      await this.pruneJobLog(jobId);
+    } catch {
+      /* non-fatal */
+    }
 
     // Broadcast log line to UI for real-time streaming
     this.broadcastJobLogLine(jobId, line);

--- a/ui/components/Documents/DocumentView.tsx
+++ b/ui/components/Documents/DocumentView.tsx
@@ -143,18 +143,37 @@ export function DocumentView({ documentId }: DocumentViewProps) {
     };
   }, [editor]);
 
-  // Sync document content into editor
+  // Sync document content into editor without yanking the user's scroll position.
   useEffect(() => {
     if (!document || !editor) return;
 
     const currentMarkdown =
       (editor.storage.markdown?.getMarkdown() as string) ?? editor.getText();
     if (currentMarkdown !== document.content) {
+      const wrapper = editorWrapperRef.current;
+      const scrollTop = wrapper?.scrollTop ?? 0;
+      const { from, to } = editor.state.selection;
+
       isLoadingContent.current = true;
       editor.commands.setContent(document.content || "", false, {
         preserveWhitespace: "full",
       });
+      if (from <= editor.state.doc.content.size && to <= editor.state.doc.content.size) {
+        editor.commands.setTextSelection({ from, to });
+      }
       isLoadingContent.current = false;
+
+      // TipTap/ProseMirror may scroll the selection into view after setContent.
+      // Restore on the next frames so auto-save/file refreshes don't jump upward.
+      if (wrapper) {
+        wrapper.scrollTop = scrollTop;
+        requestAnimationFrame(() => {
+          wrapper.scrollTop = scrollTop;
+          requestAnimationFrame(() => {
+            wrapper.scrollTop = scrollTop;
+          });
+        });
+      }
       
       // Update word count when loading new content
       setCurrentWordCount(calculateWordCount(document.content || ""));


### PR DESCRIPTION
Two independent fixes surfaced while debugging the Home app's Daily Brief Generator failing to run.

## 1. `fix(jobs)`: self-heal missing `logs/` directory in `appendLog`

`JobsService.appendLog()` called `fs.appendFile()` with no `mkdir` and no `try/catch`. If a job's `logs/` directory didn't exist on disk (older jobs that pre-date the `mkdir` in `createJob`, manual cleanup, sync issues), every log write threw `ENOENT`, which:

- **Crashed `runJobWithDependencies()` mid-run** — surfacing as `Brief generation failed: [object Object]` in the renderer for any agent job triggered from a mini-app (Daily Brief Generator, etc.).
- **Crashed `JobsScheduler.tick()`** via `reconcileStaleRunningJobs()`, so stale `running` jobs could never be reconciled and the scheduler emitted unhandled promise rejections every tick.

Reproduction:
```
rm -rf ~/Papr/jobs/<jobId>/logs
# trigger the job → ENOENT crashes the run
```

Fix: `appendLog` now catches errors, `mkdir -p`s the logs directory on `ENOENT` and retries once, and warns (does not throw) on any other failure. `pruneJobLog` is wrapped in `try/catch` too — logging must never be able to take down a job run or a scheduler tick.

## 2. `fix(docs)`: preserve scroll position when document content reloads

`DocumentView`'s `useEffect` that syncs `document.content` into the TipTap editor called `editor.commands.setContent()` unconditionally. ProseMirror scrolls the current selection into view after `setContent`, so any external content refresh (auto-save round-trip, file watcher, remote update) yanked the user back to the top of the document mid-edit — extremely disruptive when editing long docs.

Fix: snapshot `scrollTop` and the editor selection before `setContent`, restore both afterwards, and reassert `scrollTop` across two `requestAnimationFrames` to defeat ProseMirror's async `scrollIntoView`.

## Test plan

- **Jobs**: `rm -rf ~/Papr/jobs/<jobId>/logs`, click *Generate brief* in Home app — job runs, brief appears, no ENOENT.
- **Docs**: open a long doc, scroll to middle, edit something that triggers auto-save (or trigger an external file change) — scroll position stays put.