### PR TITLE
fix: Auth wall IPC listeners, signup retry, and dev startup reliability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paprwork",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paprwork",
-      "version": "2.0.40",
+      "version": "2.0.41",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [
@@ -20919,7 +20919,7 @@
     },
     "ui": {
       "name": "paprwork-ui",
-      "version": "2.0.40",
+      "version": "2.0.41",
       "dependencies": {
         "@tiptap/extension-placeholder": "3.19.0",
         "@tiptap/extension-table": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postinstall": "npx @electron/rebuild",
     "dev": "npm run kill:gateway && npm run build:gateway && concurrently \"npm run ui:dev\" \"npm run electron:dev\"",
     "build": "npm run build:gateway && npm run build:electron && npm run build:ui",
-    "build:gateway": "tsc -p tsconfig.gateway.json && shx cp -r src/resources dist/",
+    "build:gateway": "tsc -p tsconfig.gateway.json && shx rm -rf dist/resources && shx cp -r src/resources dist/",
     "build:electron": "tsc -p tsconfig.electron.json && shx mkdir -p dist/electron && shx cp src/electron/preload.cjs dist/electron/preload.cjs",
     "build:ui": "cd ui && vite build",
     "gateway:dev": "cross-env ELECTRON_RUN_AS_NODE=1 NODE_ENV=development electron ./node_modules/tsx/dist/cli.mjs watch src/gateway/index.ts",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "postinstall": "npx @electron/rebuild",
-    "dev": "npm run build:gateway && concurrently \"npm run ui:dev\" \"npm run electron:dev\"",
+    "dev": "npm run kill:gateway && npm run build:gateway && concurrently \"npm run ui:dev\" \"npm run electron:dev\"",
     "build": "npm run build:gateway && npm run build:electron && npm run build:ui",
     "build:gateway": "tsc -p tsconfig.gateway.json && shx cp -r src/resources dist/",
     "build:electron": "tsc -p tsconfig.electron.json && shx mkdir -p dist/electron && shx cp src/electron/preload.cjs dist/electron/preload.cjs",

--- a/src/core/agents/SystemPrompt.ts
+++ b/src/core/agents/SystemPrompt.ts
@@ -1561,7 +1561,8 @@ create_sub_agent({
 create_job({
   name: "API Job",
   type: "python",
-  command: "python3 code/main.py --api-key \${OPENAI_API_KEY} --secret \${STRIPE_KEY}",
+  command: "python3 code/main.py",
+  requiredKeys: ["OPENAI_API_KEY", "STRIPE_KEY"],
   requirements: ["requests"]
 })
 \`\`\`
@@ -1582,7 +1583,7 @@ args = parser.parse_args()
 api_key = "\${OPENAI_API_KEY}"  # This will NOT be substituted!
 \`\`\`
 
-**Pattern:** Put \`\${KEY_NAME}\` in the \`command\` field of \`create_job\`, then accept values via CLI arguments (argparse/process.argv) in the script.
+**Pattern:** Declare \`requiredKeys: ["KEY_NAME"]\` in \`create_job\`, keep the command free of secret arguments, and read values from \`os.environ\` / \`process.env\` in the script.
 
 **For complete architecture, mini-app REST API reference, and delivery patterns, read:**
 \`read_skill({ skillId: "preloaded-app-and-jobs-guide" })\``;

--- a/src/core/telemetry/events.ts
+++ b/src/core/telemetry/events.ts
@@ -62,6 +62,12 @@ export const AmplitudeEvents = {
   PLAN_COMPLETED: "paprwork_plan_completed",
   PLAN_DELETED: "paprwork_plan_deleted",
 
+  // Daily Do Execution Events (A/B: with-memory vs without-memory)
+  DAILY_DO_EXECUTION_STARTED: "daily_do_execution_started",
+  DAILY_DO_EXECUTION_COMPLETED: "daily_do_execution_completed",
+  DAILY_DO_CONTEXT_ASSEMBLED: "daily_do_context_assembled",
+  DAILY_DO_QUALITY_SCORED: "daily_do_quality_scored",
+
   // Settings Events
   SETTINGS_OPENED: "paprwork_settings_opened",
   PROVIDER_CONFIGURED: "paprwork_provider_configured",

--- a/src/core/tools/appJobs.ts
+++ b/src/core/tools/appJobs.ts
@@ -136,6 +136,12 @@ const createJobSchema = z.object({
         "Use list_job_folders first to see existing groups. Same name = same folder.",
     ),
   command: z.string().optional(),
+  requiredKeys: z
+    .array(z.string().min(1))
+    .optional()
+    .describe(
+      "Custom API key names from Settings to inject into the job process as environment variables. Use this instead of passing secrets as CLI args. Example: ['VERCEL_API_KEY']",
+    ),
   requirements: z
     .array(z.string().min(1))
     .optional()
@@ -399,6 +405,7 @@ export const createJobTool = createTool({
       type: args.type,
       folder: args.folder,
       command: args.command,
+      requiredKeys: args.requiredKeys,
       requirements: args.requirements,
       dependsOn: args.dependsOn?.map((dependency) => ({
         jobId: dependency.jobId,
@@ -439,13 +446,11 @@ export const createJobTool = createTool({
     const isScriptJob = ["python", "node", "bash", "shell", "swift"].includes(
       args.type,
     );
-    const commandUsesKeySubstitution = args.command?.includes("${");
-
     const keyReminder =
-      isScriptJob && !commandUsesKeySubstitution
-        ? `⚠️ API KEY REMINDER: If this job uses custom API keys from Settings, you MUST pass them as CLI args using \${KEY_NAME} in the command field. ` +
-          `Example: command: "python3 code/main.py --api-key \${MY_KEY}" + argparse in script. ` +
-          `Do NOT use os.environ.get() or process.env — custom keys are NOT available as environment variables. ` +
+      isScriptJob && (args.requiredKeys?.length ?? 0) === 0
+        ? `🔐 API KEY REMINDER: If this job uses custom API keys from Settings, declare them with requiredKeys and read them from environment variables. ` +
+          `Example: requiredKeys: ["MY_KEY"], command: "python3 code/main.py", Python: os.environ.get("MY_KEY"). ` +
+          `Do NOT pass secrets as CLI args; command-line arguments can appear in process listings, logs, and model/tool context. ` +
           `Load the guide: read_skill({ skillId: "preloaded-api-key-testing" })`
         : undefined;
 
@@ -458,10 +463,9 @@ export const createJobTool = createTool({
 });
 
 /**
- * Scan job source files for the anti-pattern of using os.environ/process.env
- * to access custom API keys. Custom keys from Settings are stored in the system
- * keychain and are NOT available as environment variables in job processes.
- * They must be passed via CLI arguments using ${KEY_NAME} in the command field.
+ * Scan job source files for likely secret handling mistakes.
+ * Preferred pattern: declare requiredKeys on the job and read those keys from
+ * os.environ / process.env. Secrets must never be passed as CLI arguments.
  */
 async function scanJobSourceForEnvKeyAntiPattern(
   jobId: string,
@@ -544,7 +548,7 @@ async function scanJobSourceForEnvKeyAntiPattern(
             if (!inheritedEnvKeys.has(key) && looksLikeApiKey(key)) {
               warnings.push(
                 `${relPath}: \`${match[0]}\` — "${key}" is a custom key from Settings and is NOT available as an env var. ` +
-                  `Fix: pass it via CLI arg in the job command using \${${key}} and read from process.argv.`,
+                  `Fix: add it to requiredKeys and read from env; do not pass it as a CLI argument.`,
               );
             }
           }
@@ -599,10 +603,10 @@ export const runJobTool = createTool({
           ? {
               _envKeyWarnings: envKeyWarnings,
               _keyPatternReminder:
-                `⚠️ DETECTED: Source files use os.environ/process.env for custom API keys that are NOT available as env vars. ` +
-                `Custom keys from Settings must be passed via CLI args using \${KEY_NAME} in the job command field. ` +
-                `This job will likely fail with None/undefined for those keys. ` +
-                `Fix: update_job to add \${KEY_NAME} to the command, update the script to use argparse/process.argv. ` +
+                `⚠️ DETECTED: Source files read custom API keys from os.environ/process.env. ` +
+                `That is correct only when the job declares those names in requiredKeys. ` +
+                `Custom keys from Settings are injected as env vars through requiredKeys; do not pass secrets as CLI args. ` +
+                `Fix: update_job({ jobId, requiredKeys: ["KEY_NAME"] }) and keep command free of secret args. ` +
                 `Read: read_skill({ skillId: "preloaded-api-key-testing" })`,
             }
           : {}),
@@ -801,6 +805,12 @@ const updateJobSchema = z.object({
     .string()
     .optional()
     .describe("New command to run (e.g. 'python3 selector.py')"),
+  requiredKeys: z
+    .array(z.string().min(1))
+    .optional()
+    .describe(
+      "Replace custom API key names to inject as env vars. Pass [] to clear. Do not pass secrets as CLI args.",
+    ),
   requirements: z
     .array(z.string().min(1))
     .optional()

--- a/src/core/tools/documents.ts
+++ b/src/core/tools/documents.ts
@@ -32,9 +32,25 @@ const importDocumentSchema = z.object({
     ),
 });
 
-const readDocumentSchema = z.object({
-  documentId: z.string().min(1).describe("Document UUID"),
-});
+// Accept `id` as an alias for `documentId` — LLMs frequently call read_document
+// with `id` instead of `documentId`. Silently normalize to avoid validation retry.
+const readDocumentSchema = z.preprocess(
+  (val) => {
+    if (val && typeof val === "object" && val !== null) {
+      const obj = val as Record<string, unknown>;
+      if (typeof obj.id === "string" && !obj.documentId) {
+        return { ...obj, documentId: obj.id };
+      }
+    }
+    return val;
+  },
+  z.object({
+    documentId: z
+      .string()
+      .min(1)
+      .describe("Document UUID (also accepted as 'id')"),
+  }),
+);
 
 const listDocumentsSchema = z.object({
   query: z

--- a/src/core/tools/keyManagement.ts
+++ b/src/core/tools/keyManagement.ts
@@ -85,7 +85,7 @@ export const listKeysTool = createTool({
 export const getKeyTool = createTool({
   id: "get_key",
   description:
-    "Get the value of a specific custom API key by name. Use this to check if a required key exists. If the key doesn't exist, guide the user to add it in Settings → API Keys → Custom API Keys.",
+    "Check whether a custom API key exists without exposing its value. If the key does not exist, guide the user to add it in Settings → API Keys → Custom API Keys.",
   inputSchema: z.object({
     name: z
       .string()
@@ -117,7 +117,7 @@ export const getKeyTool = createTool({
           name: args.name,
           exists: true,
           valueLength: value.length,
-          message: `Key '${args.name}' exists and is ${value.length} characters long. Use \${${args.name}} in bash commands to reference it.`,
+          message: `Key '${args.name}' exists and is ${value.length} characters long. For jobs, declare requiredKeys: ['${args.name}'] and read it from the process environment. Do not print it or pass it as a CLI argument.`,
         },
         duration: performance.now() - startTime,
         timestamp: new Date().toISOString(),

--- a/src/core/tools/security.ts
+++ b/src/core/tools/security.ts
@@ -39,10 +39,45 @@ export function sanitizeError(text: string, apiKeys: string[]): string {
 
   for (const key of apiKeys) {
     if (key && key.length > 0) {
-      // Replace all occurrences (case-sensitive)
+      // Replace all exact occurrences (case-sensitive)
       const regex = new RegExp(escapeRegex(key), "g");
       sanitized = sanitized.replace(regex, "***");
+
+      // Also redact common partial-leak log formats such as
+      // "starts vcp_abc123..." or "prefix: sk-abc123". Exact-value
+      // redaction cannot catch these because the full secret is absent.
+      const visiblePrefix = key.slice(0, Math.min(12, key.length));
+      if (visiblePrefix.length >= 6) {
+        sanitized = sanitized.replace(
+          new RegExp(escapeRegex(visiblePrefix) + "[A-Za-z0-9_\\-]*\\.\\.\\.", "g"),
+          "***REDACTED_SECRET_PREFIX***",
+        );
+      }
     }
+  }
+
+  return redactLikelySecrets(sanitized);
+}
+
+/**
+ * Pattern-based defense-in-depth redaction for common provider token formats.
+ * This catches secrets even when the exact value is not present in apiKeys.
+ */
+export function redactLikelySecrets(text: string): string {
+  let sanitized = text;
+  const patterns: RegExp[] = [
+    /\bvcp_[A-Za-z0-9]{6,}(?:\.\.\.)?/g, // Vercel tokens / prefixes
+    /\bsk-ant-[A-Za-z0-9_\-]{10,}(?:\.\.\.)?/g, // Anthropic
+    /\bsk-[A-Za-z0-9_\-]{10,}(?:\.\.\.)?/g, // OpenAI-style
+    /\bghp_[A-Za-z0-9]{10,}(?:\.\.\.)?/g, // GitHub classic PAT
+    /\bgithub_pat_[A-Za-z0-9_]{10,}(?:\.\.\.)?/g, // GitHub fine-grained PAT
+    /\bglpat-[A-Za-z0-9_\-]{10,}(?:\.\.\.)?/g, // GitLab
+    /\bxox[baprs]-[A-Za-z0-9\-]{10,}(?:\.\.\.)?/g, // Slack
+    /\bAIza[0-9A-Za-z_\-]{10,}(?:\.\.\.)?/g, // Google API keys
+  ];
+
+  for (const pattern of patterns) {
+    sanitized = sanitized.replace(pattern, "***REDACTED_SECRET***");
   }
 
   return sanitized;

--- a/src/electron/index.cjs
+++ b/src/electron/index.cjs
@@ -625,9 +625,31 @@ function createMainWindow() {
     }
   });
 
-  mainWindow.loadURL(uiUrl).catch((err) => {
-    console.error("[Electron] loadURL failed:", err);
-  });
+  // Load UI with retry logic — in dev mode, Vite may not be ready yet
+  // when concurrently spawns both processes in parallel.
+  const loadUIWithRetry = async (attempt = 1, maxAttempts = 30) => {
+    try {
+      await mainWindow.loadURL(uiUrl);
+      console.log(`[Electron] UI loaded successfully on attempt ${attempt}`);
+    } catch (err) {
+      const isConnectionError =
+        err?.code === "ERR_FAILED" ||
+        err?.code === "ERR_CONNECTION_REFUSED" ||
+        err?.errno === -2 ||
+        err?.errno === -102;
+
+      if (isConnectionError && attempt < maxAttempts) {
+        const delayMs = Math.min(500 * attempt, 2000);
+        console.log(
+          `[Electron] UI not ready yet (${err?.code || "unknown"}), retrying in ${delayMs}ms (attempt ${attempt}/${maxAttempts})...`,
+        );
+        setTimeout(() => loadUIWithRetry(attempt + 1, maxAttempts), delayMs);
+      } else {
+        console.error("[Electron] loadURL failed:", err);
+      }
+    }
+  };
+  loadUIWithRetry();
 
   // Track page load timing
   mainWindow.webContents.on('did-start-loading', () => {

--- a/src/electron/ipc/paprLogin.ts
+++ b/src/electron/ipc/paprLogin.ts
@@ -1006,18 +1006,63 @@ async function completePaprAuthCallback(
     claims["https://papr.scope.com/displayName"] || claims.nickname || claims.name;
   const email = claims.email;
 
-  if (!parseSessionToken || !objectId) {
-    throw new Error(
-      "Your account setup didn't finish. If you just signed up, wait a moment and try Sign in again.",
-    );
+  let finalSessionToken = parseSessionToken;
+  let finalObjectId = objectId;
+
+  if (!finalSessionToken || !finalObjectId) {
+    console.log("[PaprLogin] Claims missing on first token — likely a new signup. Retrying after delay...");
+
+    if (!tokens.refresh_token) {
+      throw new Error(
+        "Account setup is still in progress. Please wait a few seconds, then click 'Sign in' to try again.",
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 4000));
+
+    console.log("[PaprLogin] Refreshing token to get updated claims...");
+    const refreshResponse = await fetch(`https://${AUTH0_DOMAIN}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        client_id: AUTH0_CLIENT_ID,
+        refresh_token: tokens.refresh_token,
+      }),
+    });
+
+    if (refreshResponse.ok) {
+      const refreshedTokens = (await refreshResponse.json()) as {
+        id_token?: string;
+        refresh_token?: string;
+      };
+
+      if (refreshedTokens.id_token) {
+        const refreshedClaims = decodeIdToken(refreshedTokens.id_token);
+        finalSessionToken = refreshedClaims["https://papr.scope.com/sessionToken"];
+        finalObjectId = refreshedClaims["https://papr.scope.com/objectId"];
+
+        if (refreshedTokens.refresh_token) {
+          tokens.refresh_token = refreshedTokens.refresh_token;
+        }
+      }
+    }
+
+    if (!finalSessionToken || !finalObjectId) {
+      throw new Error(
+        "Account setup is still in progress. Please wait a moment and click 'Sign in' to try again.",
+      );
+    }
+
+    console.log("[PaprLogin] Claims obtained after refresh retry");
   }
 
-  console.log(`[PaprLogin] Authenticated user: ${email} (${objectId})`);
+  console.log(`[PaprLogin] Authenticated user: ${email} (${finalObjectId})`);
 
   let workspaceId: string | undefined;
   try {
-    const userData = await parseGraphQL(parseSessionToken, GET_USER_WORKSPACE, {
-      userId: objectId,
+    const userData = await parseGraphQL(finalSessionToken, GET_USER_WORKSPACE, {
+      userId: finalObjectId,
     });
     workspaceId = userData.user?.isSelectedWorkspaceFollower?.workspace?.objectId;
   } catch (e) {
@@ -1025,8 +1070,8 @@ async function completePaprAuthCallback(
   }
 
   const provision = await provisionOrGetApiKey(
-    parseSessionToken,
-    objectId,
+    finalSessionToken,
+    finalObjectId,
     email || "user",
     workspaceId,
   );
@@ -1039,7 +1084,7 @@ async function completePaprAuthCallback(
 
   await customKeysStorage.addKey({
     name: "PAPR_SESSION_TOKEN",
-    value: parseSessionToken,
+    value: finalSessionToken,
   });
 
   if (tokens.refresh_token) {
@@ -1050,17 +1095,17 @@ async function completePaprAuthCallback(
   }
 
   settingsStorage.setPaprProfile({
-    userId: objectId,
+    userId: finalObjectId,
     email: email || "",
     displayName: displayName || "",
     authenticatedAt: new Date().toISOString(),
-    sessionToken: parseSessionToken,
+    sessionToken: finalSessionToken,
     organizationId: provision.organizationId,
     activeNamespaceId: provision.namespaceId,
     activeNamespaceName: provision.namespaceName,
   });
 
-  await syncProfileToGatewaySettings(email || "", objectId);
+  await syncProfileToGatewaySettings(email || "", finalObjectId);
   console.log("[PaprLogin] Login complete. API key stored as PAPR_API_KEY.");
 
   const win = BrowserWindow.getAllWindows()[0];
@@ -1068,7 +1113,7 @@ async function completePaprAuthCallback(
     win.webContents.send("papr:login-success", {
       email: email || "",
       name: displayName || "",
-      userId: objectId,
+      userId: finalObjectId,
     });
   }
 
@@ -1076,7 +1121,7 @@ async function completePaprAuthCallback(
     success: true,
     email: email || "",
     name: displayName || "",
-    userId: objectId,
+    userId: finalObjectId,
   };
 }
 

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -193,24 +193,42 @@ async function startGateway(): Promise<void> {
     setupKeyCacheInvalidationListener();
     console.log("[Gateway] Key cache invalidation listener ready");
 
-    // Initialize services first
-    await initializeServices();
-
-    // Create Express app
+    // Create Express app and bind port BEFORE initializing services.
+    // This lets the supervisor health probes succeed while services load.
     const app = express();
     const server = createServer(app);
 
-    // Create WebSocket server
+    // Health probe — available immediately (before services init)
+    let servicesReady = false;
+    app.get("/health", (_req, res) => {
+      res.json({ status: "ok", ready: servicesReady, timestamp: Date.now() });
+    });
+
+    // Bind port early so supervisor can reach /health during service init
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", (error: NodeJS.ErrnoException) => {
+        if (error.code === "EADDRINUSE") {
+          console.error("[Gateway] Port " + PORT + " is already in use");
+        }
+        reject(error);
+      });
+      server.listen(PORT as number, HOST, () => {
+        console.log("[Gateway] Server listening on http://" + HOST + ":" + PORT + " (services loading...)");
+        resolve();
+      });
+    });
+
+    // Initialize services (can take several seconds on first run)
+    await initializeServices();
+    servicesReady = true;
+    console.log("[Gateway] All services ready");
+
+    // Create WebSocket server (after services are ready)
     const wss = new WebSocketServer({ server });
     console.log("[Gateway] WebSocket server created");
 
     // Setup WebSocket handlers
     setupWebSocketHandlers(wss);
-
-    // Health check endpoint (before static files)
-    app.get("/health", (_req, res) => {
-      res.json({ status: "ok", timestamp: Date.now() });
-    });
 
     // ── Mini-app SQLite query API ────────────────────────────────────────────
     // All synchronous better-sqlite3 calls run in a worker-thread pool so they
@@ -1074,26 +1092,9 @@ async function startGateway(): Promise<void> {
       console.log("[Gateway] Serving UI from:", uiPath);
     }
 
-    // Start server with error handling
-    await new Promise<void>((resolve, reject) => {
-      server.on("error", (error: NodeJS.ErrnoException) => {
-        if (error.code === "EADDRINUSE") {
-          console.error(`[Gateway] ERROR: Port ${PORT} is already in use!`);
-          console.error(`[Gateway] Another Gateway process may be running.`);
-          console.error(`[Gateway] Run: npm run kill:gateway`);
-          reject(error);
-        } else {
-          console.error("[Gateway] Server error:", error);
-          reject(error);
-        }
-      });
+    // Server already listening (port was bound early for health probes)
+    console.log(`[Gateway] WebSocket available at ws://${HOST}:${PORT}`);
 
-      server.listen(PORT as number, HOST, () => {
-        console.log(`[Gateway] Server listening on http://${HOST}:${PORT}`);
-        console.log(`[Gateway] WebSocket available at ws://${HOST}:${PORT}`);
-        resolve();
-      });
-    });
 
     // Handle shutdown
     const shutdown = async () => {

--- a/src/gateway/services/CustomKeysService.ts
+++ b/src/gateway/services/CustomKeysService.ts
@@ -4,6 +4,10 @@
  * Provides access to securely stored custom API keys.
  * In production, communicates with Electron main process via IPC.
  * In development, uses a local fallback (not secure, for testing only).
+ *
+ * Keys are stored in Apple Keychain (macOS) via Electron's safeStorage.
+ * This service NEVER falls back to process.env for stored keys —
+ * only the secure IPC path is used.
  */
 
 import { randomUUID } from "node:crypto";
@@ -67,6 +71,11 @@ export class CustomKeysService {
     await this.waitForIpc();
     
     this.ipcAvailable = this.checkIpcAvailable();
+
+    // Register the IPC dispatcher EAGERLY so that INVALIDATE_KEY_CACHE
+    // messages are never missed, even if no key has been fetched yet.
+    this.ensureIpcDispatcher();
+
     console.log(
       `[CustomKeysService] Initialized (IPC: ${this.ipcAvailable ? "available" : "unavailable"})`
     );
@@ -99,15 +108,8 @@ export class CustomKeysService {
    * Check if IPC channel is available and connected
    */
   private checkIpcAvailable(): boolean {
-    // Check if process.send exists (means we were spawned with IPC)
     const hasSend = typeof process.send === "function";
-    // Check if IPC channel is connected (will be false if disconnected)
     const isConnected = process.connected === true;
-    
-    /*console.log(
-      `[CustomKeysService] IPC availability check:`,
-      `hasSend=${hasSend}, isConnected=${isConnected}, connected=${process.connected}`
-    );*/
     
     if (!hasSend) {
       console.warn("[CustomKeysService] No process.send - not spawned with IPC");
@@ -156,6 +158,9 @@ export class CustomKeysService {
       const msg = message as CustomKeysIpcMessage;
 
       if (msg.type === "INVALIDATE_KEY_CACHE") {
+        // Always clear ALL caches on invalidation. A key add/delete/update
+        // affects both the value cache AND the list cache (the list metadata
+        // includes the key's id, name, permission, timestamps).
         this.invalidateCache();
         return;
       }
@@ -211,18 +216,24 @@ export class CustomKeysService {
     });
   }
 
+  /**
+   * Invalidate caches. When a specific keyName is provided, clears both
+   * the value cache for that key AND the list cache (since add/delete/update
+   * operations change the list metadata too).
+   */
   invalidateCache(keyName?: string): void {
     if (keyName) {
       this.valueCache.delete(keyName);
       this.valueInFlight.delete(keyName);
-      return;
+    } else {
+      this.valueCache.clear();
+      this.valueInFlight.clear();
     }
 
+    // Always clear the list cache — add/delete/update affects list metadata
     this.listKeysCache = null;
     this.listKeysCacheAt = 0;
     this.listKeysInFlight = null;
-    this.valueCache.clear();
-    this.valueInFlight.clear();
   }
 
   private isListCacheFresh(): boolean {
@@ -301,7 +312,11 @@ export class CustomKeysService {
   }
 
   /**
-   * Get a custom key value by name
+   * Get a custom key value by name.
+   *
+   * SECURITY: Only reads from Apple Keychain via Electron IPC.
+   * Does NOT fall back to process.env — environment variables should
+   * never silently override securely stored keys.
    */
   async getKeyByName(name: string): Promise<string | null> {
     if (!this.initialized) {
@@ -318,15 +333,17 @@ export class CustomKeysService {
     }
 
     if (!this.ipcAvailable) {
-      console.warn(`[CustomKeysService] No IPC - checking env for ${name}`);
-      return process.env[name] || null;
+      console.warn(
+        `[CustomKeysService] No IPC available — cannot retrieve key "${name}" from secure storage`
+      );
+      return null;
     }
 
     const request = (async () => {
       try {
         const response = await this.sendIpcRequest(
           { type: "CUSTOM_KEYS_GET_BY_NAME", name },
-          "Custom key get request timed out",
+          `Secure key retrieval timed out for "${name}"`,
         );
         const value = response.value ?? null;
         this.valueCache.set(name, { value, cachedAt: Date.now() });
@@ -334,38 +351,36 @@ export class CustomKeysService {
       } catch (error) {
         if (error instanceof Error && error.message === "IPC channel closed") {
           console.warn(
-            `[CustomKeysService] IPC channel closed - checking env for ${name}`,
+            `[CustomKeysService] IPC channel closed — cannot retrieve key "${name}" from secure storage`,
           );
-          return process.env[name] || null;
+          return null;
         }
 
-        // IPC timeout: reuse REQUEST_KEYS (works even when CUSTOM_KEYS_GET_BY_NAME stalls)
+        // IPC timeout: try the REQUEST_KEYS path as a fallback
+        // (still goes through IPC to Electron main — no env var fallback)
         try {
           const { resolveKeysViaIpc } = await import("../utils/keyResolver.js");
           const resolved = await resolveKeysViaIpc([name], process);
           const value = resolved[name] ?? null;
           if (value) {
             console.warn(
-              `[CustomKeysService] IPC get timed out for "${name}" — resolved via REQUEST_KEYS`,
+              `[CustomKeysService] Primary IPC timed out for "${name}" — resolved via REQUEST_KEYS`,
             );
             this.valueCache.set(name, { value, cachedAt: Date.now() });
             return value;
           }
         } catch (fallbackError) {
           console.warn(
-            `[CustomKeysService] REQUEST_KEYS fallback failed for "${name}":`,
+            `[CustomKeysService] REQUEST_KEYS fallback also failed for "${name}":`,
             fallbackError,
           );
         }
 
-        const envValue = process.env[name] || null;
-        if (envValue) {
-          this.valueCache.set(name, { value: envValue, cachedAt: Date.now() });
-          return envValue;
-        }
-
-        console.error(`[CustomKeysService] Failed to get key "${name}":`, error);
-        throw error;
+        console.error(
+          `[CustomKeysService] Failed to retrieve key "${name}" from secure storage:`,
+          error,
+        );
+        return null;
       } finally {
         this.valueInFlight.delete(name);
       }
@@ -396,6 +411,7 @@ export class CustomKeysService {
       throw new Error("Custom key add response missing key payload");
     }
 
+    // Invalidate ALL caches (value + list) since the key list changed
     this.invalidateCache(input.name);
     return response.key;
   }
@@ -423,6 +439,7 @@ export class CustomKeysService {
       "Custom key delete request timed out",
     );
 
+    // Invalidate ALL caches (value + list) since the key list changed
     this.invalidateCache(name);
   }
 }

--- a/src/gateway/services/JobsService.ts
+++ b/src/gateway/services/JobsService.ts
@@ -726,6 +726,7 @@ export class JobsService {
       status: "pending",
       folder: input.folder,
       command: input.command,
+      requiredKeys: input.requiredKeys ?? [],
       requirements: input.requirements,
       dependsOn: input.dependsOn ?? [],
       retries: input.retries ?? { maxAttempts: 1, backoffMs: 1000 },

--- a/src/gateway/services/PlanService.ts
+++ b/src/gateway/services/PlanService.ts
@@ -30,6 +30,20 @@ export interface Plan {
   sourceAgentId?: string;
   sourceAgentName?: string;
 }
+export interface PlanMetrics {
+  model?: string;
+  provider?: string;
+  tokensInput?: number;
+  tokensOutput?: number;
+  tokensTotal?: number;
+  costUsd?: number;
+  wallTimeMs?: number;
+  startedAt?: string;
+  completedAt?: string;
+  useMemory?: boolean;
+  workItemCategory?: string;
+}
+
 
 let planServiceInstance: PlanService | null = null;
 
@@ -104,6 +118,30 @@ export class PlanService {
       `);
     } catch (error) {
       // Index may already exist
+    }
+
+    // --- Daily Do execution tracking migration (v2) ---
+    // Track token spend, model, cost, timing per plan for PostHog A/B comparison
+    const executionColumns = [
+      { col: "model", type: "TEXT" },           // e.g. "claude-opus-4-0"
+      { col: "provider", type: "TEXT" },         // e.g. "anthropic"
+      { col: "tokens_input", type: "INTEGER DEFAULT 0" },
+      { col: "tokens_output", type: "INTEGER DEFAULT 0" },
+      { col: "tokens_total", type: "INTEGER DEFAULT 0" },
+      { col: "cost_usd", type: "REAL DEFAULT 0" },
+      { col: "wall_time_ms", type: "INTEGER DEFAULT 0" },
+      { col: "started_at", type: "TEXT" },       // ISO 8601 when first step started
+      { col: "completed_at", type: "TEXT" },     // ISO 8601 when plan completed
+      { col: "use_memory", type: "INTEGER" },    // 1=Papr Memory, 0=naive (A/B flag)
+      { col: "work_item_category", type: "TEXT" }, // investor_dd, customer_work, etc.
+    ];
+    for (const { col, type } of executionColumns) {
+      try {
+        this.db.exec(`ALTER TABLE plans ADD COLUMN ${col} ${type};`);
+        console.log(`[PlanService] Added ${col} column`);
+      } catch (error) {
+        // Column already exists, ignore
+      }
     }
 
     this.initialized = true;
@@ -191,6 +229,9 @@ export class PlanService {
         plan_id: planId,
         completed_steps: completedCount,
         total_steps: steps.length,
+        // --- Daily Do: running totals for live dashboards ---
+        tokens_total: (this.db?.prepare("SELECT tokens_total FROM plans WHERE plan_id = ?").get(planId) as any)?.tokens_total ?? 0,
+        cost_usd: (this.db?.prepare("SELECT cost_usd FROM plans WHERE plan_id = ?").get(planId) as any)?.cost_usd ?? 0,
       });
     }).catch(() => {});
 
@@ -223,6 +264,13 @@ export class PlanService {
       import("./gatewayTelemetry.js").then(({ getGatewayTelemetry }) => {
         getGatewayTelemetry().trackFireAndForget("paprwork_plan_completed", {
           plan_id: planId,
+          // --- Daily Do execution metrics ---
+          model: (this.db?.prepare("SELECT model FROM plans WHERE plan_id = ?").get(planId) as any)?.model,
+          tokens_total: (this.db?.prepare("SELECT tokens_total FROM plans WHERE plan_id = ?").get(planId) as any)?.tokens_total,
+          cost_usd: (this.db?.prepare("SELECT cost_usd FROM plans WHERE plan_id = ?").get(planId) as any)?.cost_usd,
+          wall_time_ms: (this.db?.prepare("SELECT wall_time_ms FROM plans WHERE plan_id = ?").get(planId) as any)?.wall_time_ms,
+          use_memory: (this.db?.prepare("SELECT use_memory FROM plans WHERE plan_id = ?").get(planId) as any)?.use_memory === 1,
+          work_item_category: (this.db?.prepare("SELECT work_item_category FROM plans WHERE plan_id = ?").get(planId) as any)?.work_item_category,
         });
       }).catch(() => {});
     }
@@ -365,6 +413,44 @@ export class PlanService {
       completed: row.completed || 0,
       cancelled: row.cancelled || 0,
     };
+  }
+
+
+  /**
+   * Update plan execution metrics (tokens, cost, time, model).
+   * Called by the agent runtime as plan steps execute.
+   * Token counts are ADDITIVE (+=) so you can call this after each tool call.
+   * startedAt uses COALESCE (only sets on first call).
+   */
+  async updatePlanMetrics(
+    planId: string,
+    metrics: PlanMetrics,
+  ): Promise<void> {
+    if (!this.db) throw new Error("PlanService not initialized");
+
+    const sets: string[] = [];
+    const values: any[] = [];
+
+    if (metrics.model !== undefined) { sets.push("model = ?"); values.push(metrics.model); }
+    if (metrics.provider !== undefined) { sets.push("provider = ?"); values.push(metrics.provider); }
+    if (metrics.tokensInput !== undefined) { sets.push("tokens_input = tokens_input + ?"); values.push(metrics.tokensInput); }
+    if (metrics.tokensOutput !== undefined) { sets.push("tokens_output = tokens_output + ?"); values.push(metrics.tokensOutput); }
+    if (metrics.tokensTotal !== undefined) { sets.push("tokens_total = tokens_total + ?"); values.push(metrics.tokensTotal); }
+    if (metrics.costUsd !== undefined) { sets.push("cost_usd = cost_usd + ?"); values.push(metrics.costUsd); }
+    if (metrics.wallTimeMs !== undefined) { sets.push("wall_time_ms = wall_time_ms + ?"); values.push(metrics.wallTimeMs); }
+    if (metrics.startedAt !== undefined) { sets.push("started_at = COALESCE(started_at, ?)"); values.push(metrics.startedAt); }
+    if (metrics.completedAt !== undefined) { sets.push("completed_at = ?"); values.push(metrics.completedAt); }
+    if (metrics.useMemory !== undefined) { sets.push("use_memory = ?"); values.push(metrics.useMemory ? 1 : 0); }
+    if (metrics.workItemCategory !== undefined) { sets.push("work_item_category = ?"); values.push(metrics.workItemCategory); }
+
+    if (sets.length === 0) return;
+
+    sets.push("updated_at = ?");
+    values.push(new Date().toISOString());
+    values.push(planId);
+
+    const sql = `UPDATE plans SET ${sets.join(", ")} WHERE plan_id = ?`;
+    this.db.prepare(sql).run(...values);
   }
 
   /**

--- a/src/gateway/services/jobs/executors/CommandJobExecutor.ts
+++ b/src/gateway/services/jobs/executors/CommandJobExecutor.ts
@@ -45,9 +45,9 @@ export class CommandJobExecutor implements IJobExecutor {
         ? this.wrapWithVenv(command, params.jobDir)
         : command;
 
-    // ── Substitute custom API keys (${KEY_NAME} syntax) ───────────────────────
-    // Jobs bypass the bash tool, so we need to substitute keys here
-    // For "ask" keys, requests permission before substituting
+    // ── Resolve custom API keys ───────────────────────────────────────────────
+    // SECURITY: Jobs receive secrets as child-process env vars only.
+    // Secrets are never substituted into the command string.
     let sanitizationValues: string[] = [];
     const keyEnvVars: Record<string, string> = {};
     try {
@@ -58,7 +58,7 @@ export class CommandJobExecutor implements IJobExecutor {
       Object.assign(keyEnvVars, result.keyEnvVars);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to substitute API keys: ${message}`);
+      throw new Error(`Failed to resolve API keys: ${message}`);
     }
     // ─────────────────────────────────────────────────────────────────────────
 
@@ -93,12 +93,12 @@ export class CommandJobExecutor implements IJobExecutor {
   /**
    * Resolve custom API keys referenced in the command template.
    * Keys are returned as env vars for child process injection.
-   * For keys with permission "ask", requests user approval before substituting.
+   * For keys with permission "ask", requests user approval before injection.
    *
    * SECURITY: Keys are injected as env vars to the child process.
    * They are NEVER substituted into the command string.
    *
-   * @returns Object with substituted command
+   * @returns Object with sanitized command and key env vars
    * @throws Error if permission denied for an "ask" key
    */
   private async resolveCustomKeys(
@@ -107,8 +107,9 @@ export class CommandJobExecutor implements IJobExecutor {
   ): Promise<{ command: string; keyEnvVars: Record<string, string>; sanitizationValues: string[] }> {
     const customKeys: Record<string, string> = {};
     const job = params.job;
+    const requiredKeys = new Set(job.requiredKeys ?? []);
 
-    // 1. Add keys from environment
+    // 1. Add keys from environment only when explicitly required or referenced
     const commonKeyVars = [
       "OPENAI_API_KEY",
       "ANTHROPIC_API_KEY",
@@ -118,6 +119,7 @@ export class CommandJobExecutor implements IJobExecutor {
       "GITLAB_TOKEN",
     ];
     for (const varName of commonKeyVars) {
+      if (!requiredKeys.has(varName) && !command.includes(`\${${varName}}`)) continue;
       const value = process.env[varName];
       if (value) customKeys[varName] = value;
     }
@@ -131,7 +133,7 @@ export class CommandJobExecutor implements IJobExecutor {
       const storedKeys = await service.listKeys();
 
       for (const keyMeta of storedKeys) {
-        if (!command.includes(`\${${keyMeta.name}}`)) continue;
+        if (!requiredKeys.has(keyMeta.name) && !command.includes(`\${${keyMeta.name}}`)) continue;
 
         const value = await service.getKeyByName(keyMeta.name);
         if (!value) continue;
@@ -175,6 +177,14 @@ export class CommandJobExecutor implements IJobExecutor {
         `Job "${job.name}" needs permission for: ${askKeys.join(", ")}. ` +
           `Run from chat or use an app with permission prompts. Or change keys to "Always allow" in Settings → API Keys.`,
       );
+    }
+
+    for (const keyName of requiredKeys) {
+      if (!customKeys[keyName]) {
+        throw new Error(
+          `Required API key "${keyName}" is missing. Add it in Settings → API Keys → Custom API Keys.`,
+        );
+      }
     }
 
     // 4. Strip ${KEY_NAME} placeholders — keys are injected via env vars

--- a/src/gateway/services/jobs/executors/CommandJobExecutor.ts
+++ b/src/gateway/services/jobs/executors/CommandJobExecutor.ts
@@ -49,11 +49,13 @@ export class CommandJobExecutor implements IJobExecutor {
     // Jobs bypass the bash tool, so we need to substitute keys here
     // For "ask" keys, requests permission before substituting
     let sanitizationValues: string[] = [];
+    const keyEnvVars: Record<string, string> = {};
     try {
-      const result = await this.substituteCustomKeys(finalCommand, params);
+      const result = await this.resolveCustomKeys(finalCommand, params);
       finalCommand = result.command;
       sanitizationValues = result.sanitizationValues;
-      // Do NOT inject customKeys into env - that's a security risk!
+      // Inject resolved keys as env vars to child process
+      Object.assign(keyEnvVars, result.keyEnvVars);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to substitute API keys: ${message}`);
@@ -71,6 +73,8 @@ export class CommandJobExecutor implements IJobExecutor {
       JOB_DIR: params.jobDir,
       JOB_DB: jobDbPath,
       ...(params.runtimeParams ?? {}),
+      // Inject resolved keys as env vars (child process only — never in command string)
+      ...keyEnvVars,
     }
     
     const proc = spawn(shellPath, shellArgs, {
@@ -87,19 +91,20 @@ export class CommandJobExecutor implements IJobExecutor {
   }
 
   /**
-   * Substitute custom API keys in command (${KEY_NAME} syntax).
-   * Loads keys from both environment AND CustomKeysStorage.
+   * Resolve custom API keys referenced in the command template.
+   * Keys are returned as env vars for child process injection.
    * For keys with permission "ask", requests user approval before substituting.
    *
-   * SECURITY: Keys are ONLY substituted in command string, NOT injected into env.
+   * SECURITY: Keys are injected as env vars to the child process.
+   * They are NEVER substituted into the command string.
    *
    * @returns Object with substituted command
    * @throws Error if permission denied for an "ask" key
    */
-  private async substituteCustomKeys(
+  private async resolveCustomKeys(
     command: string,
     params: ExecutorLaunchParams,
-  ): Promise<{ command: string; sanitizationValues: string[] }> {
+  ): Promise<{ command: string; keyEnvVars: Record<string, string>; sanitizationValues: string[] }> {
     const customKeys: Record<string, string> = {};
     const job = params.job;
 
@@ -172,20 +177,28 @@ export class CommandJobExecutor implements IJobExecutor {
       );
     }
 
-    // 4. Substitute ${KEY_NAME} with actual values
+    // 4. Strip ${KEY_NAME} placeholders — keys are injected via env vars
+    // The command seen by the agent/logs shows placeholders, never values
     let result = command;
     if (command.includes("${")) {
-      for (const [name, value] of Object.entries(customKeys)) {
-        if (value && value.length > 0) {
-          const regex = new RegExp(`\\$\\{${this.escapeRegex(name)}\\}`, "g");
-          result = result.replace(regex, value);
+      for (const name of Object.keys(customKeys)) {
+        // Remove --flag "${KEY_NAME}" arg pairs
+        const flagRe = new RegExp(
+          `\\s+--[a-z][-a-z]*\\s+["']?\\$\\{${this.escapeRegex(name)}\\}["']?`, "g",
+        );
+        if (flagRe.test(result)) {
+          result = result.replace(flagRe, "");
+        } else {
+          const re = new RegExp(`["']?\\$\\{${this.escapeRegex(name)}\\}["']?`, "g");
+          result = result.replace(re, "");
         }
       }
+      result = result.replace(/  +/g, " ").trim();
     }
     const sanitizationValues = Object.values(customKeys).filter(
-      (value) => value.length > 0,
+      (v) => v && v.length > 0,
     );
-    return { command: result, sanitizationValues };
+    return { command: result, keyEnvVars: customKeys, sanitizationValues };
   }
 
   /**

--- a/src/gateway/services/jobs/types.ts
+++ b/src/gateway/services/jobs/types.ts
@@ -23,6 +23,8 @@ export interface JobRecord {
   /** Free-form folder label for grouping related jobs (e.g. "ingestion", "reporting"). Agent-assigned. */
   folder?: string;
   command?: string;
+  /** Custom API key names from Settings to inject as child-process env vars. */
+  requiredKeys?: string[];
   requirements?: string[];
   dependsOn?: JobDependency[];
   /** Job IDs this job calls at runtime via /api/jobs/run (for visualization only - not enforced) */
@@ -72,6 +74,8 @@ export interface CreateJobInput {
   type: JobType;
   folder?: string;
   command?: string;
+  /** Custom API key names from Settings to inject as child-process env vars. */
+  requiredKeys?: string[];
   requirements?: string[];
   dependsOn?: JobDependency[];
   /** Job IDs this job calls at runtime via /api/jobs/run (for visualization - shows dashed arrows in graph) */

--- a/src/gateway/websocket/jobs.ts
+++ b/src/gateway/websocket/jobs.ts
@@ -20,6 +20,7 @@ interface CreateJobPayload {
   type: JobType;
   folder?: string;
   command?: string;
+  requiredKeys?: string[];
   dependsOn?: JobDependency[];
   retries?: JobRetryPolicy;
   deliver?: JobDelivery;

--- a/src/resources/agent-docs/APP_AND_JOBS_GUIDE.md
+++ b/src/resources/agent-docs/APP_AND_JOBS_GUIDE.md
@@ -897,7 +897,7 @@ try {
 
 **IMPORTANT: For Python scripts with API keys:**
 - Type: `python` (NOT `bash`)
-- Command: `python3 code/main.py --token ${KEY_NAME}`
+- Command: `python3 code/main.py` with `requiredKeys: ["KEY_NAME"]`.
 - The script uses argparse to receive the key
 
 ### Python Job: Auto Venv + Requirements

--- a/src/resources/skills/api-key-testing.md
+++ b/src/resources/skills/api-key-testing.md
@@ -139,7 +139,7 @@ Only after confirmation, create the job with `create_job` and the verified field
 create_job({
   name: "Amplitude Sync",
   type: "python",
-  command: "python3 code/main.py --amplitude-key ${AMPLITUDE_API_KEY}",
+  command: "python3 code/main.py", requiredKeys: ["AMPLITUDE_API_KEY"],
   requirements: ["requests"]
 })
 
@@ -180,7 +180,7 @@ Is there another field I should use?
 
 1. `list_keys` to check what keys exist; `request_key` if missing
 2. `bash` with `curl` for small probe calls (`${KEY_NAME}` substitution works automatically)
-3. `create_job` only after data shape is validated — use `type: "python"` for scripts with API keys, pass keys as CLI args
+3. `create_job` only after data shape is validated — use `type: "python"` for scripts with API keys, declare API keys in requiredKeys and read them from env
 4. `run_job` to verify output and logs
 5. `link_app_data_source` only after verified outputs
 
@@ -193,7 +193,7 @@ Is there another field I should use?
 - [ ] Pagination/rate-limit assumptions documented
 - [ ] User intent and metric definitions confirmed
 - [ ] Job created with correct type: `python` for scripts, `bash` for one-liners
-- [ ] Python jobs: keys passed as CLI args in command, NOT in source code
+- [ ] Python jobs: keys declared in requiredKeys and read from env, NOT passed as CLI args
 - [ ] Only then: write the job code
 
 ---

--- a/src/resources/skills/app-and-jobs-guide.md
+++ b/src/resources/skills/app-and-jobs-guide.md
@@ -250,7 +250,7 @@ Mini-apps run in sandboxed iframes with restricted permissions:
 |------|---------|---------|
 | `python` | Scripts with logic, API calls, data processing, ML | `command: "python3 code/main.py --token ${GITHUB_TOKEN}"` |
 | `bash` | Simple shell one-liners | `command: "curl -H 'Authorization: Bearer ${KEY}' ..."` |
-| `node` | Node.js/TypeScript scripts | `command: "node code/main.js --api-key ${KEY}"` |
+| `node` | Node.js/TypeScript scripts | `command: "node code/main.js", requiredKeys: ["KEY"]` |
 
 **Use `type: "python"` when:** The job has multi-step logic, API calls, data processing, or needs pip packages. Pass API keys as CLI arguments in the command.
 
@@ -522,11 +522,11 @@ When a job will be triggered by a button click:
 
 | Layer | Set by | Available in job |
 |-------|--------|-------------------|
-| API keys (custom from Settings) | `create_job` command | Pass as CLI args: `--token ${KEY_NAME}` |
+| API keys (custom from Settings) | `create_job` command | Declare `requiredKeys: ["KEY_NAME"]` and read `os.environ["KEY_NAME"]` / `process.env.KEY_NAME`. |
 | Job config env (`SUBREDDIT=python`) | `create_job` / `update_job` | `os.environ`, `$VAR` |
 | Runtime params (`THREAD_ID=abc123`) | `params` in `/api/jobs/run` | `os.environ.get('THREAD_ID')`, `$THREAD_ID` |
 
-Runtime params: `os.environ.get('THREAD_ID')`. API keys: pass via CLI args, parse with `argparse`.
+Runtime params: `os.environ.get('THREAD_ID')`. API keys: declare requiredKeys and read from os.environ/process.env; never pass secrets as CLI args.
 
 ---
 
@@ -701,7 +701,7 @@ create_job({ type: "bash", command: "pip3 install requests && python3 fetch.py" 
 
 // ❌ Using os.getenv for custom API keys
 // Python: token = os.getenv('GITHUB_TOKEN')
-// → Custom keys from Settings are NOT in env. Pass as CLI args.
+// → Custom keys from Settings are injected into job env when declared in requiredKeys. Do not pass secrets as CLI args.
 
 // ❌ Building a separate HTTP server job as a bridge
 create_job({ name: "api-bridge", type: "node", command: "node server.js" })

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -366,7 +366,12 @@ export function App() {
 
   // Show authentication wall IMMEDIATELY if required (before loading anything else)
   if (REQUIRE_PAPR_AUTH && !authChecked) {
-    return <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', background: 'var(--background-color, #1a1a2e)' }} />;
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100vh', background: '#1a1a2e' }}>
+        <div style={{ width: 24, height: 24, border: '2px solid rgba(255,255,255,0.2)', borderTopColor: '#0080FF', borderRadius: '50%', animation: 'spin 0.8s linear infinite' }} />
+        <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+      </div>
+    );
   }
 
   if (REQUIRE_PAPR_AUTH && !isAuthenticated) {

--- a/ui/components/Auth/AuthWall.css
+++ b/ui/components/Auth/AuthWall.css
@@ -7,14 +7,20 @@
   display: flex;
   min-height: 100vh;
   width: 100%;
-  background: var(--background-color);
+  background: var(--background-color, #f5f5f7);
+}
+
+@media (prefers-color-scheme: dark) {
+  .auth-wall {
+    background: var(--background-color, #1a1a2e);
+  }
 }
 
 /* Loading State - Centered */
 .auth-wall--loading {
   align-items: center;
   justify-content: center;
-  background: var(--background-color);
+  background: var(--background-color, #1a1a2e);
 }
 
 .auth-wall-loading-text {

--- a/ui/components/Auth/AuthWall.tsx
+++ b/ui/components/Auth/AuthWall.tsx
@@ -16,6 +16,25 @@ export function AuthWall({ onAuthenticated }: AuthWallProps) {
   const [error, setError] = useState<string | null>(null);
   const [showRefresh, setShowRefresh] = useState(false);
 
+  // Register IPC-to-DOM bridge listeners so deep link callbacks reach us.
+  // Without this, preload.cjs never dispatches the DOM events AuthWall listens for.
+  useEffect(() => {
+    const successCb = () => {
+      console.log('[AuthWall] Login success via IPC bridge');
+    };
+    const errorCb = (data: { error: string }) => {
+      console.log('[AuthWall] Login error via IPC bridge:', data?.error);
+    };
+
+    window.electronAPI.papr.onLoginSuccess(successCb);
+    window.electronAPI.papr.onLoginError(errorCb);
+
+    return () => {
+      window.electronAPI.papr.removeLoginSuccessListener?.(successCb);
+      window.electronAPI.papr.removeLoginErrorListener?.(errorCb);
+    };
+  }, []);
+
   // Check if user is already authenticated
   useEffect(() => {
     checkAuthentication();
@@ -29,7 +48,6 @@ export function AuthWall({ onAuthenticated }: AuthWallProps) {
     window.addEventListener('papr-auth-success', handleAuthSuccess);
     
     // Also poll for authentication status while waiting
-    // This ensures we catch auth even if the IPC event is missed
     let pollInterval: NodeJS.Timeout | null = null;
     let refreshTimer: NodeJS.Timeout | null = null;
     
@@ -37,9 +55,8 @@ export function AuthWall({ onAuthenticated }: AuthWallProps) {
       pollInterval = setInterval(() => {
         console.log('[AuthWall] Polling authentication status...');
         checkAuthentication();
-      }, 2000); // Check every 2 seconds
+      }, 2000);
 
-      // Show refresh button after 5 seconds
       refreshTimer = setTimeout(() => {
         setShowRefresh(true);
       }, 5000);

--- a/ui/src/lib/gateway.ts
+++ b/ui/src/lib/gateway.ts
@@ -225,9 +225,9 @@ class GatewayClient {
   /**
    * Wait until the WebSocket connection is open.
    * Resolves immediately if already connected.
-   * Times out after `timeoutMs` (default 10 s).
+   * Times out after `timeoutMs` (default 30 s — Gateway needs ~12-15s in dev).
    */
-  waitForConnection(timeoutMs = 10_000): Promise<void> {
+  waitForConnection(timeoutMs = 30_000): Promise<void> {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       return Promise.resolve();
     }
@@ -248,7 +248,7 @@ class GatewayClient {
    * Automatically waits for connection if not yet open.
    */
   async send(type: string, payload?: unknown): Promise<GatewayResponse> {
-    // Wait up to 10 s for the WebSocket to connect
+    // Wait for the WebSocket to connect (default 30s — Gateway needs ~12-15s in dev)
     await this.waitForConnection();
 
     return new Promise((resolve, reject) => {
@@ -299,7 +299,7 @@ class GatewayClient {
   ): Promise<void> {
     console.log("[Gateway.stream] START", { type, payload });
 
-    // Wait up to 10 s for the WebSocket to connect
+    // Wait for the WebSocket to connect (default 30s — Gateway needs ~12-15s in dev)
     await this.waitForConnection();
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

- **AuthWall IPC bridge**: AuthWall now registers `onLoginSuccess`/`onLoginError` IPC listeners so deep link callback errors actually reach the UI. Previously these were only registered by `PaprLoginSection` (inside Settings), which is blocked by AuthWall — causing "Waiting for authentication..." to spin forever on errors.
- **New signup JWT retry**: When Auth0 Post-Login Action hasn't finished provisioning the Parse user, `completePaprAuthCallback` now waits 4 seconds and refreshes the token to get updated claims instead of immediately throwing "Your account setup didn't finish". Fixes the "Create Account" flow for new users.
- **Dev startup reliability**: `npm run dev` auto-kills stale Gateway processes before starting (prevents port 18789 conflicts). Auth check loading state shows a visible spinner instead of an invisible empty div on macOS transparent windows. AuthWall CSS now has fallback backgrounds for when CSS variables aren't loaded yet.

## Test plan

- [ ] Run `npm run dev` — verify Gateway starts cleanly (no port conflict), UI loads, WebSocket connects
- [ ] Kill dev mode abruptly (Ctrl+C), run `npm run dev` again — verify it auto-kills orphan Gateway and starts fresh
- [ ] Build production app (`npm run build`) — verify auth check shows spinner briefly, then AuthWall renders with correct backgrounds
- [ ] Test "Create Account" flow in packaged app — verify errors display in AuthWall (not swallowed silently)
- [ ] Test "Sign in" flow for existing users — verify login still works as before
- [ ] Test new signup where JWT claims arrive delayed — verify retry logic fetches fresh token after 4s


Made with [Cursor](https://cursor.com)