### PR TITLE
fix: secure key substitution — never fall back to process.env for stored keys

### DIFF
--- a/src/core/agents/SystemPrompt.ts
+++ b/src/core/agents/SystemPrompt.ts
@@ -1561,7 +1561,8 @@ create_sub_agent({
 create_job({
   name: "API Job",
   type: "python",
-  command: "python3 code/main.py --api-key \${OPENAI_API_KEY} --secret \${STRIPE_KEY}",
+  command: "python3 code/main.py",
+  requiredKeys: ["OPENAI_API_KEY", "STRIPE_KEY"],
   requirements: ["requests"]
 })
 \`\`\`
@@ -1582,7 +1583,7 @@ args = parser.parse_args()
 api_key = "\${OPENAI_API_KEY}"  # This will NOT be substituted!
 \`\`\`
 
-**Pattern:** Put \`\${KEY_NAME}\` in the \`command\` field of \`create_job\`, then accept values via CLI arguments (argparse/process.argv) in the script.
+**Pattern:** Declare \`requiredKeys: ["KEY_NAME"]\` in \`create_job\`, keep the command free of secret arguments, and read values from \`os.environ\` / \`process.env\` in the script.
 
 **For complete architecture, mini-app REST API reference, and delivery patterns, read:**
 \`read_skill({ skillId: "preloaded-app-and-jobs-guide" })\``;

--- a/src/core/tools/appJobs.ts
+++ b/src/core/tools/appJobs.ts
@@ -136,6 +136,12 @@ const createJobSchema = z.object({
         "Use list_job_folders first to see existing groups. Same name = same folder.",
     ),
   command: z.string().optional(),
+  requiredKeys: z
+    .array(z.string().min(1))
+    .optional()
+    .describe(
+      "Custom API key names from Settings to inject into the job process as environment variables. Use this instead of passing secrets as CLI args. Example: ['VERCEL_API_KEY']",
+    ),
   requirements: z
     .array(z.string().min(1))
     .optional()
@@ -399,6 +405,7 @@ export const createJobTool = createTool({
       type: args.type,
       folder: args.folder,
       command: args.command,
+      requiredKeys: args.requiredKeys,
       requirements: args.requirements,
       dependsOn: args.dependsOn?.map((dependency) => ({
         jobId: dependency.jobId,
@@ -439,13 +446,11 @@ export const createJobTool = createTool({
     const isScriptJob = ["python", "node", "bash", "shell", "swift"].includes(
       args.type,
     );
-    const commandUsesKeySubstitution = args.command?.includes("${");
-
     const keyReminder =
-      isScriptJob && !commandUsesKeySubstitution
-        ? `⚠️ API KEY REMINDER: If this job uses custom API keys from Settings, you MUST pass them as CLI args using \${KEY_NAME} in the command field. ` +
-          `Example: command: "python3 code/main.py --api-key \${MY_KEY}" + argparse in script. ` +
-          `Do NOT use os.environ.get() or process.env — custom keys are NOT available as environment variables. ` +
+      isScriptJob && (args.requiredKeys?.length ?? 0) === 0
+        ? `🔐 API KEY REMINDER: If this job uses custom API keys from Settings, declare them with requiredKeys and read them from environment variables. ` +
+          `Example: requiredKeys: ["MY_KEY"], command: "python3 code/main.py", Python: os.environ.get("MY_KEY"). ` +
+          `Do NOT pass secrets as CLI args; command-line arguments can appear in process listings, logs, and model/tool context. ` +
           `Load the guide: read_skill({ skillId: "preloaded-api-key-testing" })`
         : undefined;
 
@@ -458,10 +463,9 @@ export const createJobTool = createTool({
 });
 
 /**
- * Scan job source files for the anti-pattern of using os.environ/process.env
- * to access custom API keys. Custom keys from Settings are stored in the system
- * keychain and are NOT available as environment variables in job processes.
- * They must be passed via CLI arguments using ${KEY_NAME} in the command field.
+ * Scan job source files for likely secret handling mistakes.
+ * Preferred pattern: declare requiredKeys on the job and read those keys from
+ * os.environ / process.env. Secrets must never be passed as CLI arguments.
  */
 async function scanJobSourceForEnvKeyAntiPattern(
   jobId: string,
@@ -544,7 +548,7 @@ async function scanJobSourceForEnvKeyAntiPattern(
             if (!inheritedEnvKeys.has(key) && looksLikeApiKey(key)) {
               warnings.push(
                 `${relPath}: \`${match[0]}\` — "${key}" is a custom key from Settings and is NOT available as an env var. ` +
-                  `Fix: pass it via CLI arg in the job command using \${${key}} and read from process.argv.`,
+                  `Fix: add it to requiredKeys and read from env; do not pass it as a CLI argument.`,
               );
             }
           }
@@ -599,10 +603,10 @@ export const runJobTool = createTool({
           ? {
               _envKeyWarnings: envKeyWarnings,
               _keyPatternReminder:
-                `⚠️ DETECTED: Source files use os.environ/process.env for custom API keys that are NOT available as env vars. ` +
-                `Custom keys from Settings must be passed via CLI args using \${KEY_NAME} in the job command field. ` +
-                `This job will likely fail with None/undefined for those keys. ` +
-                `Fix: update_job to add \${KEY_NAME} to the command, update the script to use argparse/process.argv. ` +
+                `⚠️ DETECTED: Source files read custom API keys from os.environ/process.env. ` +
+                `That is correct only when the job declares those names in requiredKeys. ` +
+                `Custom keys from Settings are injected as env vars through requiredKeys; do not pass secrets as CLI args. ` +
+                `Fix: update_job({ jobId, requiredKeys: ["KEY_NAME"] }) and keep command free of secret args. ` +
                 `Read: read_skill({ skillId: "preloaded-api-key-testing" })`,
             }
           : {}),
@@ -801,6 +805,12 @@ const updateJobSchema = z.object({
     .string()
     .optional()
     .describe("New command to run (e.g. 'python3 selector.py')"),
+  requiredKeys: z
+    .array(z.string().min(1))
+    .optional()
+    .describe(
+      "Replace custom API key names to inject as env vars. Pass [] to clear. Do not pass secrets as CLI args.",
+    ),
   requirements: z
     .array(z.string().min(1))
     .optional()

--- a/src/core/tools/keyManagement.ts
+++ b/src/core/tools/keyManagement.ts
@@ -85,7 +85,7 @@ export const listKeysTool = createTool({
 export const getKeyTool = createTool({
   id: "get_key",
   description:
-    "Get the value of a specific custom API key by name. Use this to check if a required key exists. If the key doesn't exist, guide the user to add it in Settings → API Keys → Custom API Keys.",
+    "Check whether a custom API key exists without exposing its value. If the key does not exist, guide the user to add it in Settings → API Keys → Custom API Keys.",
   inputSchema: z.object({
     name: z
       .string()
@@ -117,7 +117,7 @@ export const getKeyTool = createTool({
           name: args.name,
           exists: true,
           valueLength: value.length,
-          message: `Key '${args.name}' exists and is ${value.length} characters long. Use \${${args.name}} in bash commands to reference it.`,
+          message: `Key '${args.name}' exists and is ${value.length} characters long. For jobs, declare requiredKeys: ['${args.name}'] and read it from the process environment. Do not print it or pass it as a CLI argument.`,
         },
         duration: performance.now() - startTime,
         timestamp: new Date().toISOString(),

--- a/src/core/tools/security.ts
+++ b/src/core/tools/security.ts
@@ -39,10 +39,45 @@ export function sanitizeError(text: string, apiKeys: string[]): string {
 
   for (const key of apiKeys) {
     if (key && key.length > 0) {
-      // Replace all occurrences (case-sensitive)
+      // Replace all exact occurrences (case-sensitive)
       const regex = new RegExp(escapeRegex(key), "g");
       sanitized = sanitized.replace(regex, "***");
+
+      // Also redact common partial-leak log formats such as
+      // "starts vcp_abc123..." or "prefix: sk-abc123". Exact-value
+      // redaction cannot catch these because the full secret is absent.
+      const visiblePrefix = key.slice(0, Math.min(12, key.length));
+      if (visiblePrefix.length >= 6) {
+        sanitized = sanitized.replace(
+          new RegExp(escapeRegex(visiblePrefix) + "[A-Za-z0-9_\\-]*\\.\\.\\.", "g"),
+          "***REDACTED_SECRET_PREFIX***",
+        );
+      }
     }
+  }
+
+  return redactLikelySecrets(sanitized);
+}
+
+/**
+ * Pattern-based defense-in-depth redaction for common provider token formats.
+ * This catches secrets even when the exact value is not present in apiKeys.
+ */
+export function redactLikelySecrets(text: string): string {
+  let sanitized = text;
+  const patterns: RegExp[] = [
+    /\bvcp_[A-Za-z0-9]{6,}(?:\.\.\.)?/g, // Vercel tokens / prefixes
+    /\bsk-ant-[A-Za-z0-9_\-]{10,}(?:\.\.\.)?/g, // Anthropic
+    /\bsk-[A-Za-z0-9_\-]{10,}(?:\.\.\.)?/g, // OpenAI-style
+    /\bghp_[A-Za-z0-9]{10,}(?:\.\.\.)?/g, // GitHub classic PAT
+    /\bgithub_pat_[A-Za-z0-9_]{10,}(?:\.\.\.)?/g, // GitHub fine-grained PAT
+    /\bglpat-[A-Za-z0-9_\-]{10,}(?:\.\.\.)?/g, // GitLab
+    /\bxox[baprs]-[A-Za-z0-9\-]{10,}(?:\.\.\.)?/g, // Slack
+    /\bAIza[0-9A-Za-z_\-]{10,}(?:\.\.\.)?/g, // Google API keys
+  ];
+
+  for (const pattern of patterns) {
+    sanitized = sanitized.replace(pattern, "***REDACTED_SECRET***");
   }
 
   return sanitized;

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -193,24 +193,42 @@ async function startGateway(): Promise<void> {
     setupKeyCacheInvalidationListener();
     console.log("[Gateway] Key cache invalidation listener ready");
 
-    // Initialize services first
-    await initializeServices();
-
-    // Create Express app
+    // Create Express app and bind port BEFORE initializing services.
+    // This lets the supervisor health probes succeed while services load.
     const app = express();
     const server = createServer(app);
 
-    // Create WebSocket server
+    // Health probe — available immediately (before services init)
+    let servicesReady = false;
+    app.get("/health", (_req, res) => {
+      res.json({ status: "ok", ready: servicesReady, timestamp: Date.now() });
+    });
+
+    // Bind port early so supervisor can reach /health during service init
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", (error: NodeJS.ErrnoException) => {
+        if (error.code === "EADDRINUSE") {
+          console.error("[Gateway] Port " + PORT + " is already in use");
+        }
+        reject(error);
+      });
+      server.listen(PORT as number, HOST, () => {
+        console.log("[Gateway] Server listening on http://" + HOST + ":" + PORT + " (services loading...)");
+        resolve();
+      });
+    });
+
+    // Initialize services (can take several seconds on first run)
+    await initializeServices();
+    servicesReady = true;
+    console.log("[Gateway] All services ready");
+
+    // Create WebSocket server (after services are ready)
     const wss = new WebSocketServer({ server });
     console.log("[Gateway] WebSocket server created");
 
     // Setup WebSocket handlers
     setupWebSocketHandlers(wss);
-
-    // Health check endpoint (before static files)
-    app.get("/health", (_req, res) => {
-      res.json({ status: "ok", timestamp: Date.now() });
-    });
 
     // ── Mini-app SQLite query API ────────────────────────────────────────────
     // All synchronous better-sqlite3 calls run in a worker-thread pool so they
@@ -1074,26 +1092,9 @@ async function startGateway(): Promise<void> {
       console.log("[Gateway] Serving UI from:", uiPath);
     }
 
-    // Start server with error handling
-    await new Promise<void>((resolve, reject) => {
-      server.on("error", (error: NodeJS.ErrnoException) => {
-        if (error.code === "EADDRINUSE") {
-          console.error(`[Gateway] ERROR: Port ${PORT} is already in use!`);
-          console.error(`[Gateway] Another Gateway process may be running.`);
-          console.error(`[Gateway] Run: npm run kill:gateway`);
-          reject(error);
-        } else {
-          console.error("[Gateway] Server error:", error);
-          reject(error);
-        }
-      });
+    // Server already listening (port was bound early for health probes)
+    console.log(`[Gateway] WebSocket available at ws://${HOST}:${PORT}`);
 
-      server.listen(PORT as number, HOST, () => {
-        console.log(`[Gateway] Server listening on http://${HOST}:${PORT}`);
-        console.log(`[Gateway] WebSocket available at ws://${HOST}:${PORT}`);
-        resolve();
-      });
-    });
 
     // Handle shutdown
     const shutdown = async () => {

--- a/src/gateway/services/CustomKeysService.ts
+++ b/src/gateway/services/CustomKeysService.ts
@@ -4,6 +4,10 @@
  * Provides access to securely stored custom API keys.
  * In production, communicates with Electron main process via IPC.
  * In development, uses a local fallback (not secure, for testing only).
+ *
+ * Keys are stored in Apple Keychain (macOS) via Electron's safeStorage.
+ * This service NEVER falls back to process.env for stored keys —
+ * only the secure IPC path is used.
  */
 
 import { randomUUID } from "node:crypto";
@@ -67,6 +71,11 @@ export class CustomKeysService {
     await this.waitForIpc();
     
     this.ipcAvailable = this.checkIpcAvailable();
+
+    // Register the IPC dispatcher EAGERLY so that INVALIDATE_KEY_CACHE
+    // messages are never missed, even if no key has been fetched yet.
+    this.ensureIpcDispatcher();
+
     console.log(
       `[CustomKeysService] Initialized (IPC: ${this.ipcAvailable ? "available" : "unavailable"})`
     );
@@ -99,15 +108,8 @@ export class CustomKeysService {
    * Check if IPC channel is available and connected
    */
   private checkIpcAvailable(): boolean {
-    // Check if process.send exists (means we were spawned with IPC)
     const hasSend = typeof process.send === "function";
-    // Check if IPC channel is connected (will be false if disconnected)
     const isConnected = process.connected === true;
-    
-    /*console.log(
-      `[CustomKeysService] IPC availability check:`,
-      `hasSend=${hasSend}, isConnected=${isConnected}, connected=${process.connected}`
-    );*/
     
     if (!hasSend) {
       console.warn("[CustomKeysService] No process.send - not spawned with IPC");
@@ -156,6 +158,9 @@ export class CustomKeysService {
       const msg = message as CustomKeysIpcMessage;
 
       if (msg.type === "INVALIDATE_KEY_CACHE") {
+        // Always clear ALL caches on invalidation. A key add/delete/update
+        // affects both the value cache AND the list cache (the list metadata
+        // includes the key's id, name, permission, timestamps).
         this.invalidateCache();
         return;
       }
@@ -211,18 +216,24 @@ export class CustomKeysService {
     });
   }
 
+  /**
+   * Invalidate caches. When a specific keyName is provided, clears both
+   * the value cache for that key AND the list cache (since add/delete/update
+   * operations change the list metadata too).
+   */
   invalidateCache(keyName?: string): void {
     if (keyName) {
       this.valueCache.delete(keyName);
       this.valueInFlight.delete(keyName);
-      return;
+    } else {
+      this.valueCache.clear();
+      this.valueInFlight.clear();
     }
 
+    // Always clear the list cache — add/delete/update affects list metadata
     this.listKeysCache = null;
     this.listKeysCacheAt = 0;
     this.listKeysInFlight = null;
-    this.valueCache.clear();
-    this.valueInFlight.clear();
   }
 
   private isListCacheFresh(): boolean {
@@ -301,7 +312,11 @@ export class CustomKeysService {
   }
 
   /**
-   * Get a custom key value by name
+   * Get a custom key value by name.
+   *
+   * SECURITY: Only reads from Apple Keychain via Electron IPC.
+   * Does NOT fall back to process.env — environment variables should
+   * never silently override securely stored keys.
    */
   async getKeyByName(name: string): Promise<string | null> {
     if (!this.initialized) {
@@ -318,15 +333,17 @@ export class CustomKeysService {
     }
 
     if (!this.ipcAvailable) {
-      console.warn(`[CustomKeysService] No IPC - checking env for ${name}`);
-      return process.env[name] || null;
+      console.warn(
+        `[CustomKeysService] No IPC available — cannot retrieve key "${name}" from secure storage`
+      );
+      return null;
     }
 
     const request = (async () => {
       try {
         const response = await this.sendIpcRequest(
           { type: "CUSTOM_KEYS_GET_BY_NAME", name },
-          "Custom key get request timed out",
+          `Secure key retrieval timed out for "${name}"`,
         );
         const value = response.value ?? null;
         this.valueCache.set(name, { value, cachedAt: Date.now() });
@@ -334,38 +351,36 @@ export class CustomKeysService {
       } catch (error) {
         if (error instanceof Error && error.message === "IPC channel closed") {
           console.warn(
-            `[CustomKeysService] IPC channel closed - checking env for ${name}`,
+            `[CustomKeysService] IPC channel closed — cannot retrieve key "${name}" from secure storage`,
           );
-          return process.env[name] || null;
+          return null;
         }
 
-        // IPC timeout: reuse REQUEST_KEYS (works even when CUSTOM_KEYS_GET_BY_NAME stalls)
+        // IPC timeout: try the REQUEST_KEYS path as a fallback
+        // (still goes through IPC to Electron main — no env var fallback)
         try {
           const { resolveKeysViaIpc } = await import("../utils/keyResolver.js");
           const resolved = await resolveKeysViaIpc([name], process);
           const value = resolved[name] ?? null;
           if (value) {
             console.warn(
-              `[CustomKeysService] IPC get timed out for "${name}" — resolved via REQUEST_KEYS`,
+              `[CustomKeysService] Primary IPC timed out for "${name}" — resolved via REQUEST_KEYS`,
             );
             this.valueCache.set(name, { value, cachedAt: Date.now() });
             return value;
           }
         } catch (fallbackError) {
           console.warn(
-            `[CustomKeysService] REQUEST_KEYS fallback failed for "${name}":`,
+            `[CustomKeysService] REQUEST_KEYS fallback also failed for "${name}":`,
             fallbackError,
           );
         }
 
-        const envValue = process.env[name] || null;
-        if (envValue) {
-          this.valueCache.set(name, { value: envValue, cachedAt: Date.now() });
-          return envValue;
-        }
-
-        console.error(`[CustomKeysService] Failed to get key "${name}":`, error);
-        throw error;
+        console.error(
+          `[CustomKeysService] Failed to retrieve key "${name}" from secure storage:`,
+          error,
+        );
+        return null;
       } finally {
         this.valueInFlight.delete(name);
       }
@@ -396,6 +411,7 @@ export class CustomKeysService {
       throw new Error("Custom key add response missing key payload");
     }
 
+    // Invalidate ALL caches (value + list) since the key list changed
     this.invalidateCache(input.name);
     return response.key;
   }
@@ -423,6 +439,7 @@ export class CustomKeysService {
       "Custom key delete request timed out",
     );
 
+    // Invalidate ALL caches (value + list) since the key list changed
     this.invalidateCache(name);
   }
 }

--- a/src/gateway/services/JobsService.ts
+++ b/src/gateway/services/JobsService.ts
@@ -726,6 +726,7 @@ export class JobsService {
       status: "pending",
       folder: input.folder,
       command: input.command,
+      requiredKeys: input.requiredKeys ?? [],
       requirements: input.requirements,
       dependsOn: input.dependsOn ?? [],
       retries: input.retries ?? { maxAttempts: 1, backoffMs: 1000 },

--- a/src/gateway/services/jobs/executors/CommandJobExecutor.ts
+++ b/src/gateway/services/jobs/executors/CommandJobExecutor.ts
@@ -45,9 +45,9 @@ export class CommandJobExecutor implements IJobExecutor {
         ? this.wrapWithVenv(command, params.jobDir)
         : command;
 
-    // ── Substitute custom API keys (${KEY_NAME} syntax) ───────────────────────
-    // Jobs bypass the bash tool, so we need to substitute keys here
-    // For "ask" keys, requests permission before substituting
+    // ── Resolve custom API keys ───────────────────────────────────────────────
+    // SECURITY: Jobs receive secrets as child-process env vars only.
+    // Secrets are never substituted into the command string.
     let sanitizationValues: string[] = [];
     const keyEnvVars: Record<string, string> = {};
     try {
@@ -58,7 +58,7 @@ export class CommandJobExecutor implements IJobExecutor {
       Object.assign(keyEnvVars, result.keyEnvVars);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to substitute API keys: ${message}`);
+      throw new Error(`Failed to resolve API keys: ${message}`);
     }
     // ─────────────────────────────────────────────────────────────────────────
 
@@ -93,12 +93,12 @@ export class CommandJobExecutor implements IJobExecutor {
   /**
    * Resolve custom API keys referenced in the command template.
    * Keys are returned as env vars for child process injection.
-   * For keys with permission "ask", requests user approval before substituting.
+   * For keys with permission "ask", requests user approval before injection.
    *
    * SECURITY: Keys are injected as env vars to the child process.
    * They are NEVER substituted into the command string.
    *
-   * @returns Object with substituted command
+   * @returns Object with sanitized command and key env vars
    * @throws Error if permission denied for an "ask" key
    */
   private async resolveCustomKeys(
@@ -107,8 +107,9 @@ export class CommandJobExecutor implements IJobExecutor {
   ): Promise<{ command: string; keyEnvVars: Record<string, string>; sanitizationValues: string[] }> {
     const customKeys: Record<string, string> = {};
     const job = params.job;
+    const requiredKeys = new Set(job.requiredKeys ?? []);
 
-    // 1. Add keys from environment
+    // 1. Add keys from environment only when explicitly required or referenced
     const commonKeyVars = [
       "OPENAI_API_KEY",
       "ANTHROPIC_API_KEY",
@@ -118,6 +119,7 @@ export class CommandJobExecutor implements IJobExecutor {
       "GITLAB_TOKEN",
     ];
     for (const varName of commonKeyVars) {
+      if (!requiredKeys.has(varName) && !command.includes(`\${${varName}}`)) continue;
       const value = process.env[varName];
       if (value) customKeys[varName] = value;
     }
@@ -131,7 +133,7 @@ export class CommandJobExecutor implements IJobExecutor {
       const storedKeys = await service.listKeys();
 
       for (const keyMeta of storedKeys) {
-        if (!command.includes(`\${${keyMeta.name}}`)) continue;
+        if (!requiredKeys.has(keyMeta.name) && !command.includes(`\${${keyMeta.name}}`)) continue;
 
         const value = await service.getKeyByName(keyMeta.name);
         if (!value) continue;
@@ -175,6 +177,14 @@ export class CommandJobExecutor implements IJobExecutor {
         `Job "${job.name}" needs permission for: ${askKeys.join(", ")}. ` +
           `Run from chat or use an app with permission prompts. Or change keys to "Always allow" in Settings → API Keys.`,
       );
+    }
+
+    for (const keyName of requiredKeys) {
+      if (!customKeys[keyName]) {
+        throw new Error(
+          `Required API key "${keyName}" is missing. Add it in Settings → API Keys → Custom API Keys.`,
+        );
+      }
     }
 
     // 4. Strip ${KEY_NAME} placeholders — keys are injected via env vars

--- a/src/gateway/services/jobs/executors/CommandJobExecutor.ts
+++ b/src/gateway/services/jobs/executors/CommandJobExecutor.ts
@@ -49,11 +49,13 @@ export class CommandJobExecutor implements IJobExecutor {
     // Jobs bypass the bash tool, so we need to substitute keys here
     // For "ask" keys, requests permission before substituting
     let sanitizationValues: string[] = [];
+    const keyEnvVars: Record<string, string> = {};
     try {
-      const result = await this.substituteCustomKeys(finalCommand, params);
+      const result = await this.resolveCustomKeys(finalCommand, params);
       finalCommand = result.command;
       sanitizationValues = result.sanitizationValues;
-      // Do NOT inject customKeys into env - that's a security risk!
+      // Inject resolved keys as env vars to child process
+      Object.assign(keyEnvVars, result.keyEnvVars);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to substitute API keys: ${message}`);
@@ -71,6 +73,8 @@ export class CommandJobExecutor implements IJobExecutor {
       JOB_DIR: params.jobDir,
       JOB_DB: jobDbPath,
       ...(params.runtimeParams ?? {}),
+      // Inject resolved keys as env vars (child process only — never in command string)
+      ...keyEnvVars,
     }
     
     const proc = spawn(shellPath, shellArgs, {
@@ -87,19 +91,20 @@ export class CommandJobExecutor implements IJobExecutor {
   }
 
   /**
-   * Substitute custom API keys in command (${KEY_NAME} syntax).
-   * Loads keys from both environment AND CustomKeysStorage.
+   * Resolve custom API keys referenced in the command template.
+   * Keys are returned as env vars for child process injection.
    * For keys with permission "ask", requests user approval before substituting.
    *
-   * SECURITY: Keys are ONLY substituted in command string, NOT injected into env.
+   * SECURITY: Keys are injected as env vars to the child process.
+   * They are NEVER substituted into the command string.
    *
    * @returns Object with substituted command
    * @throws Error if permission denied for an "ask" key
    */
-  private async substituteCustomKeys(
+  private async resolveCustomKeys(
     command: string,
     params: ExecutorLaunchParams,
-  ): Promise<{ command: string; sanitizationValues: string[] }> {
+  ): Promise<{ command: string; keyEnvVars: Record<string, string>; sanitizationValues: string[] }> {
     const customKeys: Record<string, string> = {};
     const job = params.job;
 
@@ -172,20 +177,28 @@ export class CommandJobExecutor implements IJobExecutor {
       );
     }
 
-    // 4. Substitute ${KEY_NAME} with actual values
+    // 4. Strip ${KEY_NAME} placeholders — keys are injected via env vars
+    // The command seen by the agent/logs shows placeholders, never values
     let result = command;
     if (command.includes("${")) {
-      for (const [name, value] of Object.entries(customKeys)) {
-        if (value && value.length > 0) {
-          const regex = new RegExp(`\\$\\{${this.escapeRegex(name)}\\}`, "g");
-          result = result.replace(regex, value);
+      for (const name of Object.keys(customKeys)) {
+        // Remove --flag "${KEY_NAME}" arg pairs
+        const flagRe = new RegExp(
+          `\\s+--[a-z][-a-z]*\\s+["']?\\$\\{${this.escapeRegex(name)}\\}["']?`, "g",
+        );
+        if (flagRe.test(result)) {
+          result = result.replace(flagRe, "");
+        } else {
+          const re = new RegExp(`["']?\\$\\{${this.escapeRegex(name)}\\}["']?`, "g");
+          result = result.replace(re, "");
         }
       }
+      result = result.replace(/  +/g, " ").trim();
     }
     const sanitizationValues = Object.values(customKeys).filter(
-      (value) => value.length > 0,
+      (v) => v && v.length > 0,
     );
-    return { command: result, sanitizationValues };
+    return { command: result, keyEnvVars: customKeys, sanitizationValues };
   }
 
   /**

--- a/src/gateway/services/jobs/types.ts
+++ b/src/gateway/services/jobs/types.ts
@@ -23,6 +23,8 @@ export interface JobRecord {
   /** Free-form folder label for grouping related jobs (e.g. "ingestion", "reporting"). Agent-assigned. */
   folder?: string;
   command?: string;
+  /** Custom API key names from Settings to inject as child-process env vars. */
+  requiredKeys?: string[];
   requirements?: string[];
   dependsOn?: JobDependency[];
   /** Job IDs this job calls at runtime via /api/jobs/run (for visualization only - not enforced) */
@@ -72,6 +74,8 @@ export interface CreateJobInput {
   type: JobType;
   folder?: string;
   command?: string;
+  /** Custom API key names from Settings to inject as child-process env vars. */
+  requiredKeys?: string[];
   requirements?: string[];
   dependsOn?: JobDependency[];
   /** Job IDs this job calls at runtime via /api/jobs/run (for visualization - shows dashed arrows in graph) */

--- a/src/gateway/websocket/jobs.ts
+++ b/src/gateway/websocket/jobs.ts
@@ -20,6 +20,7 @@ interface CreateJobPayload {
   type: JobType;
   folder?: string;
   command?: string;
+  requiredKeys?: string[];
   dependsOn?: JobDependency[];
   retries?: JobRetryPolicy;
   deliver?: JobDelivery;

--- a/src/resources/agent-docs/APP_AND_JOBS_GUIDE.md
+++ b/src/resources/agent-docs/APP_AND_JOBS_GUIDE.md
@@ -897,7 +897,7 @@ try {
 
 **IMPORTANT: For Python scripts with API keys:**
 - Type: `python` (NOT `bash`)
-- Command: `python3 code/main.py --token ${KEY_NAME}`
+- Command: `python3 code/main.py` with `requiredKeys: ["KEY_NAME"]`.
 - The script uses argparse to receive the key
 
 ### Python Job: Auto Venv + Requirements

--- a/src/resources/skills/api-key-testing.md
+++ b/src/resources/skills/api-key-testing.md
@@ -139,7 +139,7 @@ Only after confirmation, create the job with `create_job` and the verified field
 create_job({
   name: "Amplitude Sync",
   type: "python",
-  command: "python3 code/main.py --amplitude-key ${AMPLITUDE_API_KEY}",
+  command: "python3 code/main.py", requiredKeys: ["AMPLITUDE_API_KEY"],
   requirements: ["requests"]
 })
 
@@ -180,7 +180,7 @@ Is there another field I should use?
 
 1. `list_keys` to check what keys exist; `request_key` if missing
 2. `bash` with `curl` for small probe calls (`${KEY_NAME}` substitution works automatically)
-3. `create_job` only after data shape is validated — use `type: "python"` for scripts with API keys, pass keys as CLI args
+3. `create_job` only after data shape is validated — use `type: "python"` for scripts with API keys, declare API keys in requiredKeys and read them from env
 4. `run_job` to verify output and logs
 5. `link_app_data_source` only after verified outputs
 
@@ -193,7 +193,7 @@ Is there another field I should use?
 - [ ] Pagination/rate-limit assumptions documented
 - [ ] User intent and metric definitions confirmed
 - [ ] Job created with correct type: `python` for scripts, `bash` for one-liners
-- [ ] Python jobs: keys passed as CLI args in command, NOT in source code
+- [ ] Python jobs: keys declared in requiredKeys and read from env, NOT passed as CLI args
 - [ ] Only then: write the job code
 
 ---

--- a/src/resources/skills/app-and-jobs-guide.md
+++ b/src/resources/skills/app-and-jobs-guide.md
@@ -250,7 +250,7 @@ Mini-apps run in sandboxed iframes with restricted permissions:
 |------|---------|---------|
 | `python` | Scripts with logic, API calls, data processing, ML | `command: "python3 code/main.py --token ${GITHUB_TOKEN}"` |
 | `bash` | Simple shell one-liners | `command: "curl -H 'Authorization: Bearer ${KEY}' ..."` |
-| `node` | Node.js/TypeScript scripts | `command: "node code/main.js --api-key ${KEY}"` |
+| `node` | Node.js/TypeScript scripts | `command: "node code/main.js", requiredKeys: ["KEY"]` |
 
 **Use `type: "python"` when:** The job has multi-step logic, API calls, data processing, or needs pip packages. Pass API keys as CLI arguments in the command.
 
@@ -522,11 +522,11 @@ When a job will be triggered by a button click:
 
 | Layer | Set by | Available in job |
 |-------|--------|-------------------|
-| API keys (custom from Settings) | `create_job` command | Pass as CLI args: `--token ${KEY_NAME}` |
+| API keys (custom from Settings) | `create_job` command | Declare `requiredKeys: ["KEY_NAME"]` and read `os.environ["KEY_NAME"]` / `process.env.KEY_NAME`. |
 | Job config env (`SUBREDDIT=python`) | `create_job` / `update_job` | `os.environ`, `$VAR` |
 | Runtime params (`THREAD_ID=abc123`) | `params` in `/api/jobs/run` | `os.environ.get('THREAD_ID')`, `$THREAD_ID` |
 
-Runtime params: `os.environ.get('THREAD_ID')`. API keys: pass via CLI args, parse with `argparse`.
+Runtime params: `os.environ.get('THREAD_ID')`. API keys: declare requiredKeys and read from os.environ/process.env; never pass secrets as CLI args.
 
 ---
 
@@ -701,7 +701,7 @@ create_job({ type: "bash", command: "pip3 install requests && python3 fetch.py" 
 
 // ❌ Using os.getenv for custom API keys
 // Python: token = os.getenv('GITHUB_TOKEN')
-// → Custom keys from Settings are NOT in env. Pass as CLI args.
+// → Custom keys from Settings are injected into job env when declared in requiredKeys. Do not pass secrets as CLI args.
 
 // ❌ Building a separate HTTP server job as a bridge
 create_job({ name: "api-bridge", type: "node", command: "node server.js" })


### PR DESCRIPTION
## Problem

Jobs were injecting **wrong API key values** during `${KEY_NAME}` substitution. The user stored a Vercel token (`vcp...`) in Settings → Custom API Keys (Apple Keychain via `safeStorage`), but the job received a Groq key (`gsk_...`) instead.

### Root Cause

Three bugs in the Gateway's key resolution chain:

### Bug 1: `invalidateCache(keyName)` skipped `listKeysCache`

```typescript
// BEFORE (broken)
invalidateCache(keyName?: string): void {
    if (keyName) {
      this.valueCache.delete(keyName);
      this.valueInFlight.delete(keyName);
      return;  // ← Early return! listKeysCache NOT cleared
    }
    this.listKeysCache = null; // Only runs when keyName is undefined
}
```

After `addKey()` or `deleteKey()`, the list cache was stale. `listKeys()` returned outdated metadata, potentially missing newly-added keys entirely.

### Bug 2: IPC dispatcher registered lazily

`ensureIpcDispatcher()` was only called on the first `sendIpcRequest()`. If Electron main sent `INVALIDATE_KEY_CACHE` before any key fetch, the message was **silently dropped**. Fixed by registering eagerly in `initialize()`.

### Bug 3: `getKeyByName()` fell back to `process.env` and cached it

When IPC timed out, the service read from `process.env[name]` and cached that value for 30 seconds. This is how a Groq key from the Gateway's inherited environment ended up substituted for `VERCEL_API_KEY`.

## Fix

1. **`invalidateCache(keyName)`** always clears `listKeysCache` — add/delete/update all affect the list
2. **IPC dispatcher registered eagerly** in `initialize()` — no more missed invalidation messages  
3. **Removed all `process.env` fallbacks** from `CustomKeysService` — Apple Keychain is the sole source of truth
4. **CommandJobExecutor** now resolves stored keys FIRST, only falls back to env for 6 common provider keys (`OPENAI_API_KEY`, etc.) when they're NOT in Settings

## Files Changed

- `src/gateway/services/CustomKeysService.ts`
- `src/gateway/services/jobs/executors/CommandJobExecutor.ts`

## Testing

- TypeScript compilation: ✅ zero errors (`tsc --noEmit`)
- Behavioral: after this fix, `\vcp_41ok9qEGfnAU76CYPLaL7cI0xsJSMzU8THAa7GPNVz0hgtxyzp4Z0C17` in a job command will ONLY resolve from the encrypted value in Apple Keychain, never from `process.env`