### PR TITLE
fix(stream): recover pending tool calls when Anthropic returns finish_reason=length

### DIFF
--- a/src/gateway/services/providers/PiCodexStreamWithToolLoop.ts
+++ b/src/gateway/services/providers/PiCodexStreamWithToolLoop.ts
@@ -498,19 +498,40 @@ export async function* createPiCodexStreamWithToolLoop(
           );
         }
 
-        // Don't yield "finish" when toolUse - we're continuing the loop
+        // Don't yield "finish" when toolUse - we're continuing the loop.
+        // ALSO suppress finish when reason==="length" but we have pending tool
+        // calls this turn — Anthropic truncates mid-response when maxTokens is hit,
+        // but the tool_use blocks already streamed are complete and valid JSON.
+        // If we yield finish here the orchestrator terminates and we orphan them.
+        // Instead, execute the pending tools and let the loop continue with a
+        // fresh model call (which gets a fresh maxTokens budget).
         if (event.reason === "toolUse") continue;
+        if (event.reason === "length" && toolCallsThisTurn.length > 0) {
+          console.warn(
+            `[PiCodexToolLoop] ⚠️ Model hit maxTokens mid-turn with ${toolCallsThisTurn.length} pending tool call(s). ` +
+            `Executing them and continuing loop instead of terminating (would orphan tool_use blocks).`
+          );
+          continue;
+        }
       }
 
       const chunk = adaptPiStreamToAISDKEvent(event, cumulativeTokens);
       if (chunk) yield chunk;
     }
 
-    if (
-      lastFinishReason === "tool-calls" &&
-      toolCallsThisTurn.length > 0 &&
-      finalMessage
-    ) {
+    // Execute pending tools when:
+    //   - finish==="tool-calls" (normal Anthropic tool turn), OR
+    //   - finish==="length" but we have completed tool_use blocks in this turn.
+    // The second case happens when Anthropic exhausts maxTokens mid-response;
+    // any tool_use blocks already streamed have complete JSON args and must be
+    // executed, otherwise the next turn sees orphaned tool_use → recovery markers
+    // → permanent stuck state.
+    const hasPendingToolCalls = toolCallsThisTurn.length > 0 && finalMessage;
+    const shouldExecuteTools =
+      hasPendingToolCalls &&
+      (lastFinishReason === "tool-calls" || lastFinishReason === "length");
+
+    if (shouldExecuteTools) {
       // Update total tool call counter
       totalToolCalls += toolCallsThisTurn.length;
       
@@ -639,7 +660,7 @@ export async function* createPiCodexStreamWithToolLoop(
 
       // Append full results — compaction happens in compactStaleToolResults
       // before the next model call (next loop iteration).
-      appendToolTurnToContext(context, finalMessage, toolResults, cumulativeTokens);
+      appendToolTurnToContext(context, finalMessage!, toolResults, cumulativeTokens);
 
       // Do NOT update cumulativeTokens here from raw context size — that
       // double-counts results that will be compacted before the next model call.

--- a/src/gateway/services/providers/PiCodexStreamWithToolLoop.ts
+++ b/src/gateway/services/providers/PiCodexStreamWithToolLoop.ts
@@ -182,7 +182,37 @@ function appendToolTurnToContext(
   toolResults: Array<{ toolCallId: string; toolName: string; result: unknown }>,
   _cumulativeTokens: number,
 ): void {
-  context.messages.push(assistantMessage);
+  // Sanitize: Anthropic strictly requires every `tool_use` block in an assistant
+  // message to have a matching `tool_result` in the immediately following message.
+  // If finish_reason=length truncated a tool_use block mid-stream (no toolcall_end fired),
+  // it won't have a corresponding result. Filter those out before persisting to context,
+  // otherwise the NEXT request to Anthropic fails with:
+  //   "tool_use ids were found without tool_result blocks immediately after"
+  const executedIds = new Set(toolResults.map((tr) => tr.toolCallId));
+  const sanitizedContent: unknown[] = [];
+  let droppedCount = 0;
+  for (const part of assistantMessage.content as Array<Record<string, unknown>>) {
+    if (part && (part as any).type === "toolCall") {
+      const id = (part as any).id;
+      if (typeof id !== "string" || !executedIds.has(id)) {
+        droppedCount++;
+        continue;
+      }
+    }
+    sanitizedContent.push(part);
+  }
+  if (droppedCount > 0) {
+    console.warn(
+      `[PiCodexToolLoop] ⚠️ Dropped ${droppedCount} unmatched tool_use block(s) from assistant message ` +
+      `(likely truncated by finish_reason=length). Prevents Anthropic 400 on next request.`
+    );
+  }
+
+  const sanitizedAssistantMessage = {
+    ...assistantMessage,
+    content: sanitizedContent,
+  };
+  context.messages.push(sanitizedAssistantMessage);
   const now = Date.now();
 
   for (const tr of toolResults) {


### PR DESCRIPTION
## Problem

When the model produces many tool calls in one turn (e.g. parallel `bash`/`list_documents` bursts), Anthropic can hit `maxTokens` mid-response. The stream finishes with `finish_reason: "length"` instead of `"tool-calls"`, even though some `tool_use` blocks have already streamed fully and have valid JSON args.

Today the loop treats this as terminal:

1. The `finish` chunk gets yielded → `streamOrchestrator` terminates the stream.
2. The tool-execution gate (`PiCodexStreamWithToolLoop.ts` ~L510) only fires when `lastFinishReason === "tool-calls"`, so completed `tool_use` blocks from this turn are abandoned.
3. `streamOrchestrator` synthesizes `"Tool result not persisted — stream likely interrupted"` markers for the orphaned blocks.
4. On the next user turn the model sees those markers, retries the same tool burst in parallel, and hits the same length cap → **permanent stuck state**.

## Repro signal in logs

```
Adding tool to sequence (#40): update_plan
🏁 Finish chunk received, reason: length
⚠️ 1 orphaned tool_use block(s) at stream end — synthesizing recovery markers
```

Then on the next turn:

```
toolResult | [Tool result not persisted — stream likely interrupted ...]
toolResult | [Tool result not persisted — stream likely interrupted ...]
...×30
```

## Fix

In `PiCodexStreamWithToolLoop.ts`, when `reason === "length"` AND `toolCallsThisTurn.length > 0`:

- **Suppress the `finish` chunk** so the orchestrator doesn't terminate the stream.
- **Extend the tool-execution gate** to include this case. Pending tools get executed, results are appended to context, and the next loop iteration starts with a fresh `maxTokens` budget.

Both branches log a `⚠️` warning so the recovery path is observable.

## Safety

- True `stop` turns still yield `finish` normally.
- True `length` with no tool calls still yields `finish` normally (model genuinely ran out of room with text only).
- Only the new failure mode — `length` *with* completed tool blocks — gets the recovery path.
- TypeScript clean (`tsc --noEmit` passes).

## Follow-up (not in this PR)

`maxTokens` is hardcoded to 16000 in `AgentService` for Anthropic. For tool-heavy turns the model budgets text + tool args from the same pool. Two follow-ups worth considering:

1. Raise `maxTokens` for Anthropic when tools are enabled (32k–64k).
2. Add a soft cap on tool calls per turn (e.g. nudge the model to wrap up at N≥15 calls).

This PR fixes the bug. Those tune the system to avoid hitting the bug as often.