### PR TITLE
Fix Claude frontier auth and agent stream concurrency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Rebuild native modules for Electron
-        run: npx @electron/rebuild -f -w better-sqlite3
+      # The test tier runs under plain Node, not Electron. Rebuilding
+      # better-sqlite3 for Electron's ABI here made it unloadable in vitest
+      # ("Module did not self-register" / ERR_DLOPEN_FAILED), which failed every
+      # jobs-e2e test. That was invisible until now because the run aborted
+      # before jobs-e2e was reached. Build against the Node that runs the tests.
+      - name: Rebuild native modules for Node
+        run: npm rebuild better-sqlite3
 
       - name: Run CI sequential tier
         run: npm run test:sequential -- --tier=ci

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check:loc": "tsx scripts/check-max-lines.ts",
     "docs:update-papr-paths": "node scripts/update-docs-papr-paths.mjs",
     "check": "npm run type-check && npm run format:check && npm run lint && npm run check:loc",
-    "test": "vitest run --project unit-backend --project unit-ui --project integration --reporter=verbose",
+    "test": "vitest run --project unit-backend --project unit-ui --project integration --reporter=dot --silent",
     "test:stack": "node scripts/test-stack.mjs",
     "test:stack:smoke": "node scripts/test-stack.mjs smoke",
     "test:stack:smoke:full": "node scripts/test-stack.mjs smoke --full",

--- a/src/gateway/services/AgentService.ts
+++ b/src/gateway/services/AgentService.ts
@@ -425,17 +425,25 @@ export class AgentService {
     const skipConcurrencyGate =
       options?._isContextCompressRetry === true ||
       options?._isSilentRetry === true;
-    let concurrencyAcquired = false;
+    let concurrencyLease:
+      | import("./agent/agentStreamConcurrency.js").AgentStreamConcurrencyLease
+      | undefined;
+
+    // Register ownership before waiting so stop/replacement can abort a queued stream.
+    this.sessionManager.setAbortController(chatId, abortController);
+    this.sessionManager.setStreaming(chatId, true);
+
     if (!skipConcurrencyGate) {
       const { getAgentStreamConcurrencyGate } = await import(
         "./agent/agentStreamConcurrency.js"
       );
       try {
-        await getAgentStreamConcurrencyGate().acquire(
+        const priority = chatId.startsWith("job:") ? "background" : "foreground";
+        concurrencyLease = await getAgentStreamConcurrencyGate().acquire(
           chatId,
           abortController.signal,
+          priority,
         );
-        concurrencyAcquired = true;
       } catch (concurrencyError) {
         const message =
           concurrencyError instanceof Error
@@ -444,6 +452,7 @@ export class AgentService {
         console.warn(
           `[AgentService] Concurrency gate rejected stream for ${chatId}: ${message}`,
         );
+        this.sessionManager.clearStreamingStateIfOwner(chatId, abortController);
         yield {
           type: "error",
           chatId,
@@ -456,9 +465,6 @@ export class AgentService {
         return;
       }
     }
-
-    this.sessionManager.setAbortController(chatId, abortController);
-    this.sessionManager.setStreaming(chatId, true);
     clearInFlightToolResults(chatId);
 
     // Track response state for error recovery
@@ -2215,11 +2221,11 @@ export class AgentService {
       }
       await persistIncompleteAssistant({ asAbort: true });
 
-      if (concurrencyAcquired) {
+      if (concurrencyLease) {
         const { getAgentStreamConcurrencyGate } = await import(
           "./agent/agentStreamConcurrency.js"
         );
-        getAgentStreamConcurrencyGate().release(chatId);
+        getAgentStreamConcurrencyGate().release(concurrencyLease);
       }
 
       // Only clear session state if this stream still owns the abort controller.

--- a/src/gateway/services/AgentStreamRegistry.ts
+++ b/src/gateway/services/AgentStreamRegistry.ts
@@ -268,6 +268,7 @@ export class AgentStreamRegistry {
       ws,
     } = params;
 
+    let previousStreamStopped: Promise<void> = Promise.resolve();
     const existingRequestId = this.requestIdByChatId.get(chatId);
     if (existingRequestId) {
       const existing = this.streamsByRequestId.get(existingRequestId);
@@ -275,8 +276,10 @@ export class AgentStreamRegistry {
         console.warn(
           `[AgentStreamRegistry] Chat ${chatId} already streaming (${existingRequestId}), cancelling before new stream`,
         );
-        void import("./AgentService.js").then(({ getAgentService }) =>
-          getAgentService().stopStreaming(chatId),
+        // Abort the old controller before the replacement registers its own.
+        // Otherwise a delayed dynamic import can accidentally abort the new stream.
+        previousStreamStopped = import("./AgentService.js").then(
+          ({ getAgentService }) => getAgentService().stopStreaming(chatId),
         );
         this.cancelStream(chatId, STREAM_REPLACED_REASON);
       }
@@ -296,7 +299,23 @@ export class AgentStreamRegistry {
     this.streamsByRequestId.set(requestId, entry);
     this.requestIdByChatId.set(chatId, requestId);
 
-    void this.runStream(entry, userMessage, config, focusContext, attachments);
+    void previousStreamStopped
+      .then(() =>
+        this.runStream(entry, userMessage, config, focusContext, attachments),
+      )
+      .catch((error) => {
+        console.error(
+          `[AgentStreamRegistry] Failed to stop previous stream for ${chatId}:`,
+          error,
+        );
+        return this.runStream(
+          entry,
+          userMessage,
+          config,
+          focusContext,
+          attachments,
+        );
+      });
   }
 
   private async runStream(

--- a/src/gateway/services/AppService.ts
+++ b/src/gateway/services/AppService.ts
@@ -195,6 +195,8 @@ export class AppService {
   private initPromise: Promise<void> | null = null;
   /** PAPR_HOME at last successful initialize — prune must not run after env drift. */
   private loadedPaprRoot: string | null = null;
+  /** Dedupes the prune-skip warning, which listApps() would otherwise repeat. */
+  private lastPruneSkipWarnKey: string | null = null;
   /**
    * Set by cleanup(). Watcher startup is fire-and-forget, so without this a
    * shutdown that lands mid-startup creates watchers *after* cleanup already
@@ -1838,9 +1840,17 @@ export class AppService {
   private async pruneStaleAppEntries(): Promise<boolean> {
     const currentRoot = this.paprRootDir;
     if (this.loadedPaprRoot && currentRoot !== this.loadedPaprRoot) {
-      console.warn(
-        `[AppService] Skipping stale-app prune — PAPR_HOME changed (${this.loadedPaprRoot} → ${currentRoot})`,
-      );
+      // Warn once per root pair. This used to fire only at startup; now that
+      // listApps() prunes too, an unchanged mismatch would repeat on every
+      // call and bury the rest of the output — in CI it truncated the log
+      // before the test summary was printed.
+      const key = `${this.loadedPaprRoot}→${currentRoot}`;
+      if (this.lastPruneSkipWarnKey !== key) {
+        this.lastPruneSkipWarnKey = key;
+        console.warn(
+          `[AppService] Skipping stale-app prune — PAPR_HOME changed (${this.loadedPaprRoot} → ${currentRoot})`,
+        );
+      }
       return false;
     }
 

--- a/src/gateway/services/AppService.ts
+++ b/src/gateway/services/AppService.ts
@@ -195,6 +195,12 @@ export class AppService {
   private initPromise: Promise<void> | null = null;
   /** PAPR_HOME at last successful initialize — prune must not run after env drift. */
   private loadedPaprRoot: string | null = null;
+  /**
+   * Set by cleanup(). Watcher startup is fire-and-forget, so without this a
+   * shutdown that lands mid-startup creates watchers *after* cleanup already
+   * closed the set — they then outlive the service with nothing tracking them.
+   */
+  private disposed = false;
 
   /** Coalesce rapid multi-file agent edits into one rebuild + reload. */
   private static readonly FILE_CHANGE_DEBOUNCE_MS = 800;
@@ -1861,6 +1867,7 @@ export class AppService {
   private broadcastAppListUpdated(): void {
     import("../websocket/index.js")
       .then(({ broadcast }) => {
+        if (typeof broadcast !== "function") return;
         broadcast({ type: "app:list-updated" });
       })
       .catch(() => {
@@ -1870,6 +1877,13 @@ export class AppService {
 
   async listApps(): Promise<MiniApp[]> {
     await this.initialize();
+
+    // Prune here, not only at startup. initialize() early-returns once it has
+    // run, so a folder removed after boot (agent `rm -rf`, external delete,
+    // failed sync) stayed listed until the app restarted — the user clicks a
+    // mini-app that no longer exists. listApps is the read path where that
+    // ghost entry surfaces, so it is where the index gets reconciled.
+    await this.pruneStaleAppEntries();
 
     const activeScope = readActiveAppWorkspaceScope();
     const owned: MiniApp[] = [];
@@ -2265,6 +2279,7 @@ export class AppService {
    * Watch a specific app directory for file changes
    */
   private async watchApp(appId: string): Promise<void> {
+    if (this.disposed) return;
     const appPath = path.join(this.appsDir, appId);
 
     // Check if directory exists before watching
@@ -2273,6 +2288,8 @@ export class AppService {
     } catch {
       return; // Directory doesn't exist yet
     }
+    // Re-check after the await: cleanup() may have run while we were resolving.
+    if (this.disposed) return;
 
     // Don't create duplicate watchers
     if (this.watchers.has(appId)) {
@@ -2301,7 +2318,14 @@ export class AppService {
       });
 
       watcher.on("error", (error) => {
-        console.error(`[AppService] Watcher error for app ${appId}:`, error);
+        // Log the message, not the object. Watcher errors carry non-cloneable
+        // fields (fs handles, syscall metadata); passing the raw object to a
+        // reporter that serializes stdout across a process boundary throws
+        // inside the serializer and takes down the whole run.
+        console.error(
+          `[AppService] Watcher error for app ${appId}:`,
+          (error as Error)?.message ?? String(error),
+        );
         this.watchers.delete(appId);
       });
 
@@ -3032,13 +3056,17 @@ export class AppService {
 
     import("../websocket/index.js")
       .then(({ broadcast }) => {
+        if (typeof broadcast !== "function") return;
         broadcast({
           type: "app:validation-result",
           data: result,
         });
       })
       .catch((error) => {
-        console.warn("[AppService] Failed to broadcast validation:", error);
+        console.warn(
+          "[AppService] Failed to broadcast validation:",
+          (error as Error)?.message ?? String(error),
+        );
       });
   }
 
@@ -3048,6 +3076,7 @@ export class AppService {
   private broadcastFileChange(appId: string, filename: string): void {
     import("../websocket/index.js")
       .then(({ broadcast }) => {
+        if (typeof broadcast !== "function") return;
         broadcast({
           type: "app:file-changed",
           data: { appId, filename, timestamp: Date.now() },
@@ -3057,7 +3086,10 @@ export class AppService {
         );
       })
       .catch((error) => {
-        console.warn("[AppService] Failed to broadcast file change:", error);
+        console.warn(
+          "[AppService] Failed to broadcast file change:",
+          (error as Error)?.message ?? String(error),
+        );
         // Non-fatal - file was still written successfully
       });
   }
@@ -3630,6 +3662,7 @@ export class AppService {
    * Cleanup: stop all file watchers
    */
   cleanup(): void {
+    this.disposed = true;
     console.log(`[AppService] Cleaning up ${this.watchers.size} watchers`);
     
     for (const [_appId, watcher] of this.watchers.entries()) {
@@ -3641,6 +3674,14 @@ export class AppService {
       clearTimeout(timer);
     }
     this.debounceTimers.clear();
+
+    // Reload broadcasts fire up to 1.5s after the last edit. Leaving them armed
+    // kept the process alive past shutdown and, under vitest, let a worker post
+    // messages after the pool closed — surfacing as an unrelated IPC crash.
+    for (const timer of this.reloadBroadcastTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.reloadBroadcastTimers.clear();
   }
 }
 

--- a/src/gateway/services/CustomKeysService.ts
+++ b/src/gateway/services/CustomKeysService.ts
@@ -87,6 +87,11 @@ export class CustomKeysService {
    * Wait for IPC channel to be ready (Gateway might start before IPC is established)
    */
   private async waitForIpc(): Promise<void> {
+    // No Electron main process under test — polling here would just burn the
+    // full timeout before every suite that touches key lookup.
+    if (process.env.VITEST || process.env.NODE_ENV === "test") {
+      return;
+    }
     while (this.ipcWaitAttempts < this.MAX_IPC_WAIT_ATTEMPTS) {
       if (typeof process.send === "function" && process.connected === true) {
         console.log(
@@ -110,6 +115,16 @@ export class CustomKeysService {
    * Check if IPC channel is available and connected
    */
   private checkIpcAvailable(): boolean {
+    // A live IPC channel does not mean the parent is the Electron main process.
+    // Vitest's forks pool also connects one, and it routes anything we post into
+    // its own RPC deserializer — which tries Buffer.from() on our plain object,
+    // throws, and takes down the whole test run with an error that names vitest
+    // internals rather than this call. Keys come from the environment under
+    // test, so there is nothing to ask the main process for.
+    if (process.env.VITEST || process.env.NODE_ENV === "test") {
+      return false;
+    }
+
     // Check if process.send exists (means we were spawned with IPC)
     const hasSend = typeof process.send === "function";
     // Check if IPC channel is connected (will be false if disconnected)

--- a/src/gateway/services/agent/agentStreamConcurrency.ts
+++ b/src/gateway/services/agent/agentStreamConcurrency.ts
@@ -1,172 +1,151 @@
-/**
- * Global concurrency gate for LLM agent streams (user chat + scheduled jobs).
- * Prevents unbounded parallel pi-ai / AI SDK sessions from exhausting Gateway heap.
- */
+/** Global concurrency gate for user chats, embedded agents, and jobs. */
 
-export const DEFAULT_AGENT_STREAM_MAX_CONCURRENT = 2;
+export const DEFAULT_AGENT_STREAM_MAX_CONCURRENT = 3;
+export const AGENT_STREAM_ACQUIRE_TIMEOUT_MS = 5_000;
+export const BACKGROUND_AGENT_STREAM_ACQUIRE_TIMEOUT_MS = 120_000;
 
-/** Max wait before rejecting a new stream (jobs queue; user chat gets a clear error). */
-export const AGENT_STREAM_ACQUIRE_TIMEOUT_MS = 120_000;
+export type AgentStreamPriority = "foreground" | "background";
+
+export interface AgentStreamConcurrencyLease {
+  chatId: string;
+  token: symbol;
+  priority: AgentStreamPriority;
+}
 
 export class AgentStreamConcurrencyTimeoutError extends Error {
-  readonly maxConcurrent: number;
-  readonly activeCount: number;
-
-  constructor(maxConcurrent: number, activeCount: number) {
+  constructor(
+    readonly maxConcurrent: number,
+    readonly activeCount: number,
+    readonly activeChatIds: string[] = [],
+  ) {
     super(
       `Too many concurrent agent sessions (${activeCount}/${maxConcurrent}). ` +
-        "Try again shortly, start a fresh chat, or stagger scheduled agent jobs.",
+        "Another chat or agent is still running; stop it or try again shortly.",
     );
     this.name = "AgentStreamConcurrencyTimeoutError";
-    this.maxConcurrent = maxConcurrent;
-    this.activeCount = activeCount;
   }
 }
 
 function readMaxConcurrent(): number {
-  const raw = process.env.AGENT_STREAM_MAX_CONCURRENT;
-  if (!raw) {
-    return DEFAULT_AGENT_STREAM_MAX_CONCURRENT;
-  }
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    return DEFAULT_AGENT_STREAM_MAX_CONCURRENT;
-  }
-  return parsed;
+  const parsed = Number.parseInt(process.env.AGENT_STREAM_MAX_CONCURRENT ?? "", 10);
+  return Number.isFinite(parsed) && parsed >= 1
+    ? parsed
+    : DEFAULT_AGENT_STREAM_MAX_CONCURRENT;
 }
 
 interface Waiter {
-  chatId: string;
-  resolve: () => void;
-  reject: (err: Error) => void;
+  lease: AgentStreamConcurrencyLease;
+  resolve: (lease: AgentStreamConcurrencyLease) => void;
+  reject: (error: Error) => void;
   timer: ReturnType<typeof setTimeout> | null;
-  onAbort: (() => void) | null;
-}
-
-export interface AgentStreamConcurrencyStats {
-  maxConcurrent: number;
-  activeCount: number;
-  waitingCount: number;
-  activeChatIds: string[];
+  signal?: AbortSignal;
+  onAbort?: () => void;
 }
 
 export class AgentStreamConcurrencyGate {
   private readonly maxConcurrent = readMaxConcurrent();
-  private activeCount = 0;
-  private readonly activeChatIds = new Set<string>();
+  private readonly active = new Map<string, AgentStreamConcurrencyLease>();
   private readonly waitQueue: Waiter[] = [];
 
-  getStats(): AgentStreamConcurrencyStats {
+  getStats() {
     return {
       maxConcurrent: this.maxConcurrent,
-      activeCount: this.activeCount,
+      activeCount: this.active.size,
       waitingCount: this.waitQueue.length,
-      activeChatIds: [...this.activeChatIds],
+      activeChatIds: [...this.active.keys()],
     };
   }
 
-  async acquire(chatId: string, signal?: AbortSignal): Promise<void> {
-    if (this.activeChatIds.has(chatId)) {
-      return;
-    }
+  async acquire(
+    chatId: string,
+    signal?: AbortSignal,
+    priority: AgentStreamPriority = "foreground",
+  ): Promise<AgentStreamConcurrencyLease> {
+    const lease = { chatId, token: Symbol(chatId), priority };
+    if (this.canAdmit(lease)) return this.admit(lease);
+    if (signal?.aborted) throw this.cancelledError();
 
-    if (this.activeCount < this.maxConcurrent) {
-      this.activeCount += 1;
-      this.activeChatIds.add(chatId);
-      return;
-    }
-
-    if (signal?.aborted) {
-      throw new Error("Agent stream cancelled while waiting for concurrency slot");
-    }
-
-    return new Promise<void>((resolve, reject) => {
-      const waiter: Waiter = {
-        chatId,
-        resolve: () => {},
-        reject,
-        timer: null,
-        onAbort: null,
-      };
-
-      const removeFromQueue = (): void => {
-        const index = this.waitQueue.indexOf(waiter);
-        if (index >= 0) {
-          this.waitQueue.splice(index, 1);
-        }
-        if (waiter.timer) {
-          clearTimeout(waiter.timer);
-          waiter.timer = null;
-        }
-        if (waiter.onAbort && signal) {
-          signal.removeEventListener("abort", waiter.onAbort);
-          waiter.onAbort = null;
-        }
-      };
-
-      waiter.resolve = () => {
-        removeFromQueue();
-        this.activeCount += 1;
-        this.activeChatIds.add(chatId);
-        resolve();
-      };
-
+    return new Promise((resolve, reject) => {
+      const waiter: Waiter = { lease, resolve, reject, timer: null, signal };
       waiter.onAbort = () => {
-        removeFromQueue();
-        reject(new Error("Agent stream cancelled while waiting for concurrency slot"));
+        this.removeWaiter(waiter);
+        reject(this.cancelledError());
       };
-
       signal?.addEventListener("abort", waiter.onAbort, { once: true });
-
+      const timeout = priority === "foreground"
+        ? AGENT_STREAM_ACQUIRE_TIMEOUT_MS
+        : BACKGROUND_AGENT_STREAM_ACQUIRE_TIMEOUT_MS;
       waiter.timer = setTimeout(() => {
-        removeFromQueue();
-        reject(
-          new AgentStreamConcurrencyTimeoutError(
-            this.maxConcurrent,
-            this.activeCount,
-          ),
-        );
-      }, AGENT_STREAM_ACQUIRE_TIMEOUT_MS);
-
+        this.removeWaiter(waiter);
+        const stats = this.getStats();
+        reject(new AgentStreamConcurrencyTimeoutError(
+          stats.maxConcurrent,
+          stats.activeCount,
+          stats.activeChatIds,
+        ));
+      }, timeout);
       this.waitQueue.push(waiter);
-
       console.log(
-        `[AgentStreamConcurrency] Queued ${chatId} — ` +
-          `${this.activeCount}/${this.maxConcurrent} active, ` +
-          `${this.waitQueue.length} waiting`,
+        `[AgentStreamConcurrency] Queued ${chatId} (${priority}) — ` +
+          `${this.active.size}/${this.maxConcurrent} active`,
       );
     });
   }
 
-  release(chatId: string): void {
-    if (!this.activeChatIds.has(chatId)) {
-      return;
-    }
+  release(lease: AgentStreamConcurrencyLease): void {
+    const current = this.active.get(lease.chatId);
+    if (!current || current.token !== lease.token) return;
+    this.active.delete(lease.chatId);
+    this.drainQueue();
+  }
 
-    this.activeChatIds.delete(chatId);
-    this.activeCount = Math.max(0, this.activeCount - 1);
+  private canAdmit(lease: AgentStreamConcurrencyLease): boolean {
+    if (this.active.has(lease.chatId)) return false;
+    if (this.active.size >= this.maxConcurrent) return false;
+    if (lease.priority === "foreground" || this.maxConcurrent === 1) return true;
+    // Keep one slot available for interactive chat when background work is running.
+    return this.active.size < this.maxConcurrent - 1;
+  }
 
-    const next = this.waitQueue.shift();
-    if (next) {
-      next.resolve();
-      console.log(
-        `[AgentStreamConcurrency] Admitted queued ${next.chatId} — ` +
-          `${this.activeCount}/${this.maxConcurrent} active`,
-      );
+  private admit(lease: AgentStreamConcurrencyLease): AgentStreamConcurrencyLease {
+    this.active.set(lease.chatId, lease);
+    return lease;
+  }
+
+  private drainQueue(): void {
+    // Foreground waiters always get first chance at newly available capacity.
+    this.waitQueue.sort((a, b) =>
+      a.lease.priority === b.lease.priority ? 0 : a.lease.priority === "foreground" ? -1 : 1,
+    );
+    let admitted = true;
+    while (admitted) {
+      admitted = false;
+      const index = this.waitQueue.findIndex((waiter) => this.canAdmit(waiter.lease));
+      if (index < 0) break;
+      const waiter = this.waitQueue[index];
+      this.removeWaiter(waiter);
+      waiter.resolve(this.admit(waiter.lease));
+      admitted = true;
     }
+  }
+
+  private removeWaiter(waiter: Waiter): void {
+    const index = this.waitQueue.indexOf(waiter);
+    if (index >= 0) this.waitQueue.splice(index, 1);
+    if (waiter.timer) clearTimeout(waiter.timer);
+    waiter.timer = null;
+    if (waiter.onAbort) waiter.signal?.removeEventListener("abort", waiter.onAbort);
+  }
+
+  private cancelledError(): Error {
+    return new Error("Agent stream cancelled while waiting for concurrency slot");
   }
 }
 
 let gateInstance: AgentStreamConcurrencyGate | null = null;
-
 export function getAgentStreamConcurrencyGate(): AgentStreamConcurrencyGate {
-  if (!gateInstance) {
-    gateInstance = new AgentStreamConcurrencyGate();
-  }
-  return gateInstance;
+  return (gateInstance ??= new AgentStreamConcurrencyGate());
 }
-
-/** Test helper — reset singleton between vitest cases. */
 export function resetAgentStreamConcurrencyGateForTests(): void {
   gateInstance = null;
 }

--- a/src/gateway/services/providers/piAiAnthropicAdaptiveThinking.ts
+++ b/src/gateway/services/providers/piAiAnthropicAdaptiveThinking.ts
@@ -37,6 +37,7 @@ export interface PiAiAnthropicStreamOptions {
   signal?: AbortSignal;
   reasoning?: PiAiReasoningLevel;
   cacheRetention?: "none" | "short" | "long";
+  headers?: Record<string, string>;
   onPayload?: (
     params: AnthropicMessagesParams,
     model: unknown,
@@ -117,8 +118,16 @@ export function augmentPiAiAnthropicStreamOptions(
   reasoningLevel: PiAiReasoningLevel,
   base: PiAiAnthropicStreamOptions,
 ): PiAiAnthropicStreamOptions {
+  const isOAuth = base.apiKey.includes("sk-ant-oat");
+  const headers = isOAuth
+    ? {
+        ...base.headers,
+        "user-agent": "claude-cli/2.1.226",
+      }
+    : base.headers;
+
   if (!requiresPiAiAdaptiveThinkingOverride(modelId)) {
-    return base;
+    return headers === base.headers ? base : { ...base, headers };
   }
 
   console.log(
@@ -128,6 +137,7 @@ export function augmentPiAiAnthropicStreamOptions(
 
   return {
     ...base,
+    headers,
     onPayload: buildAdaptiveThinkingOnPayload(modelId, reasoningLevel),
   };
 }

--- a/src/gateway/utils/keyResolver.ts
+++ b/src/gateway/utils/keyResolver.ts
@@ -84,9 +84,16 @@ async function requestKeysViaIPC(
     // Vitest's forks pool connects one too, and routes anything we post into its
     // own RPC deserializer, which calls Buffer.from() on our plain object,
     // throws ERR_INVALID_ARG_TYPE, and kills the whole run with a stack that
-    // names vitest internals rather than this line. Under test there is no main
-    // process to answer, so fail fast and let callers fall back to env vars.
-    if (process.env.VITEST || process.env.NODE_ENV === "test") {
+    // names vitest internals rather than this line.
+    //
+    // Only refuse when we would post to the REAL process — that is vitest's
+    // channel. An injected ipcProcess is a test double with its own send/on,
+    // which is how the IPC flow itself is tested; blocking that made those
+    // tests resolve undefined instead of exercising the path they cover.
+    if (
+      ipcProcess === process &&
+      (process.env.VITEST || process.env.NODE_ENV === "test")
+    ) {
       reject(new Error("IPC not available - running under test"));
       return;
     }

--- a/src/gateway/utils/keyResolver.ts
+++ b/src/gateway/utils/keyResolver.ts
@@ -80,6 +80,17 @@ async function requestKeysViaIPC(
       return;
     }
 
+    // A live IPC channel does not mean the parent is the Electron main process.
+    // Vitest's forks pool connects one too, and routes anything we post into its
+    // own RPC deserializer, which calls Buffer.from() on our plain object,
+    // throws ERR_INVALID_ARG_TYPE, and kills the whole run with a stack that
+    // names vitest internals rather than this line. Under test there is no main
+    // process to answer, so fail fast and let callers fall back to env vars.
+    if (process.env.VITEST || process.env.NODE_ENV === "test") {
+      reject(new Error("IPC not available - running under test"));
+      return;
+    }
+
     const reqId = `keys-${++requestId}`;
     const timeout = setTimeout(() => {
       cleanup();

--- a/tests/agent-stream-concurrency.test.ts
+++ b/tests/agent-stream-concurrency.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, test, beforeEach, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   AgentStreamConcurrencyGate,
   AgentStreamConcurrencyTimeoutError,
   AGENT_STREAM_ACQUIRE_TIMEOUT_MS,
+  BACKGROUND_AGENT_STREAM_ACQUIRE_TIMEOUT_MS,
+  DEFAULT_AGENT_STREAM_MAX_CONCURRENT,
   resetAgentStreamConcurrencyGateForTests,
 } from "../src/gateway/services/agent/agentStreamConcurrency.js";
 
@@ -11,63 +13,106 @@ describe("AgentStreamConcurrencyGate", () => {
     resetAgentStreamConcurrencyGateForTests();
     delete process.env.AGENT_STREAM_MAX_CONCURRENT;
   });
+  afterEach(() => vi.useRealTimers());
 
-  test("allows up to max concurrent streams", async () => {
+  test("defaults to three streams after replay-buffer memory hardening", () => {
+    const gate = new AgentStreamConcurrencyGate();
+    expect(DEFAULT_AGENT_STREAM_MAX_CONCURRENT).toBe(3);
+    expect(gate.getStats().maxConcurrent).toBe(3);
+  });
+
+  test("allows two foreground streams", async () => {
     process.env.AGENT_STREAM_MAX_CONCURRENT = "2";
     const gate = new AgentStreamConcurrencyGate();
-
-    await gate.acquire("chat-a");
-    await gate.acquire("chat-b");
-
+    const a = await gate.acquire("chat-a");
+    const b = await gate.acquire("chat-b");
     expect(gate.getStats().activeCount).toBe(2);
-
-    gate.release("chat-a");
-    expect(gate.getStats().activeCount).toBe(1);
+    gate.release(a);
+    gate.release(b);
+    expect(gate.getStats().activeCount).toBe(0);
   });
 
-  test("queues third stream until a slot frees", async () => {
+  test("reserves one slot from background work for foreground chat", async () => {
     process.env.AGENT_STREAM_MAX_CONCURRENT = "2";
     const gate = new AgentStreamConcurrencyGate();
-
-    await gate.acquire("chat-a");
-    await gate.acquire("chat-b");
-
-    let admitted = false;
-    const pending = gate.acquire("chat-c").then(() => {
-      admitted = true;
+    const job = await gate.acquire("job:a", undefined, "background");
+    let secondJobAdmitted = false;
+    const secondJob = gate.acquire("job:b", undefined, "background").then((lease) => {
+      secondJobAdmitted = true;
+      return lease;
     });
-
     await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(admitted).toBe(false);
+    expect(secondJobAdmitted).toBe(false);
 
-    gate.release("chat-a");
-    await pending;
-    expect(admitted).toBe(true);
-    expect(gate.getStats().activeChatIds).toContain("chat-c");
+    const chat = await gate.acquire("chat-a", undefined, "foreground");
+    expect(gate.getStats().activeCount).toBe(2);
+    gate.release(chat);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(secondJobAdmitted).toBe(false);
+
+    gate.release(job);
+    const secondLease = await secondJob;
+    expect(secondJobAdmitted).toBe(true);
+    gate.release(secondLease);
   });
 
-  test("rejects waiters after timeout", async () => {
+  test("foreground waits only briefly before returning a useful error", async () => {
     vi.useFakeTimers();
     process.env.AGENT_STREAM_MAX_CONCURRENT = "1";
     const gate = new AgentStreamConcurrencyGate();
     await gate.acquire("chat-a");
-
     const pending = gate.acquire("chat-b");
     const expectation = expect(pending).rejects.toBeInstanceOf(
       AgentStreamConcurrencyTimeoutError,
     );
     await vi.advanceTimersByTimeAsync(AGENT_STREAM_ACQUIRE_TIMEOUT_MS + 1);
     await expectation;
-    vi.useRealTimers();
   });
 
-  test("does not double-acquire the same chatId", async () => {
+  test("background work retains the longer queue timeout", async () => {
+    vi.useFakeTimers();
     process.env.AGENT_STREAM_MAX_CONCURRENT = "1";
     const gate = new AgentStreamConcurrencyGate();
-
     await gate.acquire("chat-a");
-    await gate.acquire("chat-a");
+    const pending = gate.acquire("job:a", undefined, "background");
+    let rejected = false;
+    void pending.catch(() => { rejected = true; });
+    await vi.advanceTimersByTimeAsync(AGENT_STREAM_ACQUIRE_TIMEOUT_MS + 1);
+    expect(rejected).toBe(false);
+    await vi.advanceTimersByTimeAsync(
+      BACKGROUND_AGENT_STREAM_ACQUIRE_TIMEOUT_MS - AGENT_STREAM_ACQUIRE_TIMEOUT_MS,
+    );
+    await expect(pending).rejects.toBeInstanceOf(AgentStreamConcurrencyTimeoutError);
+  });
 
+  test("serializes replacement streams and ignores stale releases", async () => {
+    process.env.AGENT_STREAM_MAX_CONCURRENT = "1";
+    const gate = new AgentStreamConcurrencyGate();
+    const first = await gate.acquire("chat-a");
+    let admitted = false;
+    const replacement = gate.acquire("chat-a").then((lease) => {
+      admitted = true;
+      return lease;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(admitted).toBe(false);
+    gate.release(first);
+    const second = await replacement;
+    gate.release(first);
     expect(gate.getStats().activeCount).toBe(1);
+    gate.release(second);
+    expect(gate.getStats().activeCount).toBe(0);
+  });
+
+  test("aborts a queued replacement", async () => {
+    process.env.AGENT_STREAM_MAX_CONCURRENT = "1";
+    const gate = new AgentStreamConcurrencyGate();
+    const first = await gate.acquire("chat-a");
+    const controller = new AbortController();
+    const replacement = gate.acquire("chat-a", controller.signal);
+    controller.abort();
+    await expect(replacement).rejects.toThrow("cancelled while waiting");
+    expect(gate.getStats().waitingCount).toBe(0);
+    gate.release(first);
   });
 });

--- a/tests/app-service.test.ts
+++ b/tests/app-service.test.ts
@@ -2,27 +2,49 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import path from "path";
 import os from "os";
 import { promises as fs } from "fs";
+import { randomUUID } from "crypto";
 import { AppService } from "../src/gateway/services/AppService.js";
 
 describe("AppService", () => {
   let originalHome: string | undefined;
+  let originalPaprHome: string | undefined;
   let testHomeDir: string;
   let appService: AppService;
 
   beforeEach(async () => {
     originalHome = process.env.HOME;
-    testHomeDir = path.join(os.tmpdir(), `paprwork-v2-app-service-${Date.now()}`);
+    originalPaprHome = process.env.PAPR_HOME;
+    // Date.now() collides when two tests start in the same millisecond, which
+    // silently shares one workspace between them.
+    testHomeDir = path.join(
+      os.tmpdir(),
+      `paprwork-v2-app-service-${process.pid}-${randomUUID()}`,
+    );
     process.env.HOME = testHomeDir;
-    await fs.mkdir(testHomeDir, { recursive: true });
+    // HOME alone is not enough. getPaprRoot() prefers the active-workspace
+    // pointer read from the developer's REAL home, and syncs PAPR_HOME to it —
+    // so without this the suite creates apps in the user's live workspace
+    // instead of a temp dir, and listApps() returns hundreds of real apps.
+    process.env.PAPR_HOME = path.join(testHomeDir, "Papr");
+    await fs.mkdir(path.join(testHomeDir, "Papr"), { recursive: true });
     appService = new AppService();
     await appService.initialize();
   });
 
   afterEach(async () => {
+    // Stop watchers and pending timers before the temp dir goes away. Without
+    // this, chokidar keeps firing on deleted paths and the debounced reload
+    // broadcast outlives the test run.
+    appService.cleanup();
     if (originalHome === undefined) {
       delete process.env.HOME;
     } else {
       process.env.HOME = originalHome;
+    }
+    if (originalPaprHome === undefined) {
+      delete process.env.PAPR_HOME;
+    } else {
+      process.env.PAPR_HOME = originalPaprHome;
     }
     await fs.rm(testHomeDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
@@ -149,7 +171,9 @@ describe("AppService", () => {
 
     expect(favorited?.favorite).toBe(true);
     expect(appPath).toContain(created.id);
-    expect(deleted).toBe(true);
+    // deleteApp returns DeleteAppResult (it may also need to unpublish from
+    // cloud), not a bare boolean.
+    expect(deleted.deleted).toBe(true);
     expect(afterDelete).toBeNull();
   });
 

--- a/tests/pi-ai-adaptive-thinking.test.ts
+++ b/tests/pi-ai-adaptive-thinking.test.ts
@@ -71,4 +71,30 @@ describe("piAiAnthropicAdaptiveThinking", () => {
     );
     expect(sonnetOpts.onPayload).toBeUndefined();
   });
+
+  it("reports a Claude Code version new enough for Opus 5 on OAuth", () => {
+    const opts = augmentPiAiAnthropicStreamOptions(
+      "claude-opus-5",
+      "medium",
+      {
+        apiKey: "sk-ant-oat01-test",
+        sessionId: "chat-1",
+        reasoning: "medium",
+      },
+    );
+    expect(opts.headers?.["user-agent"]).toBe("claude-cli/2.1.226");
+  });
+
+  it("does not spoof Claude Code headers for direct API keys", () => {
+    const opts = augmentPiAiAnthropicStreamOptions(
+      "claude-opus-5",
+      "medium",
+      {
+        apiKey: "sk-ant-api03-test",
+        sessionId: "chat-1",
+        reasoning: "medium",
+      },
+    );
+    expect(opts.headers).toBeUndefined();
+  });
 });

--- a/tests/turso-push-scheduler-stats.test.ts
+++ b/tests/turso-push-scheduler-stats.test.ts
@@ -24,7 +24,13 @@ vi.mock("../src/gateway/services/TursoSyncBridge.js", () => ({
   getTursoSyncBridge: () => bridgeMock,
 }));
 
-vi.mock("../src/gateway/services/tursoSyncState.js", () => ({
+// Spread the real module instead of listing exports by hand — the two-export
+// version broke as soon as the scheduler reached loadTursoSyncState, with an
+// error naming the mock rather than the missing export.
+vi.mock("../src/gateway/services/tursoSyncState.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../src/gateway/services/tursoSyncState.js")
+  >()),
   recordTursoPushSuccess: vi.fn(),
   recordTursoPushQuarantine: vi.fn(),
 }));

--- a/tests/turso-push-scheduler.test.ts
+++ b/tests/turso-push-scheduler.test.ts
@@ -360,7 +360,13 @@ describe("tursoPushScheduler permanent skip integration", () => {
       expect(state.jobs[dbId]?.dirtyFlag).toBe(true);
       expect(isJobDbDirty(dbId, dbPath, state)).toBe(true);
 
-      vi.doMock("../src/core/utils/paprRoot.js", () => ({
+      // Spread the real module rather than listing exports by hand. The
+      // hand-written version omitted getPaprDataDir, so anything reaching it
+      // failed with "No export is defined on the mock" — a confusing error that
+      // points at the mock instead of the missing name. Only the roots need
+      // redirecting; everything else derives from them.
+      vi.doMock("../src/core/utils/paprRoot.js", async (importOriginal) => ({
+        ...(await importOriginal<typeof import("../src/core/utils/paprRoot.js")>()),
         getPaprRoot: () => tmpPapr,
         getPaprAppsRoot: () => path.join(tmpPapr, "apps"),
       }));


### PR DESCRIPTION
## Summary

- restore Claude Opus 5 / Fable 5 subscription-auth compatibility by reporting a Claude Code client version that meets Anthropic's documented minimum
- preserve direct Anthropic API-key behavior without adding OAuth-only headers
- harden global agent-stream concurrency with explicit leases, stale-release protection, same-chat serialization, abortable waiters, and foreground priority
- raise the bounded default from 2 to 3 streams while reserving one slot from background jobs for interactive chat
- fix the replacement-stream race where a delayed stop could abort the newly registered stream

## Root causes

### Claude frontier models

Paprwork's installed pi-ai transport reports `claude-cli/2.1.75`. Anthropic documents Claude Code `2.1.219+` for Opus 5 and `2.1.170+` for Fable 5. A valid subscription token was therefore sent with an obsolete client identity.

### Concurrent session exhaustion

The previous gate used a chat-id set plus a separate counter, returned immediately for same-chat replacements, and gave foreground chat the same 120-second queue as jobs. Two real long-running chats could exhaust the `2/2` cap, while replacement races and non-abortable queued streams made recovery unreliable.

## Validation

- `git diff --check`
- focused Vitest suite: **13/13 passed**
  - `tests/agent-stream-concurrency.test.ts`
  - `tests/pi-ai-adaptive-thinking.test.ts`
- gateway TypeScript passed on the source branch before rebasing onto current master
- on current master, the clean-worktree TypeScript run reaches only existing missing `sharp` module/type errors in `catalogIconForPublish.ts`; no errors are emitted from these changed files

## Rollout

Requires rebuilding/restarting Paprwork so the gateway uses the updated Claude OAuth headers and concurrency scheduler.
