### PR TITLE
fix(settings): show every org's namespaces in the team picker

### DIFF
--- a/src/electron/ipc/paprLogin.ts
+++ b/src/electron/ipc/paprLogin.ts
@@ -869,6 +869,29 @@ const GET_ORG_NAMESPACES = `
   }
 `;
 
+/**
+ * Every organization attached to a workspace.
+ *
+ * `workSpace.organization` is a single pointer to the primary org, but
+ * Organization carries its own `workspace` pointer — so one workspace can hold
+ * several orgs, and the primary-org lookup alone hides the rest of them.
+ */
+const GET_WORKSPACE_ORGANIZATIONS = `
+  query GetWorkspaceOrganizations($workspaceId: ID!) {
+    organizations(
+      where: { workspace: { have: { objectId: { equalTo: $workspaceId } } } }
+      order: createdAt_DESC
+    ) {
+      edges {
+        node {
+          objectId
+          name
+        }
+      }
+    }
+  }
+`;
+
 const UPDATE_WORKSPACE_FOLLOWER_SELECTION = `
   mutation UpdateWorkspaceFollowerSelection($input: UpdateWorkspace_followerInput!) {
     updateWorkspace_follower(input: $input) {
@@ -1186,10 +1209,18 @@ async function syncActiveWorkspaceOrganization(
     return undefined;
   }
 
-  const orgChanged = namespaceOrgId !== profile.organizationId;
+  const workspaceChanged = active.workspaceId !== profile.workspaceId;
+
+  // A workspace can host several organizations, and `active.organizationId` is
+  // only its primary one. So an org that differs from the primary is the user's
+  // deliberate in-workspace choice, not drift — realigning it here would undo
+  // the namespace switch they just made (and issue a competing gateway switch
+  // below, which supersedes theirs). Only realign when the workspace itself
+  // changed, or when the profile carries no org at all.
+  const shouldRealignOrg = workspaceChanged || !profile.organizationId;
+  const orgChanged = shouldRealignOrg && namespaceOrgId !== profile.organizationId;
   const workspaceMetadataChanged =
-    active.workspaceId !== profile.workspaceId ||
-    active.workspaceName !== profile.workspaceName;
+    workspaceChanged || active.workspaceName !== profile.workspaceName;
 
   if (!orgChanged && !workspaceMetadataChanged) {
     return active;
@@ -1199,7 +1230,7 @@ async function syncActiveWorkspaceOrganization(
     ...profile,
     workspaceId: active.workspaceId,
     workspaceName: active.workspaceName,
-    organizationId: namespaceOrgId,
+    organizationId: orgChanged ? namespaceOrgId : profile.organizationId,
   });
 
   if (orgChanged) {
@@ -1267,6 +1298,13 @@ async function fetchUserDeveloperOrganizationId(
 async function resolveOrganizationIdForProfile(
   profile: PaprProfile,
 ): Promise<string | undefined> {
+  // The profile's org is authoritative when set: a workspace can host several
+  // organizations, so the workspace lookup below only knows the primary one and
+  // would silently move the user off the org they actually selected.
+  if (profile.organizationId) {
+    return profile.organizationId;
+  }
+
   if (profile.sessionToken && profile.userId) {
     try {
       const graphql: GraphQLExecutor = (query, variables) =>
@@ -1287,10 +1325,6 @@ async function resolveOrganizationIdForProfile(
     } catch (error) {
       console.warn("[PaprLogin] Could not resolve namespace org from workspaces:", error);
     }
-  }
-
-  if (profile.organizationId) {
-    return profile.organizationId;
   }
 
   if (profile.sessionToken && profile.userId) {
@@ -1797,16 +1831,142 @@ async function fetchOrgNamespaces(
     }),
   );
 
-  cacheNamespacesForOrg(
-    organizationId,
-    namespaces.map((ns: OrgNamespaceListItem) => ({
-      id: ns.id,
-      name: ns.name,
-      environmentType: ns.environmentType,
-    })),
-  );
+  const nextCacheEntries = namespaces.map((ns: OrgNamespaceListItem) => ({
+    id: ns.id,
+    name: ns.name,
+    environmentType: ns.environmentType,
+  }));
+
+  // Compare against what was cached BEFORE overwriting, so a background refresh
+  // that discovers new/removed namespaces can wake the renderer up.
+  const previousCacheEntries = getCachedNamespaces(organizationId) ?? [];
+  const changed =
+    namespaceListSignature(previousCacheEntries) !==
+    namespaceListSignature(nextCacheEntries);
+
+  cacheNamespacesForOrg(organizationId, nextCacheEntries);
+
+  if (changed) {
+    console.log(
+      `[PaprLogin] Namespace cache changed for org ${organizationId} ` +
+        `(${previousCacheEntries.length} -> ${nextCacheEntries.length}); notifying renderer`,
+    );
+    notifyWorkspaceCacheUpdated();
+  }
 
   return namespaces;
+}
+
+/**
+ * Tell the renderer the workspace/namespace disk cache changed underneath it.
+ *
+ * Renderers (Settings + ProfileFooter) listen on `papr:workspace-cache-updated`.
+ * Without this, a background refresh rewrites the cache but the UI keeps showing
+ * the stale list until a manual reload, so one bad cache write sticks forever.
+ */
+function notifyWorkspaceCacheUpdated(): void {
+  const win = BrowserWindow.getAllWindows()[0];
+  if (win && !win.isDestroyed()) {
+    win.webContents.send("papr:workspace-cache-updated");
+  }
+}
+
+/** Stable signature for namespace cache change detection (order-insensitive). */
+function namespaceListSignature(
+  namespaces: Array<{ id: string; name?: string; environmentType?: string }>,
+): string {
+  return namespaces
+    .map((ns) => `${ns.id}:${ns.name ?? ""}:${ns.environmentType ?? ""}`)
+    .sort()
+    .join("|");
+}
+
+/** Stable signature for workspace list change detection (order-insensitive). */
+function workspaceListSignature(
+  workspaces: Array<{
+    workspaceId?: string;
+    organizationId?: string;
+    workspaceName?: string;
+  }>,
+): string {
+  return workspaces
+    .map(
+      (ws) =>
+        `${ws.workspaceId ?? ""}:${ws.organizationId ?? ""}:${ws.workspaceName ?? ""}`,
+    )
+    .sort()
+    .join("|");
+}
+
+async function fetchWorkspaceOrganizations(
+  sessionToken: string,
+  workspaceId: string,
+  customKeysStorage: CustomKeysStorage,
+  settingsStorage: SettingsStorage,
+): Promise<Array<{ id: string; name: string }>> {
+  const data = (await parseGraphQLWithRefresh(
+    sessionToken,
+    GET_WORKSPACE_ORGANIZATIONS,
+    { workspaceId },
+    customKeysStorage,
+    settingsStorage,
+  )) as {
+    organizations?: {
+      edges?: Array<{ node: { objectId: string; name?: string } }>;
+    };
+  };
+
+  return (data.organizations?.edges ?? [])
+    .map((edge) => ({
+      id: edge.node.objectId,
+      name: edge.node.name?.trim() || "",
+    }))
+    .filter((org) => org.id);
+}
+
+/** One picker group per organization, with that org's namespaces. */
+interface WorkspaceNamespaceGroup {
+  workspaceId: string;
+  organizationId: string;
+  organizationName: string;
+  namespaces: OrgNamespaceListItem[];
+}
+
+/**
+ * Orgs with a background namespace refresh already running.
+ *
+ * The settings picker lists every org at once, so a cache-first load fans out
+ * one refresh per org. Without this guard, overlapping loads (mount + a
+ * cache-updated event) would multiply that fan-out by the number of callers.
+ */
+const backgroundNamespaceRefreshes = new Set<string>();
+
+function refreshOrgNamespacesInBackground(
+  sessionToken: string,
+  organizationId: string,
+  customKeysStorage: CustomKeysStorage,
+  settingsStorage: SettingsStorage,
+): void {
+  if (backgroundNamespaceRefreshes.has(organizationId)) return;
+  backgroundNamespaceRefreshes.add(organizationId);
+
+  // fetchOrgNamespaces rewrites the disk cache and fires
+  // `papr:workspace-cache-updated` itself when the list actually changed.
+  void fetchOrgNamespaces(
+    sessionToken,
+    organizationId,
+    customKeysStorage,
+    settingsStorage,
+  )
+    .catch((error) => {
+      console.warn(
+        `[PaprLogin] Background namespace refresh failed for org ${organizationId}:`,
+        error,
+      );
+    })
+    .finally(() => {
+      backgroundNamespaceRefreshes.delete(organizationId);
+    });
 }
 
 async function resolveNamespaceForWorkspaceSwitch(input: {
@@ -2907,6 +3067,171 @@ export function initializePaprLoginIPC(
     },
   );
 
+  // List namespaces across every workspace the user belongs to. The settings
+  // picker shows all orgs at once, so a namespace in another org is one click
+  // away instead of requiring an org switch first.
+  ipcMain.handle(
+    "papr:list-all-namespaces",
+    async (_event, options?: { forceRefresh?: boolean }) => {
+      try {
+        const profile = settingsStorage.getPaprProfile();
+        if (!profile?.sessionToken || !profile?.userId) {
+          return { success: false, error: "Not logged in" };
+        }
+
+        const sessionToken = profile.sessionToken;
+        const forceRefresh = options?.forceRefresh === true;
+
+        let workspaces: CachedWorkspace[] = readPaprWorkspaceCache()?.workspaces ?? [];
+        if (forceRefresh || workspaces.length === 0) {
+          const fetched = await fetchUserWorkspacesWithRefresh(
+            profile,
+            customKeysStorage,
+            settingsStorage,
+          );
+          workspaces = fetched.map(
+            (workspace): CachedWorkspace => ({
+              id: workspace.workspaceId,
+              name: workspaceDisplayName(workspace),
+              role: workspace.role,
+              organizationId: workspace.organizationId,
+              organizationName: workspace.organizationName,
+              workspaceName: workspace.workspaceName,
+              defaultNamespaceId: workspace.defaultNamespaceId,
+            }),
+          );
+          writePaprWorkspaceCache({ workspaces });
+        }
+
+        let partial = false;
+
+        // A workspace can hold several organizations, so ask for all of them
+        // rather than settling for `workspace.organization` (the primary).
+        const orgsPerWorkspace = await Promise.all(
+          workspaces.map(async (workspace) => {
+            const primaryOrgId = workspace.organizationId?.trim();
+            const orgs = new Map<string, string>();
+            if (primaryOrgId) {
+              orgs.set(primaryOrgId, workspace.organizationName?.trim() || "");
+            }
+
+            try {
+              for (const org of await fetchWorkspaceOrganizations(
+                sessionToken,
+                workspace.id,
+                customKeysStorage,
+                settingsStorage,
+              )) {
+                // Named result wins — the primary entry may have no name.
+                orgs.set(org.id, org.name || orgs.get(org.id) || "");
+              }
+            } catch (error) {
+              // Falling back to the primary org keeps this no worse than before.
+              console.warn(
+                `[PaprLogin] Failed to list organizations for workspace ${workspace.id}:`,
+                error,
+              );
+              partial = true;
+            }
+
+            return { workspace, orgs };
+          }),
+        );
+
+        // One group per organization: two workspaces sharing an org would
+        // otherwise list identical namespaces twice, and picking one would have
+        // an ambiguous workspace to switch to.
+        const orgEntries = new Map<
+          string,
+          { workspace: CachedWorkspace; organizationName: string }
+        >();
+        for (const { workspace, orgs } of orgsPerWorkspace) {
+          for (const [organizationId, orgName] of orgs) {
+            if (orgEntries.has(organizationId)) continue;
+            // With one org the workspace name is the familiar label; with
+            // several, qualify each so they can be told apart.
+            const organizationName =
+              orgs.size > 1 && orgName
+                ? `${workspace.name} · ${orgName}`
+                : workspace.name;
+            orgEntries.set(organizationId, { workspace, organizationName });
+          }
+        }
+
+        const groups = await Promise.all(
+          [...orgEntries.entries()].map(
+            async ([
+              organizationId,
+              { workspace, organizationName },
+            ]): Promise<WorkspaceNamespaceGroup> => {
+              const base = {
+                workspaceId: workspace.id,
+                organizationId,
+                organizationName,
+              };
+
+              const cached = forceRefresh ? null : getCachedNamespaces(organizationId);
+              if (cached) {
+                refreshOrgNamespacesInBackground(
+                  sessionToken,
+                  organizationId,
+                  customKeysStorage,
+                  settingsStorage,
+                );
+                return { ...base, namespaces: cached };
+              }
+
+              try {
+                const namespaces = await fetchOrgNamespaces(
+                  sessionToken,
+                  organizationId,
+                  customKeysStorage,
+                  settingsStorage,
+                );
+                return { ...base, namespaces };
+              } catch (error) {
+                // One unreachable org shouldn't blank the whole picker.
+                console.warn(
+                  `[PaprLogin] Failed to list namespaces for org ${organizationId}:`,
+                  error,
+                );
+                partial = true;
+                return { ...base, namespaces: [] };
+              }
+            },
+          ),
+        );
+
+        // Active workspace first so the current team stays at the top.
+        groups.sort((a, b) => {
+          if (a.workspaceId === profile.workspaceId) return -1;
+          if (b.workspaceId === profile.workspaceId) return 1;
+          return 0;
+        });
+
+        console.log(
+          `[PaprLogin] Listed ${groups.reduce((total, group) => total + group.namespaces.length, 0)} ` +
+            `namespaces across ${groups.length} organization(s)`,
+        );
+
+        return {
+          success: true,
+          groups,
+          activeOrganizationId: profile.workspaceId,
+          activeNamespaceId: profile.activeNamespaceId,
+          partial,
+        };
+      } catch (error) {
+        console.error("[PaprLogin] Failed to list all namespaces:", error);
+        return {
+          success: false,
+          error:
+            error instanceof Error ? error.message : "Failed to list namespaces",
+        };
+      }
+    },
+  );
+
   // List workspaces (dashboard uses workspace_follower → organization name for display)
   ipcMain.handle("papr:list-organizations", async () => {
     try {
@@ -2947,6 +3272,15 @@ export function initializePaprLoginIPC(
       if (cachedWorkspaces.length > 0) {
         void fetchUserWorkspacesWithRefresh(profile, customKeysStorage, settingsStorage)
           .then(async (workspaces) => {
+            const workspacesChanged =
+              workspaceListSignature(
+                cachedWorkspaces.map((workspace) => ({
+                  workspaceId: workspace.id,
+                  organizationId: workspace.organizationId,
+                  workspaceName: workspace.workspaceName ?? workspace.name,
+                })),
+              ) !== workspaceListSignature(workspaces);
+
             writePaprWorkspaceCache({
               workspaces: workspaces.map(
                 (workspace): CachedWorkspace => ({
@@ -2960,6 +3294,14 @@ export function initializePaprLoginIPC(
                 }),
               ),
             });
+
+            if (workspacesChanged) {
+              console.log(
+                `[PaprLogin] Workspace cache changed ` +
+                  `(${cachedWorkspaces.length} -> ${workspaces.length}); notifying renderer`,
+              );
+              notifyWorkspaceCacheUpdated();
+            }
 
             const active = await syncActiveWorkspaceOrganization(
               profile,
@@ -3064,7 +3406,17 @@ export function initializePaprLoginIPC(
   });
 
   // Switch workspace (updates Parse selection, then default namespace for that org)
-  ipcMain.handle("papr:switch-organization", async (_event, workspaceId: string, displayName: string) => {
+  // `preferredNamespaceId` lets the settings picker jump straight to a namespace
+  // in another org — without it the switch lands on that org's default namespace
+  // and would need a second switch to reach the one the user actually picked.
+  // `preferredOrganizationId` names which of the workspace's organizations that
+  // namespace belongs to, since the workspace's primary org is only one of them.
+  ipcMain.handle("papr:switch-organization", async (
+    _event,
+    workspaceId: string,
+    displayName: string,
+    options?: { preferredNamespaceId?: string; preferredOrganizationId?: string },
+  ) => {
     try {
       const profile = settingsStorage.getPaprProfile();
       if (!profile?.sessionToken || !profile?.userId) {
@@ -3099,7 +3451,8 @@ export function initializePaprLoginIPC(
       };
       settingsStorage.setPaprProfile(updatedProfile);
 
-      const namespaceOrgId = target.organizationId;
+      const namespaceOrgId =
+        options?.preferredOrganizationId?.trim() || target.organizationId;
       if (!namespaceOrgId) {
         return { success: false, error: "Could not resolve organization for namespaces" };
       }
@@ -3119,7 +3472,8 @@ export function initializePaprLoginIPC(
       const { namespaces, choice: defaultNs } = await resolveNamespaceForWorkspaceSwitch({
         sessionToken: profile.sessionToken,
         organizationId: namespaceOrgId,
-        preferredNamespaceId: target.defaultNamespaceId,
+        preferredNamespaceId:
+          options?.preferredNamespaceId?.trim() || target.defaultNamespaceId,
         customKeysStorage,
         settingsStorage,
       });
@@ -3195,15 +3549,25 @@ export function initializePaprLoginIPC(
     }
   });
 
-  // Switch to a different namespace — gets or creates API key for it
-  ipcMain.handle("papr:switch-namespace", async (_event, namespaceId: string, namespaceName: string) => {
+  // Switch to a different namespace — gets or creates API key for it.
+  // `organizationIdOverride` comes from the settings picker, which lists every
+  // org in the workspace: the chosen namespace may belong to a different org
+  // than the profile's current one, and resolving by profile would pick wrong.
+  ipcMain.handle("papr:switch-namespace", async (
+    _event,
+    namespaceId: string,
+    namespaceName: string,
+    organizationIdOverride?: string,
+  ) => {
     try {
       const profile = settingsStorage.getPaprProfile();
       if (!profile?.sessionToken || !profile?.userId) {
         return { success: false, error: "Not logged in or missing org info" };
       }
 
-      const organizationId = await resolveOrganizationIdForProfile(profile);
+      const organizationId =
+        organizationIdOverride?.trim() ||
+        (await resolveOrganizationIdForProfile(profile));
       if (!organizationId) {
         return { success: false, error: "Missing organization info" };
       }

--- a/src/electron/preload.cjs
+++ b/src/electron/preload.cjs
@@ -157,7 +157,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
       },
       
       listNamespaces: (options) => ipcRenderer.invoke("papr:list-namespaces", options),
-      switchNamespace: (namespaceId, namespaceName) => ipcRenderer.invoke("papr:switch-namespace", namespaceId, namespaceName),
+      listAllNamespaces: (options) => ipcRenderer.invoke("papr:list-all-namespaces", options),
+      switchNamespace: (namespaceId, namespaceName, organizationId) => ipcRenderer.invoke("papr:switch-namespace", namespaceId, namespaceName, organizationId),
       onNamespaceChanged: (callback) => {
         const wrapper = (_event, data) => {
           callback(data);
@@ -175,7 +176,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
       },
       
       listOrganizations: () => ipcRenderer.invoke("papr:list-organizations"),
-      switchOrganization: (organizationId, organizationName) => ipcRenderer.invoke("papr:switch-organization", organizationId, organizationName),
+      switchOrganization: (organizationId, organizationName, options) => ipcRenderer.invoke("papr:switch-organization", organizationId, organizationName, options),
       onOrganizationChanged: (callback) => {
         const wrapper = (_event, data) => {
           callback(data);

--- a/ui/components/Settings/PaprLoginSection.css
+++ b/ui/components/Settings/PaprLoginSection.css
@@ -138,7 +138,9 @@
 .papr-selector__select {
   width: 100%;
   padding: 6px 10px;
-  background: var(--bg-primary);
+  /* --bg-primary is not defined anywhere, which made this invalid at
+     computed-value time and left the control transparent. */
+  background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: 6px;
   color: var(--text-primary);
@@ -147,6 +149,22 @@
   appearance: auto;
   outline: none;
   transition: border-color 0.15s;
+  /* The app themes itself with CSS variables but never declares a color
+     scheme, so Chromium drew the native option list light even in dark mode. */
+  color-scheme: light;
+}
+
+/* The popup list is composited by the OS, so translucent palette values read
+   as muddy — these opaque tones match the page surface instead. */
+.papr-selector__select option,
+.papr-selector__select optgroup {
+  background-color: #f5f5f7;
+  color: var(--text-primary);
+}
+
+.papr-selector__select optgroup {
+  font-weight: 600;
+  color: var(--text-secondary);
 }
 
 .papr-selector__select:hover:not(:disabled) {
@@ -169,7 +187,7 @@
   width: 100%;
   min-height: 32px;
   padding: 6px 10px;
-  background: var(--bg-primary);
+  background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 13px;
@@ -1108,4 +1126,24 @@
   color: #2563eb;
   cursor: pointer;
   text-decoration: underline;
+}
+
+/* ─── Native select popup (dark) ─── */
+
+/* Everything else here themes through CSS variables, but the OS-drawn option
+   list needs an explicit scheme and opaque colors to match the page. */
+@media (prefers-color-scheme: dark) {
+  .papr-selector__select {
+    color-scheme: dark;
+  }
+
+  .papr-selector__select option,
+  .papr-selector__select optgroup {
+    background-color: #1c1c1e;
+    color: #f2f2f7;
+  }
+
+  .papr-selector__select optgroup {
+    color: #aeaeb2;
+  }
 }

--- a/ui/components/Settings/PaprLoginSection.tsx
+++ b/ui/components/Settings/PaprLoginSection.tsx
@@ -21,6 +21,14 @@ interface Namespace {
   environmentType?: string;
 }
 
+/** Namespaces of one organization, as rendered in the Team picker's optgroup. */
+interface NamespaceGroup {
+  workspaceId: string;
+  organizationId: string;
+  organizationName: string;
+  namespaces: Namespace[];
+}
+
 interface Organization {
   id: string;
   name: string;
@@ -85,7 +93,9 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
   const [switchingOrganization, setSwitchingOrganization] = useState(false);
   const [organizationsLoaded, setOrganizationsLoaded] = useState(false);
 
-  const [namespaces, setNamespaces] = useState<Namespace[]>([]);
+  // Every org's namespaces, not just the active one — picking a team in another
+  // org switches the workspace along with it.
+  const [namespaceGroups, setNamespaceGroups] = useState<NamespaceGroup[]>([]);
   const [activeNamespaceId, setActiveNamespaceId] = useState<string | null>(null);
   const [switchingNamespace, setSwitchingNamespace] = useState(false);
   const [namespacesLoaded, setNamespacesLoaded] = useState(false);
@@ -104,24 +114,7 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
     useState<MemoryAudience>("user");
   const [savingMemoryDefault, setSavingMemoryDefault] = useState(false);
   const switchingOrganizationRef = useRef(false);
-  const activeOrganizationIdRef = useRef<string | null>(null);
-  const organizationsRef = useRef(organizations);
-
-  useEffect(() => {
-    activeOrganizationIdRef.current = activeOrganizationId;
-  }, [activeOrganizationId]);
-
-  useEffect(() => {
-    organizationsRef.current = organizations;
-  }, [organizations]);
-
-  const resolveParseOrganizationId = useCallback(
-    (workspaceId: string | null): string | undefined => {
-      if (!workspaceId) return undefined;
-      return organizations.find((org) => org.id === workspaceId)?.organizationId;
-    },
-    [organizations],
-  );
+  const switchingNamespaceRef = useRef(false);
 
   useEffect(() => {
     checkLoginStatus();
@@ -166,18 +159,25 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
     [],
   );
 
-  const loadNamespaces = useCallback(async (parseOrganizationId?: string, forceRefresh = false) => {
+  /**
+   * Load namespaces for every organization the user belongs to.
+   *
+   * Cache-first by default: the main process answers from its disk cache and
+   * refreshes each org in the background, firing `papr:workspace-cache-updated`
+   * if anything actually changed. Pass `forceRefresh` for an explicit re-fetch.
+   */
+  const loadNamespaceGroups = useCallback(async (forceRefresh = false) => {
     try {
-      const result = await window.electronAPI.papr.listNamespaces(
-        parseOrganizationId
-          ? { organizationId: parseOrganizationId, forceRefresh }
-          : forceRefresh
-            ? { forceRefresh: true }
-            : undefined,
+      const result = await window.electronAPI.papr.listAllNamespaces(
+        forceRefresh ? { forceRefresh: true } : undefined,
       );
-      if (result.success && result.namespaces) {
-        setNamespaces(result.namespaces);
-        setActiveNamespaceId(result.activeNamespaceId || null);
+      if (result.success && result.groups) {
+        setNamespaceGroups(result.groups);
+        // A switch in flight owns the selection — the profile on disk still
+        // holds the previous namespace until it completes.
+        if (!switchingNamespaceRef.current && !switchingOrganizationRef.current) {
+          setActiveNamespaceId(result.activeNamespaceId || null);
+        }
       }
     } catch (err) {
       console.error("Failed to load namespaces:", err);
@@ -221,13 +221,10 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
   }, []);
 
   useEffect(() => {
-    if (isLoggedIn && activeOrganizationId && organizations.length > 0) {
-      const parseOrgId = resolveParseOrganizationId(activeOrganizationId);
-      if (parseOrgId) {
-        void loadNamespaces(parseOrgId, true);
-      }
+    if (isLoggedIn) {
+      void loadNamespaceGroups();
     }
-  }, [isLoggedIn, activeOrganizationId, organizations, resolveParseOrganizationId, loadNamespaces]);
+  }, [isLoggedIn, loadNamespaceGroups]);
 
   useEffect(() => {
     if (
@@ -321,88 +318,106 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
     }
   };
 
-  const handleSwitchOrganization = async (organizationId: string) => {
-    const org = organizations.find((o) => o.id === organizationId);
-    if (!org || organizationId === activeOrganizationId) return;
+  /** Core workspace switch. Callers own the confirm prompt. */
+  const switchToWorkspace = useCallback(
+    async (
+      workspaceId: string,
+      target?: { namespaceId: string; organizationId: string },
+    ) => {
+      const org = organizations.find((o) => o.id === workspaceId);
+      if (!org) return;
+
+      if (!org.organizationId) {
+        setError("Could not resolve organization");
+        return;
+      }
+
+      setSwitchingOrganization(true);
+      switchingOrganizationRef.current = true;
+      setError(null);
+
+      try {
+        await flushWorkspaceStateToGateway();
+        const result = await window.electronAPI.papr.switchOrganization(
+          workspaceId,
+          org.name,
+          target && {
+            preferredNamespaceId: target.namespaceId,
+            preferredOrganizationId: target.organizationId,
+          },
+        );
+        if (result.success) {
+          setActiveOrganizationId(workspaceId);
+          setActiveNamespaceId(result.activeNamespaceId || null);
+          setSchemas([]);
+          setWorkspaceMembers([]);
+          setWorkspaceName(null);
+          setInviteEmail("");
+          setInviteMessage(null);
+          if (result.apiKey && onApiKeyReceived) {
+            onApiKeyReceived(result.apiKey);
+          }
+        } else {
+          setError(result.error || "Failed to switch organization");
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to switch organization");
+      } finally {
+        switchingOrganizationRef.current = false;
+        setSwitchingOrganization(false);
+        // Re-read so the picker reflects the workspace that is now active.
+        void loadNamespaceGroups();
+      }
+    },
+    [organizations, onApiKeyReceived, loadNamespaceGroups],
+  );
+
+  const handleSwitchOrganization = async (workspaceId: string) => {
+    if (!workspaceId || workspaceId === activeOrganizationId) return;
+    if (!organizations.some((org) => org.id === workspaceId)) return;
 
     if (!(await confirmAndAbortStreamsForWorkspaceSwitch())) {
       return;
     }
 
-    const parseOrgId = org.organizationId;
-    if (!parseOrgId) {
-      setError("Could not resolve organization");
-      return;
-    }
-
-    setSwitchingOrganization(true);
-    switchingOrganizationRef.current = true;
-    setError(null);
-
-    // Teams list only needs Parse — fetch in parallel with gateway workspace switch.
-    const namespacesTask = window.electronAPI.papr.listNamespaces({
-      organizationId: parseOrgId,
-      forceRefresh: true,
-    });
-    void namespacesTask.then((nsResult) => {
-      if (nsResult.success && nsResult.namespaces?.length) {
-        setNamespaces(nsResult.namespaces);
-        setNamespacesLoaded(true);
-      }
-    });
-
-    try {
-      await flushWorkspaceStateToGateway();
-      const result = await window.electronAPI.papr.switchOrganization(organizationId, org.name);
-      const nsResult = await namespacesTask;
-      if (result.success) {
-        setActiveOrganizationId(organizationId);
-        if (result.namespaces?.length) {
-          setNamespaces(result.namespaces);
-          setNamespacesLoaded(true);
-        } else if (nsResult.success && nsResult.namespaces) {
-          setNamespaces(nsResult.namespaces);
-          setNamespacesLoaded(true);
-        } else {
-          await loadNamespaces(parseOrgId, true);
-        }
-        if (result.activeNamespaceId) {
-          setActiveNamespaceId(result.activeNamespaceId);
-        } else {
-          setActiveNamespaceId(null);
-        }
-        setSchemas([]);
-        setWorkspaceMembers([]);
-        setWorkspaceName(null);
-        setInviteEmail("");
-        setInviteMessage(null);
-        if (result.apiKey && onApiKeyReceived) {
-          onApiKeyReceived(result.apiKey);
-        }
-      } else {
-        setError(result.error || "Failed to switch organization");
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to switch organization");
-    } finally {
-      switchingOrganizationRef.current = false;
-      setSwitchingOrganization(false);
-    }
+    await switchToWorkspace(workspaceId);
   };
 
-  const handleSwitchNamespace = async (namespaceId: string) => {
-    const ns = namespaces.find((n) => n.id === namespaceId);
-    if (!ns || namespaceId === activeNamespaceId) return;
+  const handleSelectNamespace = async (namespaceId: string) => {
+    if (!namespaceId || namespaceId === activeNamespaceId) return;
+
+    const group = namespaceGroups.find((candidate) =>
+      candidate.namespaces.some((ns) => ns.id === namespaceId),
+    );
+    const ns = group?.namespaces.find((candidate) => candidate.id === namespaceId);
+    if (!group || !ns) return;
 
     if (!(await confirmAndAbortStreamsForWorkspaceSwitch())) {
       return;
     }
 
     setSwitchingNamespace(true);
+    switchingNamespaceRef.current = true;
     setError(null);
     try {
+      // Team in another workspace: a single switch carries the workspace, the
+      // org, and the namespace, so we never land on a default namespace first.
+      if (group.workspaceId !== activeOrganizationId) {
+        await switchToWorkspace(group.workspaceId, {
+          namespaceId: ns.id,
+          organizationId: group.organizationId,
+        });
+        return;
+      }
+
+      // Same workspace, but possibly a different org within it — pass the org
+      // explicitly so the switch doesn't resolve against the primary one.
       await flushWorkspaceStateToGateway();
-      const result = await window.electronAPI.papr.switchNamespace(namespaceId, ns.name);
+      const result = await window.electronAPI.papr.switchNamespace(
+        namespaceId,
+        ns.name,
+        group.organizationId,
+      );
       if (result.success) {
         setActiveNamespaceId(namespaceId);
         if (result.apiKey && onApiKeyReceived) {
@@ -414,6 +429,7 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to switch team");
     } finally {
+      switchingNamespaceRef.current = false;
       setSwitchingNamespace(false);
     }
   };
@@ -438,7 +454,7 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
       if (result.success) {
         setIsLoggedIn(false);
         setUserEmail(null);
-        setNamespaces([]);
+        setNamespaceGroups([]);
         setActiveNamespaceId(null);
         setNamespacesLoaded(false);
         setSchemas([]);
@@ -500,24 +516,18 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
       if (data.namespaceId) {
         setActiveNamespaceId(data.namespaceId);
       }
-      if (data.namespaces) {
-        setNamespaces(data.namespaces);
-        setNamespacesLoaded(true);
-      } else if (data.parseOrganizationId) {
-        void loadNamespaces(data.parseOrganizationId, true);
-      }
+      // The event only carries the new org's namespaces; the picker lists every
+      // org, so re-read the full set instead of narrowing it to one.
+      void loadNamespaceGroups();
     };
 
     handleWorkspaceCacheUpdatedRef.current = () => {
       void loadOrganizations();
-      const parseOrgId = organizationsRef.current.find(
-        (org) => org.id === activeOrganizationIdRef.current,
-      )?.organizationId;
-      if (parseOrgId) {
-        void loadNamespaces(parseOrgId);
-      }
+      // Cache-first is safe here: the main process writes the disk cache before
+      // it fires this event, so what we read back is the replacement list.
+      void loadNamespaceGroups();
     };
-  }, [loadNamespaces]);
+  }, [loadNamespaceGroups]);
 
   useEffect(() => {
     const loginCb = handleLoginSuccessRef.current;
@@ -548,7 +558,7 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
       setUserEmail(null);
       setOrganizations([]);
       setActiveOrganizationId(null);
-      setNamespaces([]);
+      setNamespaceGroups([]);
       setActiveNamespaceId(null);
       setSchemas([]);
     };
@@ -570,7 +580,14 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
 
   // --- Logged-in state ---
   if (isLoggedIn) {
-    const activeNs = namespaces.find((n) => n.id === activeNamespaceId);
+    // An org the user belongs to but has no namespaces in would render an empty
+    // optgroup, so drop it from the picker entirely.
+    const populatedGroups = namespaceGroups.filter(
+      (group) => group.namespaces.length > 0,
+    );
+    const activeNs = populatedGroups
+      .flatMap((group) => group.namespaces)
+      .find((ns) => ns.id === activeNamespaceId);
 
     return (
       <div className={`papr-section${profileFields ? " papr-section--profile" : ""}`}>
@@ -628,20 +645,32 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
             </div>
           )}
 
-          {namespacesLoaded && namespaces.length > 0 && (
+          {namespacesLoaded && populatedGroups.length > 0 && (
             <div className="papr-selector">
               <label className="papr-selector__label">Team</label>
               <div className="papr-selector__wrapper">
                 <select
                   className="papr-selector__select"
                   value={activeNamespaceId || ""}
-                  onChange={(e) => handleSwitchNamespace(e.target.value)}
-                  disabled={switchingNamespace}
+                  onChange={(e) => void handleSelectNamespace(e.target.value)}
+                  disabled={switchingNamespace || switchingOrganization}
                 >
-                  {namespaces.map((ns) => (
-                    <option key={ns.id} value={ns.id}>
-                      {formatNamespaceOptionLabel(ns)}
+                  {!activeNamespaceId && <option value="">Select a team…</option>}
+                  {/* Keep the select from rendering blank when the active team's
+                      org failed to load (partial result). */}
+                  {activeNamespaceId && !activeNs && (
+                    <option value={activeNamespaceId}>
+                      Active team ({activeNamespaceId})
                     </option>
+                  )}
+                  {populatedGroups.map((group) => (
+                    <optgroup key={group.organizationId} label={group.organizationName}>
+                      {group.namespaces.map((ns) => (
+                        <option key={ns.id} value={ns.id}>
+                          {formatNamespaceOptionLabel(ns)}
+                        </option>
+                      ))}
+                    </optgroup>
                   ))}
                 </select>
                 {switchingNamespace && <Spinner />}
@@ -649,7 +678,7 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
             </div>
           )}
 
-          {namespacesLoaded && namespaces.length === 0 && activeOrganizationId && (
+          {namespacesLoaded && populatedGroups.length === 0 && (
             <div className="papr-selector">
               <label className="papr-selector__label">Team</label>
               <div className="papr-selector__empty-row">
@@ -657,10 +686,7 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
                 <button
                   type="button"
                   className="papr-team__refresh"
-                  onClick={() => {
-                    const parseOrgId = resolveParseOrganizationId(activeOrganizationId);
-                    if (parseOrgId) void loadNamespaces(parseOrgId, true);
-                  }}
+                  onClick={() => void loadNamespaceGroups(true)}
                 >
                   Refresh
                 </button>
@@ -668,7 +694,7 @@ export function PaprLoginSection({ onApiKeyReceived, profileFields }: PaprLoginS
             </div>
           )}
 
-          {!namespacesLoaded && activeOrganizationId && (
+          {!namespacesLoaded && (
             <div className="papr-selector">
               <label className="papr-selector__label">Team</label>
               <div className="papr-selector__placeholder">

--- a/ui/types/electron.d.ts
+++ b/ui/types/electron.d.ts
@@ -230,7 +230,26 @@ export interface ElectronAPI {
       fromCache?: boolean;
       error?: string;
     }>;
-    switchNamespace: (namespaceId: string, namespaceName: string) => Promise<{
+    listAllNamespaces: (options?: { forceRefresh?: boolean }) => Promise<{
+      success: boolean;
+      groups?: Array<{
+        workspaceId: string;
+        organizationId: string;
+        organizationName: string;
+        namespaces: Array<{ id: string; name: string; environmentType?: string }>;
+      }>;
+      activeOrganizationId?: string;
+      activeNamespaceId?: string;
+      /** True when at least one org's namespaces could not be loaded. */
+      partial?: boolean;
+      error?: string;
+    }>;
+    switchNamespace: (
+      namespaceId: string,
+      namespaceName: string,
+      /** Org this namespace belongs to; defaults to the profile's current org. */
+      organizationId?: string,
+    ) => Promise<{
       success: boolean;
       apiKey?: string;
       error?: string;
@@ -251,7 +270,16 @@ export interface ElectronAPI {
       activeOrganizationId?: string;
       error?: string;
     }>;
-    switchOrganization: (organizationId: string, organizationName: string) => Promise<{
+    switchOrganization: (
+      organizationId: string,
+      organizationName: string,
+      options?: {
+        /** Land on this namespace instead of the org's default. */
+        preferredNamespaceId?: string;
+        /** Which of the workspace's orgs that namespace belongs to. */
+        preferredOrganizationId?: string;
+      },
+    ) => Promise<{
       success: boolean;
       organizationId?: string;
       parseOrganizationId?: string;


### PR DESCRIPTION
## Problem

The **Team** picker in profile settings listed namespaces for one organization only, and selecting a team in any other org silently bounced back to the original workspace after ~a minute.

Both symptoms come from the same assumption: that a workspace has exactly one organization.

## Root causes

### 1. Only the primary org was ever listed

`workSpace.organization` is a single pointer to the *primary* org, but `Organization` carries its own `workspace` pointer — so **one workspace can hold several orgs**. Only the primary was queried, hiding the rest.

Adds `GET_WORKSPACE_ORGANIZATIONS` and a `papr:list-all-namespaces` handler that unions the primary org with every org attached to each workspace.

- **Cache-first**: answers from the namespace disk cache, then refreshes each org in the background. An in-flight guard keeps overlapping loads (mount + a cache-updated event) from multiplying the fan-out.
- **Degrades gracefully**: an org that fails to load yields `partial: true` rather than blanking the picker.
- On one account this went from **1 namespace across 1 org → 16 across 3**.

### 2. Switching orgs was reverted by a competing switch

`syncActiveWorkspaceOrganization` treated any `profile.organizationId` differing from the workspace's primary org as drift, rewrote it, then called `syncNamespaceApiKeyIfNeeded` — which issues its own gateway workspace switch. Since the gateway now supersedes in-flight switches, that late switch-back won the race:

```
[PaprLogin] Switched to namespace: deeptrust-dev-10 (jnDaZ2v6QY)   <- the switch worked
[PaprLogin] Synced profile to workspace Papr namespace org rCalm7lyoq   <- reset to primary
[WorkspaceSwitch] Superseding in-flight switch -> org=rCalm7lyoq ns=4IHVWof2Z5
[WorkspaceSwitch] Background switch complete: org=rCalm7lyoq ns=4IHVWof2Z5   <- back to start
```

This also fired on every launch, so a non-primary org never survived a restart.

- `syncActiveWorkspaceOrganization` now realigns the org only when the workspace itself changed, or when the profile has no org — a non-primary org is a deliberate choice, not drift.
- `resolveOrganizationIdForProfile` now treats `profile.organizationId` as authoritative instead of preferring the workspace's primary org.

### 3. Switch paths dropped the target org

A namespace in a secondary org would resolve its API key against the wrong organization. `papr:switch-namespace` now takes an `organizationId` override, and `papr:switch-organization` takes `{ preferredNamespaceId, preferredOrganizationId }` so a cross-workspace pick lands on the chosen namespace in one switch instead of stopping at that org's default.

### 4. Picker colors didn't match the page

- `--bg-primary` **is not defined anywhere in the app**, so `background: var(--bg-primary)` was invalid at computed-value time and left the control transparent. Now uses `--bg-secondary`, which is defined and already used in this file.
- The app themes via CSS variables but never declared a `color-scheme`, so Chromium drew the native option list light even in dark mode. Now set explicitly, with opaque `option`/`optgroup` colors — the palette's translucent values read as muddy in an OS-composited popup.

## UI

The Team select now groups namespaces by organization via `<optgroup>`, active workspace first. Picking a team in another org switches the workspace and the namespace together.

## Testing

- `npm run build` clean; `tsc --noEmit` clean for gateway and electron projects; oxlint clean on changed files.
- Verified in the running app: `[PaprLogin] Listed 16 namespaces across 3 organization(s)`, no per-org failures.
- The `ui` project has ~273 pre-existing type errors unrelated to this change; the 3 in `PaprLoginSection.tsx` are on untouched lines (the `settings:get` response shape and the `onLoginSuccess` signature).

**Not yet verified**: switching *into* a newly-visible org end to end — that mutates the active workspace and API key, so it needs a manual click to confirm.

## Note

This branch also carries pre-existing local work in `paprLogin.ts` / `PaprLoginSection.tsx` (the `papr:workspace-cache-updated` notification plumbing). It is a prerequisite for the cache-first picker refresh and is interleaved with these changes, so it is included here rather than split out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
