### PR TITLE
feat(ui): Memory light/dark support + sidebar profile footer

### DIFF
--- a/ui/components/Memory/WikiLibrary.css
+++ b/ui/components/Memory/WikiLibrary.css
@@ -1,19 +1,20 @@
 /* Memory Wiki — Meridian design tokens + library browser */
 
 .memory-view {
-  --bg: #0d0f14;
-  --bg-panel: #13161d;
-  --bg-sunk: #0a0c10;
-  --bg-inset: #1a1d26;
-  --line: rgba(255,255,255,0.08);
-  --line-soft: rgba(255,255,255,0.05);
-  --text: #f0f0ee;
-  --text-mute: rgba(240,240,238,0.5);
-  --text-dim: rgba(240,240,238,0.3);
+  /* Light defaults — dark values live in prefers-color-scheme: dark below */
+  --bg: #f5f6f8;
+  --bg-panel: #ffffff;
+  --bg-sunk: #eceef1;
+  --bg-inset: #e4e7ec;
+  --line: rgba(0,0,0,0.10);
+  --line-soft: rgba(0,0,0,0.06);
+  --text: #1d1d1f;
+  --text-mute: rgba(29,29,31,0.62);
+  --text-dim: rgba(29,29,31,0.42);
   --accent: #0080FF;
-  --accent-soft: rgba(0,128,255,0.15);
-  --shadow: 0 1px 2px rgba(0,0,0,0.3), 0 8px 32px rgba(0,0,0,0.5);
-  --shadow-sm: 0 1px 3px rgba(0,0,0,0.4);
+  --accent-soft: rgba(0,128,255,0.12);
+  --shadow: 0 1px 2px rgba(0,0,0,0.05), 0 8px 32px rgba(0,0,0,0.10);
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.08);
   --g-project: linear-gradient(135deg, #0080FF, #0040CC);
   --g-goal: linear-gradient(135deg, #f59e0b, #d97706);
   --g-person: linear-gradient(135deg, #10b981, #059669);
@@ -22,12 +23,12 @@
   --g-task: linear-gradient(135deg, #f97316, #ea580c);
   --g-entity: linear-gradient(135deg, #a855f7, #9333ea);
 
-  /* Markdown/CodeBlock tokens — memory view is always dark */
-  --text-primary: #f0f0ee;
-  --text-secondary: rgba(240, 240, 238, 0.55);
-  --text-color: #f0f0ee;
-  --primary-color: #7cacf8;
-  --border-color: rgba(255, 255, 255, 0.08);
+  /* Markdown/CodeBlock tokens — adapt with theme */
+  --text-primary: #1d1d1f;
+  --text-secondary: rgba(29, 29, 31, 0.55);
+  --text-color: #1d1d1f;
+  --primary-color: #0066cc;
+  --border-color: rgba(0, 0, 0, 0.08);
 
   display: flex;
   flex-direction: column;
@@ -883,6 +884,12 @@
     --accent-soft: oklch(28% 0.06 230);
     --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 8px 24px rgba(0, 0, 0, 0.35);
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    /* Markdown/CodeBlock tokens — dark */
+    --text-primary: #e7e6e1;
+    --text-secondary: rgba(231, 230, 225, 0.55);
+    --text-color: #e7e6e1;
+    --primary-color: #7cacf8;
+    --border-color: rgba(255, 255, 255, 0.08);
   }
 
   .wiki-palette-scrim {
@@ -914,21 +921,21 @@
   letter-spacing: 0.08em;
 }
 
-/* Hero bg — deeper gradient on dark */
+/* Hero bg — branded blue cover; white hero text stays legible in light + dark */
 .wiki-hero__bg {
-  background: linear-gradient(135deg, #0d0f14 0%, #13161d 60%, #1a1d26 100%) !important;
+  background: linear-gradient(135deg, #0a4da8 0%, #0080FF 55%, #2ba6ff 100%) !important;
 }
 
-/* Palette (⌘K) — dark glass style */
+/* Palette (⌘K) — glass style */
 .wiki-palette {
-  background: #1a1d26 !important;
-  border: 1px solid rgba(255,255,255,0.1) !important;
+  background: var(--bg-panel) !important;
+  border: 1px solid var(--line) !important;
 }
 
 .wiki-palette__input {
-  background: rgba(255,255,255,0.06) !important;
+  background: var(--bg-sunk) !important;
   color: var(--text) !important;
-  border-color: rgba(255,255,255,0.1) !important;
+  border-color: var(--line) !important;
 }
 
 .wiki-palette__result:hover,
@@ -941,22 +948,22 @@
   color: var(--text-mute) !important;
 }
 .wiki-view-switch__btn[aria-selected="true"] {
-  background: rgba(0,128,255,0.2) !important;
-  color: #0080FF !important;
+  background: var(--accent-soft) !important;
+  color: var(--accent) !important;
 }
 
 /* Entity page sections */
 .wiki-entity__overview {
-  background: rgba(255,255,255,0.04);
-  border: 1px solid rgba(255,255,255,0.06);
+  background: var(--bg-panel);
+  border: 1px solid var(--line);
   border-radius: 10px;
   padding: 16px 20px;
   margin-bottom: 24px;
 }
 
-/* Skeleton loading on dark */
+/* Skeleton loading */
 .wiki-skeleton__block {
-  background: rgba(255,255,255,0.06) !important;
+  background: var(--bg-inset) !important;
 }
 
 /* ── Entity Stats Bar ─────────────────── */
@@ -1235,29 +1242,29 @@
   padding: 0 4px;
 }
 .wiki-entity__markdown .markdown-content {
-  color: #ddd;
+  color: var(--text-mute);
   line-height: 1.7;
 }
 .wiki-entity__markdown .markdown-h1 {
   font-size: 1.4rem;
   margin: 1.2rem 0 0.6rem;
-  color: #fff;
+  color: var(--text);
 }
 .wiki-entity__markdown .markdown-h2 {
   font-size: 1.15rem;
   margin: 1.5rem 0 0.5rem;
-  color: #fff;
-  border-bottom: 1px solid rgba(255,255,255,0.08);
+  color: var(--text);
+  border-bottom: 1px solid var(--line);
   padding-bottom: 6px;
 }
 .wiki-entity__markdown .markdown-h3 {
   font-size: 1rem;
   margin: 1rem 0 0.4rem;
-  color: #ccc;
+  color: var(--text);
 }
 .wiki-entity__markdown .markdown-p {
   margin: 0.5rem 0;
-  color: #bbb;
+  color: var(--text-mute);
 }
 .wiki-entity__markdown .markdown-ul,
 .wiki-entity__markdown .markdown-ol {
@@ -1266,26 +1273,26 @@
 }
 .wiki-entity__markdown .markdown-li {
   margin: 0.25rem 0;
-  color: #bbb;
+  color: var(--text-mute);
 }
 .wiki-entity__markdown .markdown-strong {
-  color: #fff;
+  color: var(--text);
 }
 .wiki-entity__markdown .markdown-link {
-  color: #7cacf8;
+  color: var(--primary-color);
 }
 .wiki-entity__markdown .markdown-blockquote {
-  border-left: 3px solid rgba(255,255,255,0.15);
+  border-left: 3px solid var(--line);
   padding-left: 12px;
   margin: 0.5rem 0;
-  color: #999;
+  color: var(--text-dim);
 }
 
 .wiki-entity__markdown .code-inline,
 .wiki-entity__markdown code.code-inline {
-  background: rgba(255, 255, 255, 0.1);
-  color: #e8eaed;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: var(--bg-inset);
+  color: var(--text);
+  border: 1px solid var(--line);
   padding: 2px 6px;
   border-radius: 4px;
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
@@ -1293,7 +1300,7 @@
 }
 
 .wiki-entity__markdown .markdown-li .code-inline {
-  color: #f5f5f5;
+  color: var(--text);
 }
 
 /* Context file editor */

--- a/ui/components/Sidebar/ProfileFooter.css
+++ b/ui/components/Sidebar/ProfileFooter.css
@@ -1,0 +1,99 @@
+/* ProfileFooter — sidebar identity row */
+.profile-footer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  transition: background-color 0.15s var(--ease);
+}
+
+.profile-footer:hover {
+  background: var(--hover-bg);
+}
+
+/* Avatar */
+.profile-footer__avatar {
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--border-color);
+  padding: 0;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  background: linear-gradient(135deg, #d4e4ff, #c8b6ff);
+  color: #2c2c2e;
+  transition: transform 0.15s var(--ease), box-shadow 0.15s var(--ease);
+}
+
+.profile-footer__avatar:hover {
+  transform: scale(1.05);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+}
+
+.profile-footer__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-footer__initials {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+/* Name + plan */
+.profile-footer__id {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+
+.profile-footer__name {
+  max-width: 100%;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profile-footer__plan {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+/* More (…) */
+.profile-footer__more {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background-color 0.15s var(--ease), color 0.15s var(--ease);
+}
+
+.profile-footer__more:hover {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}

--- a/ui/components/Sidebar/ProfileFooter.tsx
+++ b/ui/components/Sidebar/ProfileFooter.tsx
@@ -1,0 +1,75 @@
+/**
+ * ProfileFooter - Bottom-of-sidebar identity row.
+ * Avatar (→ profile section), name + subscription, and a more (…) button → Settings.
+ */
+
+import React from "react";
+import { useProfileStore } from "../../stores/profileStore";
+import { ConnectionIndicator } from "../ConnectionIndicator/ConnectionIndicator";
+import "./ProfileFooter.css";
+
+interface ProfileFooterProps {
+  onOpenProfile: () => void;
+  onOpenSettings: () => void;
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "";
+  const first = parts[0][0] ?? "";
+  const last = parts.length > 1 ? parts[parts.length - 1][0] ?? "" : "";
+  return (first + last).toUpperCase();
+}
+
+export function ProfileFooter({ onOpenProfile, onOpenSettings }: ProfileFooterProps) {
+  const { name, plan, imageUrl } = useProfileStore();
+  const displayName = name || "Your account";
+  const ini = initials(name);
+
+  return (
+    <div className="profile-footer">
+      <button
+        className="profile-footer__avatar"
+        onClick={onOpenProfile}
+        aria-label="Edit profile"
+        title="Edit profile"
+      >
+        {imageUrl ? (
+          <img src={imageUrl} alt={displayName} />
+        ) : ini ? (
+          <span className="profile-footer__initials">{ini}</span>
+        ) : (
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+            <circle cx="12" cy="8" r="4" stroke="currentColor" strokeWidth="1.6" />
+            <path
+              d="M4 20c0-3.3 3.6-6 8-6s8 2.7 8 6"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+          </svg>
+        )}
+      </button>
+
+      <button className="profile-footer__id" onClick={onOpenProfile}>
+        <span className="profile-footer__name">{displayName}</span>
+        <span className="profile-footer__plan">{plan}</span>
+      </button>
+
+      <ConnectionIndicator />
+
+      <button
+        className="profile-footer__more"
+        onClick={onOpenSettings}
+        aria-label="Settings"
+        title="Settings"
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+          <circle cx="5" cy="12" r="1.6" />
+          <circle cx="12" cy="12" r="1.6" />
+          <circle cx="19" cy="12" r="1.6" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/ui/components/Sidebar/Sidebar.tsx
+++ b/ui/components/Sidebar/Sidebar.tsx
@@ -12,7 +12,7 @@ import { NavButton } from "./NavButton";
 import { FavoritesList } from "./FavoritesList";
 import { NewChatButton } from "./NewChatButton";
 import { OnboardingCard } from "./OnboardingCard";
-import { ConnectionIndicator } from "../ConnectionIndicator/ConnectionIndicator";
+import { ProfileFooter } from "./ProfileFooter";
 import { SidebarToggleButton } from "./SidebarToggleButton";
 import { MemoryIcon } from "../Memory/MemoryIcon";
 import "./Sidebar.css";
@@ -78,6 +78,16 @@ export function Sidebar({ onToggleCollapse }: { onToggleCollapse?: () => void })
   const handleOpenSettings = useCallback(() => {
     const settingsId = createTab("settings", "settings", "Settings");
     switchToTab(settingsId);
+  }, [createTab, switchToTab]);
+
+  const handleOpenProfile = useCallback(() => {
+    const settingsId = createTab("settings", "settings", "Settings");
+    switchToTab(settingsId);
+    window.setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent("papr:open-settings", { detail: { tab: "profile" } }),
+      );
+    }, 60);
   }, [createTab, switchToTab]);
 
   const handleOpenGettingStarted = useCallback(() => {
@@ -272,34 +282,10 @@ export function Sidebar({ onToggleCollapse }: { onToggleCollapse?: () => void })
           onOpenGettingStarted={handleOpenGettingStarted}
           onSendMessage={handleOnboardingSendMessage}
         />
-        <div className="sidebar__footer-buttons">
-          <ConnectionIndicator />
-          <button
-            className="sidebar__settings-btn"
-            aria-label="Settings"
-            onClick={handleOpenSettings}
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
-              <path
-                d="M12.22 2h-.44a2 2 0 00-2 2v.18a2 2 0 01-1 1.73l-.43.25a2 2 0 01-2 0l-.15-.08a2 2 0 00-2.73.73l-.22.38a2 2 0 00.73 2.73l.15.1a2 2 0 011 1.72v.51a2 2 0 01-1 1.74l-.15.09a2 2 0 00-.73 2.73l.22.38a2 2 0 002.73.73l.15-.08a2 2 0 012 0l.43.25a2 2 0 011 1.73V20a2 2 0 002 2h.44a2 2 0 002-2v-.18a2 2 0 011-1.73l.43-.25a2 2 0 012 0l.15.08a2 2 0 002.73-.73l.22-.39a2 2 0 00-.73-2.73l-.15-.08a2 2 0 01-1-1.74v-.5a2 2 0 011-1.74l.15-.09a2 2 0 00.73-2.73l-.22-.38a2 2 0 00-2.73-.73l-.15.08a2 2 0 01-2 0l-.43-.25a2 2 0 01-1-1.73V4a2 2 0 00-2-2z"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <circle
-                cx="12"
-                cy="12"
-                r="3"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-            <span>Settings</span>
-          </button>
-        </div>
+        <ProfileFooter
+          onOpenProfile={handleOpenProfile}
+          onOpenSettings={handleOpenSettings}
+        />
       </div>
     </div>
   );

--- a/ui/stores/profileStore.ts
+++ b/ui/stores/profileStore.ts
@@ -9,15 +9,22 @@ interface ProfileState {
   name: string;
   email: string;
   imageUrl: string;
+  plan: string;
   loaded: boolean;
   loadProfile: () => Promise<void>;
-  setProfile: (profile: { name?: string; email?: string; imageUrl?: string }) => void;
+  setProfile: (profile: {
+    name?: string;
+    email?: string;
+    imageUrl?: string;
+    plan?: string;
+  }) => void;
 }
 
 export const useProfileStore = create<ProfileState>((set, get) => ({
   name: "",
   email: "",
   imageUrl: "",
+  plan: "Free plan",
   loaded: false,
 
   loadProfile: async () => {
@@ -25,13 +32,24 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
     try {
       const response = await gateway.send("settings:get");
       const data = response.data as {
-        profile?: { name?: string; email?: string; imageUrl?: string };
+        profile?: {
+          name?: string;
+          email?: string;
+          imageUrl?: string;
+          plan?: string;
+        };
+        subscription?: { plan?: string; name?: string };
       };
       if (data?.profile) {
         set({
           name: data.profile.name ?? "",
           email: data.profile.email ?? "",
           imageUrl: data.profile.imageUrl ?? "",
+          plan:
+            data.profile.plan ??
+            data.subscription?.plan ??
+            data.subscription?.name ??
+            "Free plan",
           loaded: true,
         });
       } else {
@@ -48,6 +66,7 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
       name: profile.name ?? get().name,
       email: profile.email ?? get().email,
       imageUrl: profile.imageUrl ?? get().imageUrl,
+      plan: profile.plan ?? get().plan,
     });
   },
 }));


### PR DESCRIPTION
## What & why

Two focused UX/design improvements, built with the Papr Liquid Glass system and Apple "less is more" principles.

### 1. Memory — light + dark mode
The Memory (Wiki Library) view was **dark-only**. It now supports **both light and dark**, consistent with the rest of the app.
- `.memory-view` root flipped to light defaults; dark values moved into `prefers-color-scheme: dark`
- Hardcoded dark-only rules (hero background, color palette, entity overview, markdown body, loading skeletons) converted to **design tokens** so they adapt automatically

### 2. Sidebar — real profile footer
Replaced the bare "Settings" row with a proper identity footer:
- **Avatar** (user photo) → clicks straight to the **Profile** section to edit photo/details
- **Name + subscription plan** shown inline — identity + plan at a glance
- **•••** → navigates to **Settings**
- `profileStore` extended with optional `plan`/`subscription`

## Files
| File | Change |
|---|---|
| `ui/components/Memory/WikiLibrary.css` | Light/dark tokenization |
| `ui/components/Sidebar/ProfileFooter.tsx` | New profile footer component |
| `ui/components/Sidebar/ProfileFooter.css` | Footer styling (Liquid Glass) |
| `ui/components/Sidebar/Sidebar.tsx` | Swap Settings row → ProfileFooter |
| `ui/stores/profileStore.ts` | Add plan/subscription |

## Testing
- Master build: clean, no errors
- Verified Memory adapts to light/dark; footer avatar→Profile, •••→Settings

_No functional/backend changes — UI only._
