### PR TITLE
Memory: branded icons for context files + goals/insights (customer default)

### DIFF
--- a/ui/components/Memory/WikiLibrary.css
+++ b/ui/components/Memory/WikiLibrary.css
@@ -1,19 +1,20 @@
 /* Memory Wiki — Meridian design tokens + library browser */
 
 .memory-view {
-  --bg: #0d0f14;
-  --bg-panel: #13161d;
-  --bg-sunk: #0a0c10;
-  --bg-inset: #1a1d26;
-  --line: rgba(255,255,255,0.08);
-  --line-soft: rgba(255,255,255,0.05);
-  --text: #f0f0ee;
-  --text-mute: rgba(240,240,238,0.5);
-  --text-dim: rgba(240,240,238,0.3);
+  /* Light defaults — dark values live in prefers-color-scheme: dark below */
+  --bg: #f5f6f8;
+  --bg-panel: #ffffff;
+  --bg-sunk: #eceef1;
+  --bg-inset: #e4e7ec;
+  --line: rgba(0,0,0,0.10);
+  --line-soft: rgba(0,0,0,0.06);
+  --text: #1d1d1f;
+  --text-mute: rgba(29,29,31,0.62);
+  --text-dim: rgba(29,29,31,0.42);
   --accent: #0080FF;
-  --accent-soft: rgba(0,128,255,0.15);
-  --shadow: 0 1px 2px rgba(0,0,0,0.3), 0 8px 32px rgba(0,0,0,0.5);
-  --shadow-sm: 0 1px 3px rgba(0,0,0,0.4);
+  --accent-soft: rgba(0,128,255,0.12);
+  --shadow: 0 1px 2px rgba(0,0,0,0.05), 0 8px 32px rgba(0,0,0,0.10);
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.08);
   --g-project: linear-gradient(135deg, #0080FF, #0040CC);
   --g-goal: linear-gradient(135deg, #f59e0b, #d97706);
   --g-person: linear-gradient(135deg, #10b981, #059669);
@@ -22,12 +23,12 @@
   --g-task: linear-gradient(135deg, #f97316, #ea580c);
   --g-entity: linear-gradient(135deg, #a855f7, #9333ea);
 
-  /* Markdown/CodeBlock tokens — memory view is always dark */
-  --text-primary: #f0f0ee;
-  --text-secondary: rgba(240, 240, 238, 0.55);
-  --text-color: #f0f0ee;
-  --primary-color: #7cacf8;
-  --border-color: rgba(255, 255, 255, 0.08);
+  /* Markdown/CodeBlock tokens — adapt with theme */
+  --text-primary: #1d1d1f;
+  --text-secondary: rgba(29, 29, 31, 0.55);
+  --text-color: #1d1d1f;
+  --primary-color: #0066cc;
+  --border-color: rgba(0, 0, 0, 0.08);
 
   display: flex;
   flex-direction: column;
@@ -883,6 +884,12 @@
     --accent-soft: oklch(28% 0.06 230);
     --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 8px 24px rgba(0, 0, 0, 0.35);
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    /* Markdown/CodeBlock tokens — dark */
+    --text-primary: #e7e6e1;
+    --text-secondary: rgba(231, 230, 225, 0.55);
+    --text-color: #e7e6e1;
+    --primary-color: #7cacf8;
+    --border-color: rgba(255, 255, 255, 0.08);
   }
 
   .wiki-palette-scrim {
@@ -914,21 +921,21 @@
   letter-spacing: 0.08em;
 }
 
-/* Hero bg — deeper gradient on dark */
+/* Hero bg — branded blue cover; white hero text stays legible in light + dark */
 .wiki-hero__bg {
-  background: linear-gradient(135deg, #0d0f14 0%, #13161d 60%, #1a1d26 100%) !important;
+  background: linear-gradient(135deg, #0a4da8 0%, #0080FF 55%, #2ba6ff 100%) !important;
 }
 
-/* Palette (⌘K) — dark glass style */
+/* Palette (⌘K) — glass style */
 .wiki-palette {
-  background: #1a1d26 !important;
-  border: 1px solid rgba(255,255,255,0.1) !important;
+  background: var(--bg-panel) !important;
+  border: 1px solid var(--line) !important;
 }
 
 .wiki-palette__input {
-  background: rgba(255,255,255,0.06) !important;
+  background: var(--bg-sunk) !important;
   color: var(--text) !important;
-  border-color: rgba(255,255,255,0.1) !important;
+  border-color: var(--line) !important;
 }
 
 .wiki-palette__result:hover,
@@ -941,22 +948,22 @@
   color: var(--text-mute) !important;
 }
 .wiki-view-switch__btn[aria-selected="true"] {
-  background: rgba(0,128,255,0.2) !important;
-  color: #0080FF !important;
+  background: var(--accent-soft) !important;
+  color: var(--accent) !important;
 }
 
 /* Entity page sections */
 .wiki-entity__overview {
-  background: rgba(255,255,255,0.04);
-  border: 1px solid rgba(255,255,255,0.06);
+  background: var(--bg-panel);
+  border: 1px solid var(--line);
   border-radius: 10px;
   padding: 16px 20px;
   margin-bottom: 24px;
 }
 
-/* Skeleton loading on dark */
+/* Skeleton loading */
 .wiki-skeleton__block {
-  background: rgba(255,255,255,0.06) !important;
+  background: var(--bg-inset) !important;
 }
 
 /* ── Entity Stats Bar ─────────────────── */
@@ -1235,29 +1242,29 @@
   padding: 0 4px;
 }
 .wiki-entity__markdown .markdown-content {
-  color: #ddd;
+  color: var(--text-mute);
   line-height: 1.7;
 }
 .wiki-entity__markdown .markdown-h1 {
   font-size: 1.4rem;
   margin: 1.2rem 0 0.6rem;
-  color: #fff;
+  color: var(--text);
 }
 .wiki-entity__markdown .markdown-h2 {
   font-size: 1.15rem;
   margin: 1.5rem 0 0.5rem;
-  color: #fff;
-  border-bottom: 1px solid rgba(255,255,255,0.08);
+  color: var(--text);
+  border-bottom: 1px solid var(--line);
   padding-bottom: 6px;
 }
 .wiki-entity__markdown .markdown-h3 {
   font-size: 1rem;
   margin: 1rem 0 0.4rem;
-  color: #ccc;
+  color: var(--text);
 }
 .wiki-entity__markdown .markdown-p {
   margin: 0.5rem 0;
-  color: #bbb;
+  color: var(--text-mute);
 }
 .wiki-entity__markdown .markdown-ul,
 .wiki-entity__markdown .markdown-ol {
@@ -1266,26 +1273,26 @@
 }
 .wiki-entity__markdown .markdown-li {
   margin: 0.25rem 0;
-  color: #bbb;
+  color: var(--text-mute);
 }
 .wiki-entity__markdown .markdown-strong {
-  color: #fff;
+  color: var(--text);
 }
 .wiki-entity__markdown .markdown-link {
-  color: #7cacf8;
+  color: var(--primary-color);
 }
 .wiki-entity__markdown .markdown-blockquote {
-  border-left: 3px solid rgba(255,255,255,0.15);
+  border-left: 3px solid var(--line);
   padding-left: 12px;
   margin: 0.5rem 0;
-  color: #999;
+  color: var(--text-dim);
 }
 
 .wiki-entity__markdown .code-inline,
 .wiki-entity__markdown code.code-inline {
-  background: rgba(255, 255, 255, 0.1);
-  color: #e8eaed;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: var(--bg-inset);
+  color: var(--text);
+  border: 1px solid var(--line);
   padding: 2px 6px;
   border-radius: 4px;
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
@@ -1293,7 +1300,7 @@
 }
 
 .wiki-entity__markdown .markdown-li .code-inline {
-  color: #f5f5f5;
+  color: var(--text);
 }
 
 /* Context file editor */
@@ -1473,8 +1480,8 @@
 
 .wiki-card__gradient--context {
   background:
-    radial-gradient(circle at 20% 20%, color-mix(in srgb, var(--accent) 36%, transparent), transparent 34%),
-    linear-gradient(135deg, var(--bg-panel-2), var(--bg-panel));
+    radial-gradient(circle at 78% 18%, rgba(255, 255, 255, 0.22), transparent 42%),
+    linear-gradient(135deg, #0080FF, #0a2a8c 55%, #06165a);
 }
 
 .wiki-card--context .wiki-card__glyph {
@@ -1544,4 +1551,48 @@
   flex: 0 0 220px;
   min-width: 0;
   max-width: none;
+}
+
+/* ── Demo: real images on cards + entity hero ── */
+.wiki-card__avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+  display: block;
+}
+.wiki-card__art-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.wiki-entity__hero-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* ── Branded centered glyph icons (context files, goals, insights) ── */
+.wiki-card__art-icon {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 46px;
+  height: 46px;
+  color: rgba(255, 255, 255, 0.92);
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.28));
+}
+.wiki-card__art-icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.wiki-card__art-icon--context {
+  width: 42px;
+  height: 42px;
 }

--- a/ui/components/Memory/WikiLibrary.tsx
+++ b/ui/components/Memory/WikiLibrary.tsx
@@ -52,7 +52,17 @@ function bodyPreview(body: string, maxLen = 140): string {
 
 const IC = `fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"`;
 
-/** Big centered icon for context .md cards, keyed by file name. */
+/**
+ * Returns an SVG icon for context .md files based on filename keywords.
+ * Matches against common file naming patterns to provide appropriate visual representation.
+ * 
+ * @param name - The filename to match against (e.g., "IDENTITY.md", "ICP.md", "Playbook.md")
+ * @returns SVG markup string with appropriate icon:
+ *   - identity/brand → person icon
+ *   - icp/customer/audience → target icon
+ *   - playbook/play/guide → book icon
+ *   - default → generic document icon
+ */
 function fileGlyphSvg(name: string): string {
   const n = name.toLowerCase();
   if (n.includes("identity") || n.includes("brand"))
@@ -64,7 +74,16 @@ function fileGlyphSvg(name: string): string {
   return `<svg viewBox="0 0 24 24" ${IC}><path d="M6 3h8l4 4v14H6z"/><path d="M14 3v4h4"/></svg>`;
 }
 
-/** SVG glyph for entity types with no cover image (goal, insight). */
+/**
+ * Returns an SVG icon for entity types when no cover image is available.
+ * Only returns icons for specific entity types that have custom glyphs.
+ * 
+ * @param type - The entity type (e.g., "goal", "insight")
+ * @returns SVG markup string for supported types, or null if the type should use the default glyph
+ *   - goal → target/bullseye icon
+ *   - insight → lightbulb icon
+ *   - other types → null (falls back to type's default glyph)
+ */
 function typeGlyphSvg(type: string): string | null {
   if (type === "goal")
     return `<svg viewBox="0 0 24 24" ${IC}><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="4.4"/><circle cx="12" cy="12" r="1"/></svg>`;
@@ -91,7 +110,12 @@ function PosterCard({ node, onClick }: { node: WikiNode; onClick: () => void }) 
         <span className="wiki-card__type-chip">{meta.label}</span>
         {status ? <span className="wiki-card__status"><span className="wiki-card__status-dot" />{status}</span> : null}
         {glyphSvg ? (
-          <span className="wiki-card__art-icon" dangerouslySetInnerHTML={{ __html: glyphSvg }} />
+          <span 
+            className="wiki-card__art-icon" 
+            dangerouslySetInnerHTML={{ __html: glyphSvg }}
+            aria-label={`${node.type} icon`}
+            role="img"
+          />
         ) : image ? null : (
           <span className="wiki-card__glyph">{meta.glyph}</span>
         )}
@@ -139,8 +163,12 @@ function ContextFileCard({ file, onOpen }: { file: WorkspaceFilePreview; onOpen:
       <div className="wiki-card__art wiki-card__art--context">
         <div className="wiki-card__gradient wiki-card__gradient--context" />
         <span className="wiki-card__type-chip">{chipLabel}</span>
-        <span className="wiki-card__art-icon wiki-card__art-icon--context"
-          dangerouslySetInnerHTML={{ __html: fileGlyphSvg(file.name) }} />
+        <span 
+          className="wiki-card__art-icon wiki-card__art-icon--context"
+          dangerouslySetInnerHTML={{ __html: fileGlyphSvg(file.name) }}
+          aria-label={`${fileLabel(file.name)} icon`}
+          role="img"
+        />
       </div>
       <div className="wiki-card__body">
         <h4 className="wiki-card__title">{fileLabel(file.name)}</h4>

--- a/ui/components/Memory/WikiLibrary.tsx
+++ b/ui/components/Memory/WikiLibrary.tsx
@@ -50,18 +50,51 @@ function bodyPreview(body: string, maxLen = 140): string {
 
 /* ── Cards ────────────────────────────────────────── */
 
+const IC = `fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"`;
+
+/** Big centered icon for context .md cards, keyed by file name. */
+function fileGlyphSvg(name: string): string {
+  const n = name.toLowerCase();
+  if (n.includes("identity") || n.includes("brand"))
+    return `<svg viewBox="0 0 24 24" ${IC}><circle cx="12" cy="8" r="3.2"/><path d="M5.5 19c.6-3.2 3.2-5 6.5-5s5.9 1.8 6.5 5"/></svg>`;
+  if (n.includes("icp") || n.includes("customer") || n.includes("audience"))
+    return `<svg viewBox="0 0 24 24" ${IC}><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="4.4"/><circle cx="12" cy="12" r="1"/></svg>`;
+  if (n.includes("playbook") || n.includes("play") || n.includes("guide"))
+    return `<svg viewBox="0 0 24 24" ${IC}><path d="M4 5.5A2 2 0 0 1 6 4h5v15H6a2 2 0 0 0-2 1.5z"/><path d="M20 5.5A2 2 0 0 0 18 4h-5v15h5a2 2 0 0 1 2 1.5z"/></svg>`;
+  return `<svg viewBox="0 0 24 24" ${IC}><path d="M6 3h8l4 4v14H6z"/><path d="M14 3v4h4"/></svg>`;
+}
+
+/** SVG glyph for entity types with no cover image (goal, insight). */
+function typeGlyphSvg(type: string): string | null {
+  if (type === "goal")
+    return `<svg viewBox="0 0 24 24" ${IC}><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="4.4"/><circle cx="12" cy="12" r="1"/></svg>`;
+  if (type === "insight")
+    return `<svg viewBox="0 0 24 24" ${IC}><path d="M9 18h6"/><path d="M10 21h4"/><path d="M12 3a6 6 0 0 0-3.6 10.8c.6.5 1 1.2 1.1 2h5c.1-.8.5-1.5 1.1-2A6 6 0 0 0 12 3z"/></svg>`;
+  return null;
+}
+
 function PosterCard({ node, onClick }: { node: WikiNode; onClick: () => void }) {
   const meta = wikiTypeMeta(node.type);
   const props = node.props ?? {};
   const status = props.status ? String(props.status) : null;
+  const image = props.image ? String(props.image) : null;
+  const glyphSvg = image ? null : typeGlyphSvg(node.type);
   return (
     <article className="wiki-card poster" onClick={onClick}>
       <div className="wiki-card__art">
-        <div className="wiki-card__gradient"
-          style={{ background: `linear-gradient(135deg, ${meta.color}, color-mix(in srgb, ${meta.color} 70%, #000))` }} />
+        {image ? (
+          <img className="wiki-card__art-img" src={image} alt={node.label} />
+        ) : (
+          <div className="wiki-card__gradient"
+            style={{ background: `linear-gradient(135deg, ${meta.color}, color-mix(in srgb, ${meta.color} 70%, #000))` }} />
+        )}
         <span className="wiki-card__type-chip">{meta.label}</span>
         {status ? <span className="wiki-card__status"><span className="wiki-card__status-dot" />{status}</span> : null}
-        <span className="wiki-card__glyph">{meta.glyph}</span>
+        {glyphSvg ? (
+          <span className="wiki-card__art-icon" dangerouslySetInnerHTML={{ __html: glyphSvg }} />
+        ) : image ? null : (
+          <span className="wiki-card__glyph">{meta.glyph}</span>
+        )}
       </div>
       <div className="wiki-card__body">
         <h4 className="wiki-card__title">{node.label}</h4>
@@ -75,9 +108,12 @@ function PersonCard({ node, onClick }: { node: WikiNode; onClick: () => void }) 
   const label = node.label ?? node.id;
   const initials = label.split(/\s+/).map((s) => s[0]).filter(Boolean).slice(0, 2).join("").toUpperCase();
   const props = node.props ?? {};
+  const image = props.image ? String(props.image) : null;
   return (
     <article className="wiki-card person" onClick={onClick}>
-      <div className="wiki-card__avatar">{initials || "?"}</div>
+      <div className="wiki-card__avatar">
+        {image ? <img className="wiki-card__avatar-img" src={image} alt={label} /> : (initials || "?")}
+      </div>
       <div className="wiki-card__name">{label}</div>
       {props.role ? <div className="wiki-card__role">{String(props.role)}</div> : null}
     </article>
@@ -103,7 +139,8 @@ function ContextFileCard({ file, onOpen }: { file: WorkspaceFilePreview; onOpen:
       <div className="wiki-card__art wiki-card__art--context">
         <div className="wiki-card__gradient wiki-card__gradient--context" />
         <span className="wiki-card__type-chip">{chipLabel}</span>
-        <span className="wiki-card__glyph">md</span>
+        <span className="wiki-card__art-icon wiki-card__art-icon--context"
+          dangerouslySetInnerHTML={{ __html: fileGlyphSvg(file.name) }} />
       </div>
       <div className="wiki-card__body">
         <h4 className="wiki-card__title">{fileLabel(file.name)}</h4>
@@ -749,8 +786,12 @@ function WikiEntityPage({ node, rails, relatedMemories, allNodes, loading, error
         {/* Hero */}
         <div className="wiki-entity__hero">
           <button type="button" className="wiki-entity__back" onClick={onBack}>← Library</button>
-          <div className="wiki-entity__hero-bg"
-            style={{ background: `linear-gradient(135deg, ${meta.color}, color-mix(in srgb, ${meta.color} 55%, #111))` }} />
+          {props.image ? (
+            <img className="wiki-entity__hero-img" src={String(props.image)} alt={node.label} />
+          ) : (
+            <div className="wiki-entity__hero-bg"
+              style={{ background: `linear-gradient(135deg, ${meta.color}, color-mix(in srgb, ${meta.color} 55%, #111))` }} />
+          )}
           <div className="wiki-entity__hero-inner">
             <div className="wiki-entity__eyebrow">
               <span>{meta.label}</span><span>·</span>
@@ -758,7 +799,7 @@ function WikiEntityPage({ node, rails, relatedMemories, allNodes, loading, error
             </div>
             <h1>{node.label}</h1>
             <div className="wiki-entity__meta-row">
-              {Object.entries(props).map(([key, value]) => (
+              {Object.entries(props).filter(([key]) => key !== "image").map(([key, value]) => (
                 <span key={key} className="wiki-entity__pill">{key}: {String(value)}</span>
               ))}
             </div>


### PR DESCRIPTION
Brings the same visual defaults every customer sees in Memory:

- **Context .md cards** (IDENTITY / ICP / Playbook) now render a fitting SVG icon on a Papr-blue gradient instead of tiny grey 'md' text.
- **Goals / insights** get crisp target + lightbulb glyphs (was plain ★ / ◇).
- **People / projects / companies** render a cover image when `props.image` is set (graceful fallback to gradient / initials).

Pure component change — 2 files (WikiLibrary.tsx/.css), no fixtures. Cleanly branched off master (`b94770b`); vite build passes. Same code already validated live in the demo emulator.