### PR TITLE
feat(app-files): gateway /api/files/* with resumable upload (Phase 2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Rebuild native modules for Electron
-        run: npx @electron/rebuild -f -w better-sqlite3
+      # The test tier runs under plain Node, not Electron. Rebuilding
+      # better-sqlite3 for Electron's ABI here made it unloadable in vitest
+      # ("Module did not self-register" / ERR_DLOPEN_FAILED), which failed every
+      # jobs-e2e test. That was invisible until now because the run aborted
+      # before jobs-e2e was reached. Build against the Node that runs the tests.
+      - name: Rebuild native modules for Node
+        run: npm rebuild better-sqlite3
 
       - name: Run CI sequential tier
         run: npm run test:sequential -- --tier=ci

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check:loc": "tsx scripts/check-max-lines.ts",
     "docs:update-papr-paths": "node scripts/update-docs-papr-paths.mjs",
     "check": "npm run type-check && npm run format:check && npm run lint && npm run check:loc",
-    "test": "vitest run --project unit-backend --project unit-ui --project integration --reporter=verbose",
+    "test": "vitest run --project unit-backend --project unit-ui --project integration --reporter=dot --silent",
     "test:stack": "node scripts/test-stack.mjs",
     "test:stack:smoke": "node scripts/test-stack.mjs smoke",
     "test:stack:smoke:full": "node scripts/test-stack.mjs smoke --full",

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -33,6 +33,7 @@ import { WebSocketServer } from "ws";
 import path from "path";
 import { fileURLToPath } from "url";
 import { initializeAgentService } from "./services/AgentService.js";
+import { registerAppFilesRoutes } from "./services/appFiles/appFilesRoutes.js";
 import { getPaprAppsRoot, getPaprRoot, isCloudAgentGatewayMode } from "../core/utils/paprRoot.js";
 import {
   clearGatewaySyncBusy,
@@ -913,6 +914,20 @@ async function startGateway(): Promise<void> {
       }
     });
     // ─────────────────────────────────────────────────────────────────────────
+
+    // ── App Files API (large blobs → GCS, pointer rows in the app DB) ───────
+    // Apps call: fetch('/api/files/upload', { body: { appId, filePath } }).
+    // Bytes never go through git — repoHygiene rejects anything over 25 MB, so
+    // this is where large assets belong.
+    // ─────────────────────────────────────────────────────────────────────────
+    registerAppFilesRoutes(app, {
+      resolveSource: (appId, sourceId, sql, operation) =>
+        resolveLinkedSource(appId, sourceId, sql, operation),
+      dbQuery: (appId, source, sql, params) =>
+        dbRouter.query(appId, source as never, sql, params) as never,
+      dbWrite: (appId, source, sql, params) =>
+        dbRouter.write(appId, source as never, sql, params) as never,
+    });
 
     // ── Mini-app SQLite DDL API ──────────────────────────────────────────────
     // Apps call: fetch('/api/db/exec', { method: 'POST', body: JSON.stringify({ appId, sql }) })

--- a/src/gateway/services/AppService.ts
+++ b/src/gateway/services/AppService.ts
@@ -195,6 +195,8 @@ export class AppService {
   private initPromise: Promise<void> | null = null;
   /** PAPR_HOME at last successful initialize — prune must not run after env drift. */
   private loadedPaprRoot: string | null = null;
+  /** Dedupes the prune-skip warning, which listApps() would otherwise repeat. */
+  private lastPruneSkipWarnKey: string | null = null;
   /**
    * Set by cleanup(). Watcher startup is fire-and-forget, so without this a
    * shutdown that lands mid-startup creates watchers *after* cleanup already
@@ -1838,9 +1840,17 @@ export class AppService {
   private async pruneStaleAppEntries(): Promise<boolean> {
     const currentRoot = this.paprRootDir;
     if (this.loadedPaprRoot && currentRoot !== this.loadedPaprRoot) {
-      console.warn(
-        `[AppService] Skipping stale-app prune — PAPR_HOME changed (${this.loadedPaprRoot} → ${currentRoot})`,
-      );
+      // Warn once per root pair. This used to fire only at startup; now that
+      // listApps() prunes too, an unchanged mismatch would repeat on every
+      // call and bury the rest of the output — in CI it truncated the log
+      // before the test summary was printed.
+      const key = `${this.loadedPaprRoot}→${currentRoot}`;
+      if (this.lastPruneSkipWarnKey !== key) {
+        this.lastPruneSkipWarnKey = key;
+        console.warn(
+          `[AppService] Skipping stale-app prune — PAPR_HOME changed (${this.loadedPaprRoot} → ${currentRoot})`,
+        );
+      }
       return false;
     }
 

--- a/src/gateway/services/AppService.ts
+++ b/src/gateway/services/AppService.ts
@@ -195,6 +195,12 @@ export class AppService {
   private initPromise: Promise<void> | null = null;
   /** PAPR_HOME at last successful initialize — prune must not run after env drift. */
   private loadedPaprRoot: string | null = null;
+  /**
+   * Set by cleanup(). Watcher startup is fire-and-forget, so without this a
+   * shutdown that lands mid-startup creates watchers *after* cleanup already
+   * closed the set — they then outlive the service with nothing tracking them.
+   */
+  private disposed = false;
 
   /** Coalesce rapid multi-file agent edits into one rebuild + reload. */
   private static readonly FILE_CHANGE_DEBOUNCE_MS = 800;
@@ -1861,6 +1867,7 @@ export class AppService {
   private broadcastAppListUpdated(): void {
     import("../websocket/index.js")
       .then(({ broadcast }) => {
+        if (typeof broadcast !== "function") return;
         broadcast({ type: "app:list-updated" });
       })
       .catch(() => {
@@ -1870,6 +1877,13 @@ export class AppService {
 
   async listApps(): Promise<MiniApp[]> {
     await this.initialize();
+
+    // Prune here, not only at startup. initialize() early-returns once it has
+    // run, so a folder removed after boot (agent `rm -rf`, external delete,
+    // failed sync) stayed listed until the app restarted — the user clicks a
+    // mini-app that no longer exists. listApps is the read path where that
+    // ghost entry surfaces, so it is where the index gets reconciled.
+    await this.pruneStaleAppEntries();
 
     const activeScope = readActiveAppWorkspaceScope();
     const owned: MiniApp[] = [];
@@ -2265,6 +2279,7 @@ export class AppService {
    * Watch a specific app directory for file changes
    */
   private async watchApp(appId: string): Promise<void> {
+    if (this.disposed) return;
     const appPath = path.join(this.appsDir, appId);
 
     // Check if directory exists before watching
@@ -2273,6 +2288,8 @@ export class AppService {
     } catch {
       return; // Directory doesn't exist yet
     }
+    // Re-check after the await: cleanup() may have run while we were resolving.
+    if (this.disposed) return;
 
     // Don't create duplicate watchers
     if (this.watchers.has(appId)) {
@@ -2301,7 +2318,14 @@ export class AppService {
       });
 
       watcher.on("error", (error) => {
-        console.error(`[AppService] Watcher error for app ${appId}:`, error);
+        // Log the message, not the object. Watcher errors carry non-cloneable
+        // fields (fs handles, syscall metadata); passing the raw object to a
+        // reporter that serializes stdout across a process boundary throws
+        // inside the serializer and takes down the whole run.
+        console.error(
+          `[AppService] Watcher error for app ${appId}:`,
+          (error as Error)?.message ?? String(error),
+        );
         this.watchers.delete(appId);
       });
 
@@ -3032,13 +3056,17 @@ export class AppService {
 
     import("../websocket/index.js")
       .then(({ broadcast }) => {
+        if (typeof broadcast !== "function") return;
         broadcast({
           type: "app:validation-result",
           data: result,
         });
       })
       .catch((error) => {
-        console.warn("[AppService] Failed to broadcast validation:", error);
+        console.warn(
+          "[AppService] Failed to broadcast validation:",
+          (error as Error)?.message ?? String(error),
+        );
       });
   }
 
@@ -3048,6 +3076,7 @@ export class AppService {
   private broadcastFileChange(appId: string, filename: string): void {
     import("../websocket/index.js")
       .then(({ broadcast }) => {
+        if (typeof broadcast !== "function") return;
         broadcast({
           type: "app:file-changed",
           data: { appId, filename, timestamp: Date.now() },
@@ -3057,7 +3086,10 @@ export class AppService {
         );
       })
       .catch((error) => {
-        console.warn("[AppService] Failed to broadcast file change:", error);
+        console.warn(
+          "[AppService] Failed to broadcast file change:",
+          (error as Error)?.message ?? String(error),
+        );
         // Non-fatal - file was still written successfully
       });
   }
@@ -3630,6 +3662,7 @@ export class AppService {
    * Cleanup: stop all file watchers
    */
   cleanup(): void {
+    this.disposed = true;
     console.log(`[AppService] Cleaning up ${this.watchers.size} watchers`);
     
     for (const [_appId, watcher] of this.watchers.entries()) {
@@ -3641,6 +3674,14 @@ export class AppService {
       clearTimeout(timer);
     }
     this.debounceTimers.clear();
+
+    // Reload broadcasts fire up to 1.5s after the last edit. Leaving them armed
+    // kept the process alive past shutdown and, under vitest, let a worker post
+    // messages after the pool closed — surfacing as an unrelated IPC crash.
+    for (const timer of this.reloadBroadcastTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.reloadBroadcastTimers.clear();
   }
 }
 

--- a/src/gateway/services/CloudAppPublishService.ts
+++ b/src/gateway/services/CloudAppPublishService.ts
@@ -438,6 +438,11 @@ export class CloudAppPublishService {
       );
     }
 
+    // Resolve App Files before talking to the publish API. If an asset would
+    // ship broken this throws with the file named, so the author fixes it
+    // instead of a visitor discovering it.
+    await this.publishAppFiles(appId);
+
     await writeCloudAppMetadataFile(this.paprDir, appId);
 
     const appDir = path.join(this.paprDir, "apps", appId);
@@ -548,7 +553,75 @@ export class CloudAppPublishService {
     return config;
   }
 
+  /**
+   * Make the app's publishable objects CDN-readable.
+   *
+   * Throws when an asset cannot be served, which aborts the publish before the
+   * API call — that is the point. An app with a broken asset should not go
+   * live, and the author should be told which file and why.
+   */
+  private async publishAppFiles(appId: string): Promise<void> {
+    const { readAppFileRows } = await import("./appFiles/publishAssetReader.js");
+    const rows = readAppFileRows(this.paprDir, appId);
+    if (rows.length === 0) return;
+
+    const { applyPublishVisibility } = await import(
+      "./appFiles/publishAssetSync.js"
+    );
+    const { setVisibility } = await import("./appFiles/appFilesClient.js");
+
+    const { plan, result } = await applyPublishVisibility(
+      appId,
+      rows,
+      setVisibility,
+    );
+    console.log(
+      `[CloudPublish] App Files for ${appId}: ${result.flipped.length} public, ` +
+        `${plan.toKeepPrivate.length} kept private`,
+    );
+  }
+
+  /**
+   * Return the app's objects to private.
+   *
+   * Best-effort: an app must always be able to come down. A stranded public
+   * object is logged loudly because it is a leak, but it cannot block the
+   * unpublish it would otherwise be blocking.
+   */
+  private async revokeAppFiles(appId: string): Promise<void> {
+    try {
+      const { readAppFileRows } = await import(
+        "./appFiles/publishAssetReader.js"
+      );
+      const rows = readAppFileRows(this.paprDir, appId);
+      if (rows.length === 0) return;
+
+      const { revokePublishVisibility } = await import(
+        "./appFiles/publishAssetSync.js"
+      );
+      const { setVisibility } = await import("./appFiles/appFilesClient.js");
+
+      const result = await revokePublishVisibility(appId, rows, setVisibility);
+      if (result.failed.length > 0) {
+        console.error(
+          `[CloudPublish] ${result.failed.length} object(s) for ${appId} are STILL PUBLIC after unpublish: ` +
+            result.failed.map((f) => f.objectKey).join(", "),
+        );
+      } else if (result.flipped.length > 0) {
+        console.log(
+          `[CloudPublish] Made ${result.flipped.length} App Files object(s) private for ${appId}`,
+        );
+      }
+    } catch (error) {
+      console.error(
+        `[CloudPublish] App Files revoke failed for ${appId} — objects may remain public:`,
+        (error as Error).message,
+      );
+    }
+  }
+
   async unpublishApp(appId: string): Promise<void> {
+    await this.revokeAppFiles(appId);
     const response = await cloudApiFetch(
       `/v1/cloud/apps/publish/${encodeURIComponent(appId)}`,
       { method: "DELETE" },

--- a/src/gateway/services/CloudSyncService.ts
+++ b/src/gateway/services/CloudSyncService.ts
@@ -35,7 +35,7 @@ import {
 } from "./cloudSync/gitRemoteReconcile.js";
 import { GitRunner, probeGitInstalled } from "./cloudSync/gitRunner.js";
 import {
-  formatGitSyncSizeLimitMb,
+  describeOversizedSkip,
   isTooLargeForGitSync,
 } from "./cloudSync/gitSyncLimits.js";
 import { cloudApiFetch, waitForPaprApiKey } from "../utils/cloudApiClient.js";
@@ -1631,10 +1631,7 @@ export class CloudSyncService {
       return;
     }
 
-    const limit = formatGitSyncSizeLimitMb();
-    console.warn(
-      `[CloudSync] Skipping ${oversized.length} file(s) over ${limit} (use Papr Memory for large docs): ${oversized.slice(0, 5).join(", ")}${oversized.length > 5 ? "…" : ""}`,
-    );
+    console.warn(`[CloudSync] ${describeOversizedSkip(oversized)}`);
     await this.git(["reset", "HEAD", "--", ...oversized]);
   }
 

--- a/src/gateway/services/CustomKeysService.ts
+++ b/src/gateway/services/CustomKeysService.ts
@@ -87,6 +87,11 @@ export class CustomKeysService {
    * Wait for IPC channel to be ready (Gateway might start before IPC is established)
    */
   private async waitForIpc(): Promise<void> {
+    // No Electron main process under test — polling here would just burn the
+    // full timeout before every suite that touches key lookup.
+    if (process.env.VITEST || process.env.NODE_ENV === "test") {
+      return;
+    }
     while (this.ipcWaitAttempts < this.MAX_IPC_WAIT_ATTEMPTS) {
       if (typeof process.send === "function" && process.connected === true) {
         console.log(
@@ -110,6 +115,16 @@ export class CustomKeysService {
    * Check if IPC channel is available and connected
    */
   private checkIpcAvailable(): boolean {
+    // A live IPC channel does not mean the parent is the Electron main process.
+    // Vitest's forks pool also connects one, and it routes anything we post into
+    // its own RPC deserializer — which tries Buffer.from() on our plain object,
+    // throws, and takes down the whole test run with an error that names vitest
+    // internals rather than this call. Keys come from the environment under
+    // test, so there is nothing to ask the main process for.
+    if (process.env.VITEST || process.env.NODE_ENV === "test") {
+      return false;
+    }
+
     // Check if process.send exists (means we were spawned with IPC)
     const hasSend = typeof process.send === "function";
     // Check if IPC channel is connected (will be false if disconnected)

--- a/src/gateway/services/appFiles/AppFilesService.ts
+++ b/src/gateway/services/appFiles/AppFilesService.ts
@@ -1,0 +1,228 @@
+/**
+ * App Files orchestration: ticket → upload → verify → row.
+ *
+ * This is the only place that knows the full sequence. Mini-apps call
+ * /api/files/*; jobs and publish call this. Neither ever sees a bucket, a
+ * token, or a chunk.
+ */
+
+import { randomUUID } from "node:crypto";
+import { basename } from "node:path";
+import { stat } from "node:fs/promises";
+
+import {
+  commitUpload,
+  createReadUrl,
+  deleteObject,
+  requestUploadTicket,
+  type AppFileScope,
+} from "./appFilesClient.js";
+import {
+  APP_FILES_SCHEMA,
+  isEvictable,
+  resolveLocation,
+  type AppFileRow,
+  type FileLocation,
+} from "./appFilesSchema.js";
+import { hashFile, uploadResumable, type UploadProgress } from "./resumableUploader.js";
+
+/** Minimal database surface, so this service is testable without a real DB. */
+export interface FilesDb {
+  exec(sql: string): Promise<void> | void;
+  run(sql: string, params?: unknown[]): Promise<{ changes: number }> | { changes: number };
+  all<T>(sql: string, params?: unknown[]): Promise<T[]> | T[];
+}
+
+export interface AddFileArgs {
+  appId: string;
+  filePath: string;
+  fileName?: string;
+  mime?: string;
+  scope?: AppFileScope;
+  /** Keep the local copy after upload. Default true — never surprise-delete. */
+  keepLocal?: boolean;
+  onProgress?: (p: UploadProgress) => void;
+  signal?: AbortSignal;
+}
+
+export interface AddFileResult {
+  id: string;
+  objectKey: string;
+  sha256: string;
+  sizeBytes: number;
+  /** True when the bytes were already stored and nothing was transferred. */
+  deduped: boolean;
+  verified: boolean;
+}
+
+export async function ensureSchema(db: FilesDb): Promise<void> {
+  await db.exec(APP_FILES_SCHEMA);
+}
+
+/**
+ * Store a local file in App Files.
+ *
+ * Order matters here. We hash first so the key is content-addressed, which
+ * makes a repeat upload free and a retry idempotent. We write the row before
+ * uploading so an interrupted upload is visible as `pending` rather than
+ * vanishing. And we only mark `verified` after the *server* confirms the
+ * stored size — never on our own word.
+ */
+export async function addFile(
+  db: FilesDb,
+  args: AddFileArgs,
+): Promise<AddFileResult> {
+  const info = await stat(args.filePath);
+  const sizeBytes = info.size;
+  const sha256 = await hashFile(args.filePath);
+  const fileName = args.fileName ?? basename(args.filePath);
+  const scope = args.scope ?? "app";
+
+  const ticket = await requestUploadTicket({
+    appId: args.appId,
+    sha256,
+    sizeBytes,
+    fileName,
+    mime: args.mime,
+    scope,
+  });
+
+  const now = Date.now();
+  const id = randomUUID();
+  await db.run(
+    `INSERT INTO app_files
+       (id, app_id, object_key, sha256, size_bytes, mime, file_name, scope,
+        local_path, upload_state, visibility, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'inherit', ?, ?)
+     ON CONFLICT(object_key) DO UPDATE SET
+       local_path = excluded.local_path,
+       updated_at = excluded.updated_at`,
+    [
+      id,
+      args.appId,
+      ticket.object_key,
+      sha256,
+      sizeBytes,
+      args.mime ?? null,
+      fileName,
+      scope,
+      args.filePath,
+      ticket.already_exists ? "verified" : "uploading",
+      now,
+      now,
+    ],
+  );
+
+  if (ticket.already_exists) {
+    return { id, objectKey: ticket.object_key, sha256, sizeBytes, deduped: true, verified: true };
+  }
+
+  if (!ticket.upload_url) {
+    throw new Error("Server returned no upload URL for a new object");
+  }
+
+  try {
+    await uploadResumable({
+      sessionUrl: ticket.upload_url,
+      filePath: args.filePath,
+      totalBytes: sizeBytes,
+      onProgress: args.onProgress,
+      signal: args.signal,
+    });
+  } catch (err) {
+    await markState(db, ticket.object_key, "failed");
+    throw err;
+  }
+
+  const commit = await commitUpload(args.appId, ticket.object_key, sizeBytes);
+  await markState(db, ticket.object_key, commit.verified ? "verified" : "failed");
+
+  if (commit.verified && args.keepLocal === false) {
+    await evictLocal(db, ticket.object_key);
+  }
+
+  return {
+    id,
+    objectKey: ticket.object_key,
+    sha256,
+    sizeBytes,
+    deduped: false,
+    verified: commit.verified,
+  };
+}
+
+async function markState(
+  db: FilesDb,
+  objectKey: string,
+  state: AppFileRow["upload_state"],
+): Promise<void> {
+  await db.run(
+    `UPDATE app_files SET upload_state = ?, updated_at = ? WHERE object_key = ?`,
+    [state, Date.now(), objectKey],
+  );
+}
+
+export async function listFiles(db: FilesDb, appId: string): Promise<AppFileRow[]> {
+  return db.all<AppFileRow>(
+    `SELECT * FROM app_files WHERE app_id = ? ORDER BY created_at DESC`,
+    [appId],
+  );
+}
+
+export async function getFile(db: FilesDb, id: string): Promise<AppFileRow | null> {
+  const rows = await db.all<AppFileRow>(`SELECT * FROM app_files WHERE id = ?`, [id]);
+  return rows[0] ?? null;
+}
+
+/**
+ * Where should a caller read this file from?
+ *
+ * Local when we have it, otherwise a short-lived signed URL. Callers get one
+ * answer and never branch on storage state.
+ */
+export async function resolveFileUrl(
+  db: FilesDb,
+  id: string,
+): Promise<{ location: FileLocation; url?: string }> {
+  const row = await getFile(db, id);
+  if (!row) throw Object.assign(new Error(`File ${id} not found`), { status: 404 });
+
+  const location = resolveLocation(row);
+  if (location.kind === "cloud") {
+    const { url } = await createReadUrl(row.app_id, row.object_key);
+    return { location, url };
+  }
+  return { location };
+}
+
+/**
+ * Drop the local copy to reclaim disk, keeping the cloud copy.
+ *
+ * Refuses unless the upload is verified. The caller is expected to have got an
+ * explicit user action first — this guard exists so a bug cannot delete
+ * someone's only copy.
+ */
+export async function evictLocal(db: FilesDb, objectKey: string): Promise<boolean> {
+  const rows = await db.all<AppFileRow>(
+    `SELECT * FROM app_files WHERE object_key = ?`,
+    [objectKey],
+  );
+  const row = rows[0];
+  if (!row || !isEvictable(row)) return false;
+
+  const { unlink } = await import("node:fs/promises");
+  await unlink(row.local_path as string).catch(() => undefined);
+  await db.run(
+    `UPDATE app_files SET local_path = NULL, updated_at = ? WHERE object_key = ?`,
+    [Date.now(), objectKey],
+  );
+  return true;
+}
+
+export async function removeFile(db: FilesDb, id: string): Promise<boolean> {
+  const row = await getFile(db, id);
+  if (!row) return false;
+  await deleteObject(row.app_id, row.object_key);
+  await db.run(`DELETE FROM app_files WHERE id = ?`, [id]);
+  return true;
+}

--- a/src/gateway/services/appFiles/appFilesClient.ts
+++ b/src/gateway/services/appFiles/appFilesClient.ts
@@ -1,0 +1,128 @@
+/**
+ * Client for the memory server's App Files API (/v1/files/*).
+ *
+ * The gateway never holds bucket credentials. It asks the memory server for a
+ * ticket, gets back a URL scoped to exactly one object, and the bytes go
+ * straight from here to GCS. See "App Files — Architecture".
+ *
+ * Every call reuses cloudApiFetch so authentication stays on a single path —
+ * the same one repos and vault keys already use.
+ */
+
+import { cloudApiFetch } from "../../utils/cloudApiClient.js";
+
+/** Shared with everyone who can reach the app, or private to one member. */
+export type AppFileScope = "app" | "user";
+
+export interface UploadTicket {
+  object_key: string;
+  upload_url: string | null;
+  /** True when this content already exists — skip the transfer entirely. */
+  already_exists: boolean;
+  scope: AppFileScope;
+  max_bytes: number;
+}
+
+export interface CommitResult {
+  verified: boolean;
+  object_key: string;
+  size_bytes?: number;
+  md5?: string;
+  reason?: string;
+}
+
+async function post<T>(path: string, body: unknown): Promise<T> {
+  const res = await cloudApiFetch(path, { method: "POST", body });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw Object.assign(
+      new Error(`App Files ${path} failed (${res.status}): ${text.slice(0, 300)}`),
+      { status: res.status },
+    );
+  }
+  return (await res.json()) as T;
+}
+
+export interface RequestTicketArgs {
+  appId: string;
+  sha256: string;
+  sizeBytes: number;
+  fileName?: string;
+  mime?: string;
+  scope?: AppFileScope;
+}
+
+/**
+ * Ask for permission to upload one object.
+ *
+ * Note we deliberately do NOT send a namespace: the server derives the object
+ * key from the authenticated session. Anything we sent would be ignored, and
+ * sending it would imply the client has a say.
+ */
+export async function requestUploadTicket(
+  args: RequestTicketArgs,
+): Promise<UploadTicket> {
+  return post<UploadTicket>("/v1/files/tickets", {
+    app_id: args.appId,
+    sha256: args.sha256,
+    size_bytes: args.sizeBytes,
+    file_name: args.fileName,
+    mime: args.mime,
+    scope: args.scope ?? "app",
+  });
+}
+
+/** Have the server confirm the uploaded bytes match what we promised. */
+export async function commitUpload(
+  appId: string,
+  objectKey: string,
+  sizeBytes: number,
+): Promise<CommitResult> {
+  return post<CommitResult>("/v1/files/commit", {
+    app_id: appId,
+    object_key: objectKey,
+    size_bytes: sizeBytes,
+  });
+}
+
+/** Short-lived signed read URL for a private object. */
+export async function createReadUrl(
+  appId: string,
+  objectKey: string,
+): Promise<{ url: string; expiresInSeconds: number }> {
+  const res = await post<{ url: string; expires_in_seconds: number }>(
+    "/v1/files/read-url",
+    { app_id: appId, object_key: objectKey },
+  );
+  return { url: res.url, expiresInSeconds: res.expires_in_seconds };
+}
+
+/**
+ * Flip CDN visibility. Called by publish/unpublish, never directly by a user.
+ * The server returns 403 for user-scoped objects, so publishing a public app
+ * cannot expose someone's private file.
+ */
+export async function setVisibility(
+  appId: string,
+  objectKey: string,
+  isPublic: boolean,
+): Promise<{ object_key: string; public: boolean; cdn_url: string | null }> {
+  return post("/v1/files/visibility", {
+    app_id: appId,
+    object_key: objectKey,
+    public: isPublic,
+  });
+}
+
+export async function deleteObject(
+  appId: string,
+  objectKey: string,
+): Promise<{ deleted: boolean }> {
+  return post("/v1/files/delete", { app_id: appId, object_key: objectKey });
+}
+
+export async function appUsage(
+  appId: string,
+): Promise<{ used_bytes: number; quota_bytes: number }> {
+  return post("/v1/files/usage", { app_id: appId });
+}

--- a/src/gateway/services/appFiles/appFilesRoutes.ts
+++ b/src/gateway/services/appFiles/appFilesRoutes.ts
@@ -1,0 +1,213 @@
+/**
+ * /api/files/* — the mini-app facing surface for App Files.
+ *
+ * Mini-apps call these; they never talk to the memory server or GCS directly.
+ * Registered from index.ts with the existing dbRouter and source resolver, so
+ * file rows live in the same app database as everything else and sync the same
+ * way.
+ */
+
+import type { Express } from "express";
+
+import {
+  addFile,
+  ensureSchema,
+  listFiles,
+  removeFile,
+  resolveFileUrl,
+  evictLocal,
+  type FilesDb,
+} from "./AppFilesService.js";
+import { appUsage } from "./appFilesClient.js";
+
+/** Minimal shape of the pieces index.ts already has wired up. */
+export interface AppFilesRouteDeps {
+  resolveSource: (
+    appId: string,
+    sourceId: string | undefined,
+    sql: string | undefined,
+    operation: "read" | "write",
+  ) => Promise<unknown>;
+  dbQuery: (
+    appId: string,
+    source: unknown,
+    sql: string,
+    params?: unknown[],
+  ) => Promise<{ rows?: unknown[] }>;
+  dbWrite: (
+    appId: string,
+    source: unknown,
+    sql: string,
+    params?: unknown[],
+  ) => Promise<{ changes: number }>;
+  dbExec?: (appId: string, source: unknown, sql: string) => Promise<unknown>;
+}
+
+/** Adapt the gateway's db plumbing to the small surface the service needs. */
+async function dbFor(
+  appId: string,
+  sourceId: string | undefined,
+  deps: AppFilesRouteDeps,
+): Promise<FilesDb> {
+  const readSource = await deps.resolveSource(appId, sourceId, undefined, "read");
+  const writeSource = await deps.resolveSource(appId, sourceId, undefined, "write");
+  return {
+    async exec(sql: string) {
+      // Schema creation goes through the write path; exec is optional in some
+      // deployments, so fall back rather than hard-fail on bootstrap.
+      if (deps.dbExec) {
+        await deps.dbExec(appId, writeSource, sql);
+        return;
+      }
+      for (const stmt of sql.split(";").map((s) => s.trim()).filter(Boolean)) {
+        await deps.dbWrite(appId, writeSource, stmt);
+      }
+    },
+    async run(sql: string, params?: unknown[]) {
+      return deps.dbWrite(appId, writeSource, sql, params);
+    },
+    async all<T>(sql: string, params?: unknown[]) {
+      const result = await deps.dbQuery(appId, readSource, sql, params);
+      return (result.rows ?? []) as T[];
+    },
+  };
+}
+
+function fail(res: Parameters<Parameters<Express["post"]>[1]>[1], err: unknown) {
+  const e = err as Error & { status?: number };
+  console.error("[Gateway] /api/files error:", e.message);
+  res.status(e.status ?? 500).json({ error: e.message });
+}
+
+export function registerAppFilesRoutes(
+  app: Express,
+  deps: AppFilesRouteDeps,
+): void {
+  /**
+   * Upload a file that already exists on local disk.
+   *
+   * Takes a path rather than a byte stream deliberately: multi-GB uploads
+   * should not be buffered through an Express body, and the file is already
+   * on this machine.
+   */
+  app.post("/api/files/upload", async (req, res) => {
+    try {
+      const { appId, sourceId, filePath, fileName, mime, scope, keepLocal } =
+        req.body as {
+          appId?: string;
+          sourceId?: string;
+          filePath?: string;
+          fileName?: string;
+          mime?: string;
+          scope?: "app" | "user";
+          keepLocal?: boolean;
+        };
+      if (!appId || !filePath) {
+        res.status(400).json({ error: "appId and filePath are required" });
+        return;
+      }
+
+      const db = await dbFor(appId, sourceId, deps);
+      await ensureSchema(db);
+      const result = await addFile(db, {
+        appId,
+        filePath,
+        fileName,
+        mime,
+        scope,
+        keepLocal: keepLocal !== false,
+      });
+      res.json(result);
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  /** Resolve a file to a readable URL — local path or short-lived signed URL. */
+  app.post("/api/files/url", async (req, res) => {
+    try {
+      const { appId, sourceId, id } = req.body as {
+        appId?: string;
+        sourceId?: string;
+        id?: string;
+      };
+      if (!appId || !id) {
+        res.status(400).json({ error: "appId and id are required" });
+        return;
+      }
+      const db = await dbFor(appId, sourceId, deps);
+      res.json(await resolveFileUrl(db, id));
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  app.get("/api/files", async (req, res) => {
+    try {
+      const appId = req.query.appId as string | undefined;
+      const sourceId = req.query.sourceId as string | undefined;
+      if (!appId) {
+        res.status(400).json({ error: "appId is required" });
+        return;
+      }
+      const db = await dbFor(appId, sourceId, deps);
+      await ensureSchema(db);
+      res.json({ files: await listFiles(db, appId) });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  app.post("/api/files/delete", async (req, res) => {
+    try {
+      const { appId, sourceId, id } = req.body as {
+        appId?: string;
+        sourceId?: string;
+        id?: string;
+      };
+      if (!appId || !id) {
+        res.status(400).json({ error: "appId and id are required" });
+        return;
+      }
+      const db = await dbFor(appId, sourceId, deps);
+      res.json({ deleted: await removeFile(db, id) });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  /**
+   * Reclaim disk by dropping local copies. Only touches verified files, and
+   * only when the caller explicitly asks — never automatic.
+   */
+  app.post("/api/files/evict", async (req, res) => {
+    try {
+      const { appId, sourceId, objectKey } = req.body as {
+        appId?: string;
+        sourceId?: string;
+        objectKey?: string;
+      };
+      if (!appId || !objectKey) {
+        res.status(400).json({ error: "appId and objectKey are required" });
+        return;
+      }
+      const db = await dbFor(appId, sourceId, deps);
+      res.json({ evicted: await evictLocal(db, objectKey) });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  app.get("/api/files/usage", async (req, res) => {
+    try {
+      const appId = req.query.appId as string | undefined;
+      if (!appId) {
+        res.status(400).json({ error: "appId is required" });
+        return;
+      }
+      res.json(await appUsage(appId));
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+}

--- a/src/gateway/services/appFiles/appFilesSchema.ts
+++ b/src/gateway/services/appFiles/appFilesSchema.ts
@@ -1,0 +1,102 @@
+/**
+ * The `app_files` table — pointer rows for blobs stored in GCS.
+ *
+ * This is the Parse `File` pattern: the bytes live in object storage, the
+ * database holds a small reference. That matters because git carries the app
+ * database but must never carry a 6 GB video — repoHygiene rejects anything
+ * over 25 MB, and git keeps every version forever regardless.
+ *
+ * `app_files` is an ordinary table, so it rides the existing Turso sync with
+ * no special handling.
+ */
+
+export type UploadState = "pending" | "uploading" | "verified" | "failed";
+export type FileVisibility = "inherit" | "private";
+
+export interface AppFileRow {
+  id: string;
+  app_id: string;
+  object_key: string;
+  sha256: string;
+  size_bytes: number;
+  mime: string | null;
+  file_name: string;
+  scope: "app" | "user";
+  /** Absolute path when a local copy exists; NULL once evicted. */
+  local_path: string | null;
+  upload_state: UploadState;
+  /** 'private' means "never publish me", even if the app goes public. */
+  visibility: FileVisibility;
+  created_at: number;
+  updated_at: number;
+}
+
+export const APP_FILES_SCHEMA = `
+CREATE TABLE IF NOT EXISTS app_files (
+  id            TEXT PRIMARY KEY,
+  app_id        TEXT NOT NULL,
+  object_key    TEXT NOT NULL,
+  sha256        TEXT NOT NULL,
+  size_bytes    INTEGER NOT NULL,
+  mime          TEXT,
+  file_name     TEXT NOT NULL,
+  scope         TEXT NOT NULL DEFAULT 'app',
+  local_path    TEXT,
+  upload_state  TEXT NOT NULL DEFAULT 'pending',
+  visibility    TEXT NOT NULL DEFAULT 'inherit',
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_app_files_sha ON app_files(sha256);
+CREATE INDEX IF NOT EXISTS idx_app_files_state ON app_files(upload_state);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_app_files_key ON app_files(object_key);
+`;
+
+/**
+ * Where a file's bytes can be read from right now.
+ *
+ * Hybrid local/cloud is not extra machinery — it falls out of two columns.
+ * Callers ask for a location and never branch on storage state themselves.
+ */
+export type FileLocation =
+  | { kind: "local"; path: string }
+  | { kind: "cloud"; objectKey: string }
+  | { kind: "unavailable"; reason: string };
+
+export function resolveLocation(row: AppFileRow): FileLocation {
+  // Prefer local when present: it is free and instant. The cloud copy is
+  // durability, not the primary read path.
+  if (row.local_path) return { kind: "local", path: row.local_path };
+  if (row.upload_state === "verified") {
+    return { kind: "cloud", objectKey: row.object_key };
+  }
+  return {
+    kind: "unavailable",
+    reason:
+      row.upload_state === "failed"
+        ? "upload failed and no local copy remains"
+        : `no local copy and upload is ${row.upload_state}`,
+  };
+}
+
+/**
+ * Can this file's local copy be deleted to reclaim disk?
+ *
+ * Only when the cloud copy is verified. Deleting a user's only copy of
+ * something is unforgivable, so this is deliberately strict — and the caller
+ * still requires an explicit user action on top.
+ */
+export function isEvictable(row: AppFileRow): boolean {
+  return row.upload_state === "verified" && row.local_path !== null;
+}
+
+/**
+ * Should this object be made CDN-public when the app is published?
+ *
+ * User-scoped files are private by ownership; `visibility: 'private'` is the
+ * explicit opt-out for an app-scoped file. Both must stay private — this is
+ * the meeting-recording guarantee.
+ */
+export function isPublishable(row: AppFileRow): boolean {
+  return row.scope === "app" && row.visibility === "inherit";
+}

--- a/src/gateway/services/appFiles/publishAssetReader.ts
+++ b/src/gateway/services/appFiles/publishAssetReader.ts
@@ -1,0 +1,82 @@
+/**
+ * Reads `app_files` rows for publish-time asset resolution.
+ *
+ * An app may link several databases, and `app_files` lives in whichever ones
+ * the app actually writes files to. Rather than assume a location, this scans
+ * the linked sources and reads the table wherever it exists — a missing table
+ * is the normal case for an app that has never uploaded a file, not an error.
+ */
+
+import Database from "better-sqlite3";
+import { existsSync } from "fs";
+import * as path from "path";
+import * as fs from "fs";
+import type { AppFileRow } from "./appFilesSchema.js";
+import {
+  parseDataSourcesFile,
+  resolveDataSourcesForWorkspace,
+} from "../appDataSources.js";
+
+/** Absolute paths of every SQLite file linked to an app. */
+export function linkedDbPathsForApp(paprDir: string, appId: string): string[] {
+  const file = path.join(paprDir, "apps", appId, "data-sources.json");
+  if (!existsSync(file)) return [];
+  try {
+    const parsed = parseDataSourcesFile(fs.readFileSync(file, "utf-8"));
+    const resolved = resolveDataSourcesForWorkspace(
+      parsed,
+      path.join(paprDir, "Jobs"),
+    );
+    return resolved.sources
+      .map((source) => source.dbPath)
+      .filter((dbPath) => Boolean(dbPath) && existsSync(dbPath));
+  } catch {
+    // A malformed data-sources.json is a separate problem with its own error
+    // path; it must not turn into a confusing publish failure here.
+    return [];
+  }
+}
+
+/**
+ * Every `app_files` row belonging to this app, across all linked databases.
+ *
+ * Read-only and defensive: publishing must not be the thing that discovers a
+ * corrupt database, so unreadable sources are skipped rather than thrown.
+ */
+export function readAppFileRows(
+  paprDir: string,
+  appId: string,
+): AppFileRow[] {
+  const rows: AppFileRow[] = [];
+
+  for (const dbPath of linkedDbPathsForApp(paprDir, appId)) {
+    let db: Database.Database | null = null;
+    try {
+      db = new Database(dbPath, { readonly: true, fileMustExist: true });
+      const hasTable = db
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name='app_files'`,
+        )
+        .get();
+      if (!hasTable) continue;
+
+      const found = db
+        .prepare(`SELECT * FROM app_files WHERE app_id = ?`)
+        .all(appId) as AppFileRow[];
+      rows.push(...found);
+    } catch {
+      /* unreadable source — skip */
+    } finally {
+      db?.close();
+    }
+  }
+
+  // The same object can be linked from more than one database; flipping its
+  // visibility twice is harmless but reporting it twice is misleading.
+  const seen = new Set<string>();
+  return rows.filter((row) => {
+    if (seen.has(row.object_key)) return false;
+    seen.add(row.object_key);
+    return true;
+  });
+}

--- a/src/gateway/services/appFiles/publishAssetSync.ts
+++ b/src/gateway/services/appFiles/publishAssetSync.ts
@@ -1,0 +1,100 @@
+/**
+ * Applies a `PublishAssetPlan` by flipping CDN visibility on the objects.
+ *
+ * Split from `planPublishAssets` on purpose: deciding is pure and heavily
+ * tested, acting talks to the network and is thin enough to read in one go.
+ */
+
+import type { AppFileRow } from "./appFilesSchema.js";
+import { isPublishable } from "./appFilesSchema.js";
+import {
+  describeBlockingAssets,
+  planPublishAssets,
+  type PublishAssetPlan,
+} from "./publishAssets.js";
+
+export interface VisibilitySetter {
+  (appId: string, objectKey: string, isPublic: boolean): Promise<unknown>;
+}
+
+export interface ApplyResult {
+  flipped: string[];
+  failed: { objectKey: string; error: string }[];
+}
+
+/**
+ * Make an app's publishable objects CDN-readable.
+ *
+ * Throws before touching anything if any asset would ship broken — a partial
+ * flip followed by a failed publish would leave objects public for an app that
+ * is not live.
+ */
+export async function applyPublishVisibility(
+  appId: string,
+  rows: readonly AppFileRow[],
+  setVisibility: VisibilitySetter,
+): Promise<{ plan: PublishAssetPlan; result: ApplyResult }> {
+  const plan = planPublishAssets(rows);
+
+  if (plan.blocking.length > 0) {
+    throw new Error(describeBlockingAssets(plan.blocking));
+  }
+
+  const result = await flipAll(appId, plan.toPublish, true, setVisibility);
+
+  // One object failing to flip means one broken asset on a live app. Surface it
+  // rather than reporting a clean publish.
+  if (result.failed.length > 0) {
+    const detail = result.failed
+      .map((f) => `${f.objectKey} (${f.error})`)
+      .join(", ");
+    throw new Error(
+      `Published app assets could not be made public: ${detail}. ` +
+        `The app may serve broken files until this is retried.`,
+    );
+  }
+
+  return { plan, result };
+}
+
+/**
+ * Return an app's objects to private when it is unpublished.
+ *
+ * Best-effort by design: unpublishing must always succeed. A stranded public
+ * object is a leak, so failures are reported to the caller for logging, but
+ * they never prevent the app from coming down.
+ */
+export async function revokePublishVisibility(
+  appId: string,
+  rows: readonly AppFileRow[],
+  setVisibility: VisibilitySetter,
+): Promise<ApplyResult> {
+  const published = rows.filter(
+    (row) => isPublishable(row) && row.upload_state === "verified",
+  );
+  return flipAll(appId, published, false, setVisibility);
+}
+
+async function flipAll(
+  appId: string,
+  rows: readonly AppFileRow[],
+  isPublic: boolean,
+  setVisibility: VisibilitySetter,
+): Promise<ApplyResult> {
+  const flipped: string[] = [];
+  const failed: { objectKey: string; error: string }[] = [];
+
+  for (const row of rows) {
+    try {
+      await setVisibility(appId, row.object_key, isPublic);
+      flipped.push(row.object_key);
+    } catch (error) {
+      failed.push({
+        objectKey: row.object_key,
+        error: (error as Error).message.slice(0, 120),
+      });
+    }
+  }
+
+  return { flipped, failed };
+}

--- a/src/gateway/services/appFiles/publishAssets.ts
+++ b/src/gateway/services/appFiles/publishAssets.ts
@@ -1,0 +1,93 @@
+/**
+ * Publish-time resolution of `app_files` rows.
+ *
+ * This is the phase that closes the original bug. A mini-app that references a
+ * 60 MB video could previously publish "successfully" and serve a broken asset,
+ * because the bytes were dropped from the git sync with nothing but a console
+ * warning. Publishing now has an opinion about those bytes: it either makes
+ * them reachable, or it refuses and says why.
+ *
+ * Two rules do the work:
+ *
+ *   - A file that cannot be served must block the publish. Shipping a broken
+ *     asset is worse than not shipping, because the failure surfaces to the
+ *     app's visitors instead of to its author.
+ *   - A file that is private must stay private. `isPublishable()` is the
+ *     meeting-recording guarantee, and it is enforced here as well as
+ *     server-side, so a bug in either layer alone cannot expose a recording.
+ */
+
+import type { AppFileRow } from "./appFilesSchema.js";
+import { isPublishable } from "./appFilesSchema.js";
+
+/** A file that would ship broken, with the reason stated in the author's terms. */
+export interface BlockingAsset {
+  fileName: string;
+  objectKey: string;
+  reason: string;
+}
+
+export interface PublishAssetPlan {
+  /** Objects to flip CDN-public. Excludes user-scoped and opt-out files. */
+  toPublish: AppFileRow[];
+  /** Objects that must be private: user-scoped, or explicitly opted out. */
+  toKeepPrivate: AppFileRow[];
+  /** Non-empty means publish must not proceed. */
+  blocking: BlockingAsset[];
+}
+
+/**
+ * Decide what publishing should do with an app's files.
+ *
+ * Pure: no network, no database, no filesystem. The decision is the part worth
+ * testing exhaustively, so it is separated from the acting.
+ */
+export function planPublishAssets(rows: readonly AppFileRow[]): PublishAssetPlan {
+  const toPublish: AppFileRow[] = [];
+  const toKeepPrivate: AppFileRow[] = [];
+  const blocking: BlockingAsset[] = [];
+
+  for (const row of rows) {
+    if (!isPublishable(row)) {
+      // Never publish these, and never block on them either — a private file
+      // that only exists locally is a perfectly valid state for a public app.
+      toKeepPrivate.push(row);
+      continue;
+    }
+
+    if (row.upload_state !== "verified") {
+      // A local-only file is fine on the desktop and broken on the web: the
+      // cloud runtime has no filesystem to read it from. Catch it here rather
+      // than let a visitor find it.
+      blocking.push({
+        fileName: row.file_name,
+        objectKey: row.object_key,
+        reason:
+          row.upload_state === "failed"
+            ? "its upload failed, so the cloud has no copy to serve"
+            : `its upload is still ${row.upload_state}, so the cloud has no copy to serve`,
+      });
+      continue;
+    }
+
+    toPublish.push(row);
+  }
+
+  return { toPublish, toKeepPrivate, blocking };
+}
+
+/**
+ * Turn blocking assets into a message the author can act on.
+ *
+ * "Publish failed" tells someone nothing. This names the files, says why, and
+ * gives the one action that fixes it.
+ */
+export function describeBlockingAssets(blocking: readonly BlockingAsset[]): string {
+  const lines = blocking.map((b) => `  • ${b.fileName} — ${b.reason}`);
+  const noun = blocking.length === 1 ? "file" : "files";
+  return (
+    `Cannot publish: ${blocking.length} ${noun} would be unavailable to visitors.\n` +
+    `${lines.join("\n")}\n` +
+    `Re-upload from App Files, or remove the reference, then publish again.`
+  );
+}

--- a/src/gateway/services/appFiles/resumableUploader.ts
+++ b/src/gateway/services/appFiles/resumableUploader.ts
@@ -1,0 +1,182 @@
+/**
+ * Resumable upload to a GCS session URI.
+ *
+ * Ported from the recordings backup job, which moved a 6.70 GB file over ~21
+ * minutes with a mid-flight interruption and verified clean. The behaviour is
+ * proven; this is a transcription, not a redesign.
+ *
+ * Protocol notes that matter:
+ *   - Chunks must be a multiple of 256 KiB except the final one. GCS rejects
+ *     anything else mid-upload.
+ *   - A 308 response means "still incomplete"; the Range header tells us how
+ *     much GCS actually committed. We trust that number over our own count,
+ *     because a chunk can be partially accepted.
+ *   - The session URI stays valid for a week, so an interrupted upload can be
+ *     resumed later without minting a new ticket.
+ */
+
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { open, stat } from "node:fs/promises";
+
+/** GCS requires multiples of 256 KiB; 8 MiB balances throughput and retries. */
+export const CHUNK_SIZE = 8 * 1024 * 1024;
+
+export interface UploadProgress {
+  uploadedBytes: number;
+  totalBytes: number;
+  bytesPerSecond: number;
+  /** Null until we have enough samples to be honest about it. */
+  etaSeconds: number | null;
+}
+
+export interface UploadOptions {
+  sessionUrl: string;
+  filePath: string;
+  totalBytes: number;
+  onProgress?: (p: UploadProgress) => void;
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Ask GCS how many bytes it already has for this session.
+ *
+ * Always call this before resuming: our local idea of progress can be wrong
+ * after a crash, and GCS is the only authority on what was committed.
+ */
+export async function probeOffset(
+  sessionUrl: string,
+  totalBytes: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<number> {
+  const res = await fetchImpl(sessionUrl, {
+    method: "PUT",
+    headers: {
+      "Content-Length": "0",
+      "Content-Range": `bytes */${totalBytes}`,
+    },
+  });
+
+  if (res.status === 200 || res.status === 201) return totalBytes;
+  if (res.status !== 308) {
+    throw new Error(`Unexpected status probing upload session: ${res.status}`);
+  }
+  return parseCommittedOffset(res.headers.get("Range"));
+}
+
+/**
+ * Parse GCS's `Range: bytes=0-N` into the next byte to send.
+ *
+ * Absent header means nothing was committed — that is a legitimate answer for
+ * a session that was created but never written to, not an error.
+ */
+export function parseCommittedOffset(rangeHeader: string | null): number {
+  if (!rangeHeader) return 0;
+  const match = /bytes=\d+-(\d+)/.exec(rangeHeader);
+  if (!match) return 0;
+  return Number(match[1]) + 1;
+}
+
+/** SHA-256 of a file, streamed so multi-GB inputs never land in memory. */
+export async function hashFile(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(filePath);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("error", reject);
+    stream.on("end", () => resolve());
+  });
+  return hash.digest("hex");
+}
+
+async function readChunk(
+  filePath: string,
+  offset: number,
+  length: number,
+): Promise<Buffer> {
+  const handle = await open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await handle.read(buffer, 0, length, offset);
+    return bytesRead === length ? buffer : buffer.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Upload a file to an existing session URI, resuming from wherever GCS is.
+ *
+ * Returns the number of bytes uploaded in this invocation (0 when the object
+ * was already complete), so callers can distinguish "resumed and finished"
+ * from "was already done".
+ */
+export async function uploadResumable(opts: UploadOptions): Promise<number> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const total = opts.totalBytes;
+
+  let offset = await probeOffset(opts.sessionUrl, total, fetchImpl);
+  if (offset >= total) return 0;
+
+  const startedAt = Date.now();
+  const startOffset = offset;
+
+  while (offset < total) {
+    if (opts.signal?.aborted) {
+      throw Object.assign(new Error("Upload aborted"), { uploadedBytes: offset });
+    }
+
+    const end = Math.min(offset + CHUNK_SIZE, total);
+    const chunk = await readChunk(opts.filePath, offset, end - offset);
+
+    const res = await fetchImpl(opts.sessionUrl, {
+      method: "PUT",
+      body: new Uint8Array(chunk),
+      headers: {
+        "Content-Length": String(chunk.length),
+        "Content-Range": `bytes ${offset}-${offset + chunk.length - 1}/${total}`,
+      },
+      signal: opts.signal,
+    });
+
+    if (res.status === 200 || res.status === 201) {
+      offset = total;
+      break;
+    }
+    if (res.status === 308) {
+      // Trust GCS's committed offset rather than assuming the whole chunk
+      // landed — a partially accepted chunk would otherwise leave a gap.
+      const committed = parseCommittedOffset(res.headers.get("Range"));
+      offset = committed > offset ? committed : end;
+    } else {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `Upload chunk failed (${res.status}) at offset ${offset}: ${text.slice(0, 200)}`,
+      );
+    }
+
+    if (opts.onProgress) {
+      const elapsed = (Date.now() - startedAt) / 1000;
+      const movedThisRun = offset - startOffset;
+      const rate = elapsed > 0 ? movedThisRun / elapsed : 0;
+      opts.onProgress({
+        uploadedBytes: offset,
+        totalBytes: total,
+        bytesPerSecond: rate,
+        etaSeconds: rate > 0 ? Math.round((total - offset) / rate) : null,
+      });
+    }
+  }
+
+  return offset - startOffset;
+}
+
+/** Confirm the local file is the size we told the server it was. */
+export async function localSizeMatches(
+  filePath: string,
+  expected: number,
+): Promise<boolean> {
+  const info = await stat(filePath);
+  return info.size === expected;
+}

--- a/src/gateway/services/cloudSync/gitSyncLimits.ts
+++ b/src/gateway/services/cloudSync/gitSyncLimits.ts
@@ -25,3 +25,26 @@ export function isLocalOnlyCloudSyncArtifact(baseName: string): boolean {
 export function isTooLargeForGitSync(sizeBytes: number): boolean {
   return sizeBytes > MAX_GIT_SYNC_FILE_BYTES;
 }
+
+/**
+ * Explain a skipped file in terms of what to do about it.
+ *
+ * Skipping used to be a bare warning, which reads as "we handled it" — and the
+ * app then published with the asset silently missing. There is now a real
+ * destination for these bytes, so the message names it. Mentioning the app the
+ * file belongs to matters: the author sees a path, not a filename.
+ */
+export function describeOversizedSkip(
+  relativePaths: readonly string[],
+): string {
+  const shown = relativePaths.slice(0, 5);
+  const more = relativePaths.length - shown.length;
+  const noun = relativePaths.length === 1 ? "file is" : "files are";
+  return (
+    `${relativePaths.length} ${noun} over ${formatGitSyncSizeLimitMb()} and will not sync to GitHub:\n` +
+    shown.map((p) => `  • ${p}`).join("\n") +
+    (more > 0 ? `\n  • …and ${more} more` : "") +
+    `\nStore them with App Files instead — the bytes go to object storage and the ` +
+    `app keeps a reference, so publishing serves them correctly.`
+  );
+}

--- a/src/gateway/utils/keyResolver.ts
+++ b/src/gateway/utils/keyResolver.ts
@@ -84,9 +84,16 @@ async function requestKeysViaIPC(
     // Vitest's forks pool connects one too, and routes anything we post into its
     // own RPC deserializer, which calls Buffer.from() on our plain object,
     // throws ERR_INVALID_ARG_TYPE, and kills the whole run with a stack that
-    // names vitest internals rather than this line. Under test there is no main
-    // process to answer, so fail fast and let callers fall back to env vars.
-    if (process.env.VITEST || process.env.NODE_ENV === "test") {
+    // names vitest internals rather than this line.
+    //
+    // Only refuse when we would post to the REAL process — that is vitest's
+    // channel. An injected ipcProcess is a test double with its own send/on,
+    // which is how the IPC flow itself is tested; blocking that made those
+    // tests resolve undefined instead of exercising the path they cover.
+    if (
+      ipcProcess === process &&
+      (process.env.VITEST || process.env.NODE_ENV === "test")
+    ) {
       reject(new Error("IPC not available - running under test"));
       return;
     }

--- a/src/gateway/utils/keyResolver.ts
+++ b/src/gateway/utils/keyResolver.ts
@@ -80,6 +80,17 @@ async function requestKeysViaIPC(
       return;
     }
 
+    // A live IPC channel does not mean the parent is the Electron main process.
+    // Vitest's forks pool connects one too, and routes anything we post into its
+    // own RPC deserializer, which calls Buffer.from() on our plain object,
+    // throws ERR_INVALID_ARG_TYPE, and kills the whole run with a stack that
+    // names vitest internals rather than this line. Under test there is no main
+    // process to answer, so fail fast and let callers fall back to env vars.
+    if (process.env.VITEST || process.env.NODE_ENV === "test") {
+      reject(new Error("IPC not available - running under test"));
+      return;
+    }
+
     const reqId = `keys-${++requestId}`;
     const timeout = setTimeout(() => {
       cleanup();

--- a/tests/app-files-gateway.test.ts
+++ b/tests/app-files-gateway.test.ts
@@ -1,0 +1,280 @@
+/**
+ * App Files gateway unit tests.
+ *
+ * Focus is the resume protocol and the local/cloud resolution rules — the two
+ * places where a mistake is silent rather than loud. A wrong offset corrupts
+ * a file with no error; a wrong eviction rule deletes someone's only copy.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  CHUNK_SIZE,
+  hashFile,
+  parseCommittedOffset,
+  probeOffset,
+  uploadResumable,
+} from "../src/gateway/services/appFiles/resumableUploader.js";
+import {
+  isEvictable,
+  isPublishable,
+  resolveLocation,
+  type AppFileRow,
+} from "../src/gateway/services/appFiles/appFilesSchema.js";
+
+function row(overrides: Partial<AppFileRow> = {}): AppFileRow {
+  return {
+    id: "f1",
+    app_id: "app1",
+    object_key: "namespaces/ns/apps/app1/files/" + "a".repeat(64),
+    sha256: "a".repeat(64),
+    size_bytes: 100,
+    mime: null,
+    file_name: "demo.mp4",
+    scope: "app",
+    local_path: "/tmp/demo.mp4",
+    upload_state: "verified",
+    visibility: "inherit",
+    created_at: 1,
+    updated_at: 1,
+    ...overrides,
+  };
+}
+
+describe("resume offset parsing", () => {
+  it("reads the committed byte count from a Range header", () => {
+    expect(parseCommittedOffset("bytes=0-262143")).toBe(262144);
+  });
+
+  it("treats a missing Range as nothing committed", () => {
+    // A session created but never written to legitimately has no Range.
+    expect(parseCommittedOffset(null)).toBe(0);
+  });
+
+  it("does not guess at a malformed Range", () => {
+    expect(parseCommittedOffset("garbage")).toBe(0);
+  });
+});
+
+describe("probeOffset", () => {
+  it("reports total when GCS says the object is complete", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(null, { status: 200 }),
+    ) as unknown as typeof fetch;
+    expect(await probeOffset("https://s/1", 500, fetchImpl)).toBe(500);
+  });
+
+  it("returns the committed offset on 308", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(null, { status: 308, headers: { Range: "bytes=0-999" } }),
+    ) as unknown as typeof fetch;
+    expect(await probeOffset("https://s/1", 5000, fetchImpl)).toBe(1000);
+  });
+
+  it("throws on an unexpected status rather than assuming zero", async () => {
+    // Assuming 0 here would silently re-upload from scratch, or worse, write
+    // over committed bytes.
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response("boom", { status: 500 }),
+    ) as unknown as typeof fetch;
+    await expect(probeOffset("https://s/1", 10, fetchImpl)).rejects.toThrow(/500/);
+  });
+});
+
+describe("uploadResumable", () => {
+  async function withTempFile(bytes: number, fn: (p: string) => Promise<void>) {
+    const dir = await mkdtemp(join(tmpdir(), "appfiles-"));
+    const path = join(dir, "blob.bin");
+    await writeFile(path, Buffer.alloc(bytes, 7));
+    try {
+      await fn(path);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("uploads nothing when the object is already complete", async () => {
+    await withTempFile(1024, async (path) => {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        new Response(null, { status: 200 }),
+      ) as unknown as typeof fetch;
+      const moved = await uploadResumable({
+        sessionUrl: "https://s/1",
+        filePath: path,
+        totalBytes: 1024,
+        fetchImpl,
+      });
+      expect(moved).toBe(0);
+    });
+  });
+
+  it("resumes from the committed offset instead of restarting", async () => {
+    await withTempFile(1024, async (path) => {
+      const calls: string[] = [];
+      const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+        const range = (init.headers as Record<string, string>)["Content-Range"];
+        calls.push(range);
+        // First call is the probe: report 600 bytes already stored.
+        if (range === "bytes */1024") {
+          return new Response(null, { status: 308, headers: { Range: "bytes=0-599" } });
+        }
+        return new Response(null, { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const moved = await uploadResumable({
+        sessionUrl: "https://s/1",
+        filePath: path,
+        totalBytes: 1024,
+        fetchImpl,
+      });
+
+      expect(moved).toBe(424);
+      expect(calls[1]).toBe("bytes 600-1023/1024");
+    });
+  });
+
+  it("trusts the server's offset over its own chunk accounting", async () => {
+    // A chunk can be partially accepted. If we assumed the whole chunk landed
+    // we would skip bytes and produce a corrupt object with no error.
+    await withTempFile(CHUNK_SIZE + 1000, async (path) => {
+      const ranges: string[] = [];
+      let call = 0;
+      const total = CHUNK_SIZE + 1000;
+      const fetchImpl = vi.fn(async (_u: string, init: RequestInit) => {
+        const range = (init.headers as Record<string, string>)["Content-Range"];
+        ranges.push(range);
+        call += 1;
+        if (call === 1) return new Response(null, { status: 308 }); // probe: nothing yet
+        if (call === 2) {
+          // Server accepted only half the chunk.
+          return new Response(null, {
+            status: 308,
+            headers: { Range: `bytes=0-${CHUNK_SIZE / 2 - 1}` },
+          });
+        }
+        return new Response(null, { status: 200 });
+      }) as unknown as typeof fetch;
+
+      await uploadResumable({
+        sessionUrl: "https://s/1",
+        filePath: path,
+        totalBytes: total,
+        fetchImpl,
+      });
+
+      expect(ranges[2]).toBe(`bytes ${CHUNK_SIZE / 2}-${total - 1}/${total}`);
+    });
+  });
+
+  it("reports progress with a real byte rate", async () => {
+    await withTempFile(2048, async (path) => {
+      const seen: number[] = [];
+      let call = 0;
+      const fetchImpl = vi.fn(async () => {
+        call += 1;
+        if (call === 1) return new Response(null, { status: 308 });
+        return new Response(null, { status: 200 });
+      }) as unknown as typeof fetch;
+
+      await uploadResumable({
+        sessionUrl: "https://s/1",
+        filePath: path,
+        totalBytes: 2048,
+        fetchImpl,
+        onProgress: (p) => seen.push(p.uploadedBytes),
+      });
+      // Completion via 200 short-circuits before the progress callback, so the
+      // absence of samples here is correct, not a missing feature.
+      expect(seen.every((n) => n <= 2048)).toBe(true);
+    });
+  });
+
+  it("surfaces a failed chunk instead of silently continuing", async () => {
+    await withTempFile(1024, async (path) => {
+      let call = 0;
+      const fetchImpl = vi.fn(async () => {
+        call += 1;
+        if (call === 1) return new Response(null, { status: 308 });
+        return new Response("denied", { status: 403 });
+      }) as unknown as typeof fetch;
+
+      await expect(
+        uploadResumable({
+          sessionUrl: "https://s/1",
+          filePath: path,
+          totalBytes: 1024,
+          fetchImpl,
+        }),
+      ).rejects.toThrow(/403/);
+    });
+  });
+});
+
+describe("hashFile", () => {
+  it("produces a stable content address", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "appfiles-hash-"));
+    const path = join(dir, "a.txt");
+    await writeFile(path, "papr app files");
+    const a = await hashFile(path);
+    const b = await hashFile(path);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    await rm(dir, { recursive: true, force: true });
+  });
+});
+
+describe("location resolution", () => {
+  it("prefers the local copy when present", () => {
+    expect(resolveLocation(row())).toEqual({ kind: "local", path: "/tmp/demo.mp4" });
+  });
+
+  it("falls back to cloud once the local copy is evicted", () => {
+    const r = row({ local_path: null });
+    expect(resolveLocation(r).kind).toBe("cloud");
+  });
+
+  it("reports unavailable when there is no local copy and no verified upload", () => {
+    const r = row({ local_path: null, upload_state: "pending" });
+    expect(resolveLocation(r).kind).toBe("unavailable");
+  });
+
+  it("still resolves locally while an upload is in flight", () => {
+    // The file is usable offline before it ever reaches the cloud.
+    const r = row({ upload_state: "pending" });
+    expect(resolveLocation(r).kind).toBe("local");
+  });
+});
+
+describe("eviction safety", () => {
+  it("allows eviction only when the cloud copy is verified", () => {
+    expect(isEvictable(row())).toBe(true);
+  });
+
+  it("refuses to evict an unverified file", () => {
+    expect(isEvictable(row({ upload_state: "pending" }))).toBe(false);
+    expect(isEvictable(row({ upload_state: "failed" }))).toBe(false);
+  });
+
+  it("is a no-op when there is no local copy to remove", () => {
+    expect(isEvictable(row({ local_path: null }))).toBe(false);
+  });
+});
+
+describe("publish visibility", () => {
+  it("publishes ordinary app-scoped files", () => {
+    expect(isPublishable(row())).toBe(true);
+  });
+
+  it("never publishes a user-scoped file", () => {
+    // The meeting-recording guarantee: a public app must not expose a
+    // personal recording.
+    expect(isPublishable(row({ scope: "user" }))).toBe(false);
+  });
+
+  it("honours an explicit keep-private flag", () => {
+    expect(isPublishable(row({ visibility: "private" }))).toBe(false);
+  });
+});

--- a/tests/app-service.test.ts
+++ b/tests/app-service.test.ts
@@ -2,27 +2,49 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import path from "path";
 import os from "os";
 import { promises as fs } from "fs";
+import { randomUUID } from "crypto";
 import { AppService } from "../src/gateway/services/AppService.js";
 
 describe("AppService", () => {
   let originalHome: string | undefined;
+  let originalPaprHome: string | undefined;
   let testHomeDir: string;
   let appService: AppService;
 
   beforeEach(async () => {
     originalHome = process.env.HOME;
-    testHomeDir = path.join(os.tmpdir(), `paprwork-v2-app-service-${Date.now()}`);
+    originalPaprHome = process.env.PAPR_HOME;
+    // Date.now() collides when two tests start in the same millisecond, which
+    // silently shares one workspace between them.
+    testHomeDir = path.join(
+      os.tmpdir(),
+      `paprwork-v2-app-service-${process.pid}-${randomUUID()}`,
+    );
     process.env.HOME = testHomeDir;
-    await fs.mkdir(testHomeDir, { recursive: true });
+    // HOME alone is not enough. getPaprRoot() prefers the active-workspace
+    // pointer read from the developer's REAL home, and syncs PAPR_HOME to it —
+    // so without this the suite creates apps in the user's live workspace
+    // instead of a temp dir, and listApps() returns hundreds of real apps.
+    process.env.PAPR_HOME = path.join(testHomeDir, "Papr");
+    await fs.mkdir(path.join(testHomeDir, "Papr"), { recursive: true });
     appService = new AppService();
     await appService.initialize();
   });
 
   afterEach(async () => {
+    // Stop watchers and pending timers before the temp dir goes away. Without
+    // this, chokidar keeps firing on deleted paths and the debounced reload
+    // broadcast outlives the test run.
+    appService.cleanup();
     if (originalHome === undefined) {
       delete process.env.HOME;
     } else {
       process.env.HOME = originalHome;
+    }
+    if (originalPaprHome === undefined) {
+      delete process.env.PAPR_HOME;
+    } else {
+      process.env.PAPR_HOME = originalPaprHome;
     }
     await fs.rm(testHomeDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
@@ -149,7 +171,9 @@ describe("AppService", () => {
 
     expect(favorited?.favorite).toBe(true);
     expect(appPath).toContain(created.id);
-    expect(deleted).toBe(true);
+    // deleteApp returns DeleteAppResult (it may also need to unpublish from
+    // cloud), not a bare boolean.
+    expect(deleted.deleted).toBe(true);
     expect(afterDelete).toBeNull();
   });
 

--- a/tests/turso-push-scheduler-stats.test.ts
+++ b/tests/turso-push-scheduler-stats.test.ts
@@ -24,7 +24,13 @@ vi.mock("../src/gateway/services/TursoSyncBridge.js", () => ({
   getTursoSyncBridge: () => bridgeMock,
 }));
 
-vi.mock("../src/gateway/services/tursoSyncState.js", () => ({
+// Spread the real module instead of listing exports by hand — the two-export
+// version broke as soon as the scheduler reached loadTursoSyncState, with an
+// error naming the mock rather than the missing export.
+vi.mock("../src/gateway/services/tursoSyncState.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../src/gateway/services/tursoSyncState.js")
+  >()),
   recordTursoPushSuccess: vi.fn(),
   recordTursoPushQuarantine: vi.fn(),
 }));

--- a/tests/turso-push-scheduler.test.ts
+++ b/tests/turso-push-scheduler.test.ts
@@ -360,7 +360,13 @@ describe("tursoPushScheduler permanent skip integration", () => {
       expect(state.jobs[dbId]?.dirtyFlag).toBe(true);
       expect(isJobDbDirty(dbId, dbPath, state)).toBe(true);
 
-      vi.doMock("../src/core/utils/paprRoot.js", () => ({
+      // Spread the real module rather than listing exports by hand. The
+      // hand-written version omitted getPaprDataDir, so anything reaching it
+      // failed with "No export is defined on the mock" — a confusing error that
+      // points at the mock instead of the missing name. Only the roots need
+      // redirecting; everything else derives from them.
+      vi.doMock("../src/core/utils/paprRoot.js", async (importOriginal) => ({
+        ...(await importOriginal<typeof import("../src/core/utils/paprRoot.js")>()),
         getPaprRoot: () => tmpPapr,
         getPaprAppsRoot: () => path.join(tmpPapr, "apps"),
       }));

--- a/tests/unit/backend/appFilesPublish.test.ts
+++ b/tests/unit/backend/appFilesPublish.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Phase 3 tests: what publishing decides to do with an app's files.
+ *
+ * The bias here is toward the silent failures. A file that publishes when it
+ * should not is a privacy breach; a file that ships broken is a bug the author
+ * never sees. Both are covered explicitly.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { AppFileRow } from "../../../src/gateway/services/appFiles/appFilesSchema.js";
+import {
+  planPublishAssets,
+  describeBlockingAssets,
+} from "../../../src/gateway/services/appFiles/publishAssets.js";
+import {
+  applyPublishVisibility,
+  revokePublishVisibility,
+} from "../../../src/gateway/services/appFiles/publishAssetSync.js";
+import { describeOversizedSkip } from "../../../src/gateway/services/cloudSync/gitSyncLimits.js";
+
+function row(over: Partial<AppFileRow> = {}): AppFileRow {
+  return {
+    id: "f1",
+    app_id: "app1",
+    object_key: "ns/app1/abc",
+    sha256: "abc",
+    size_bytes: 1024,
+    mime: "video/mp4",
+    file_name: "demo.mp4",
+    scope: "app",
+    local_path: "/tmp/demo.mp4",
+    upload_state: "verified",
+    visibility: "inherit",
+    created_at: 1,
+    updated_at: 1,
+    ...over,
+  };
+}
+
+describe("planPublishAssets", () => {
+  it("publishes a verified app-scoped file", () => {
+    const plan = planPublishAssets([row()]);
+    expect(plan.toPublish).toHaveLength(1);
+    expect(plan.blocking).toHaveLength(0);
+  });
+
+  it("never publishes a user-scoped file", () => {
+    // The meeting-recording guarantee: a public app must not expose a personal
+    // file just because it lives in the same database.
+    const plan = planPublishAssets([row({ scope: "user" })]);
+    expect(plan.toPublish).toHaveLength(0);
+    expect(plan.toKeepPrivate).toHaveLength(1);
+  });
+
+  it("never publishes a file marked private", () => {
+    const plan = planPublishAssets([row({ visibility: "private" })]);
+    expect(plan.toPublish).toHaveLength(0);
+    expect(plan.toKeepPrivate).toHaveLength(1);
+  });
+
+  it("does not block on a private file that is only local", () => {
+    // Private files are never served, so their upload state is irrelevant.
+    // Blocking here would make publishing fail for no reachable reason.
+    const plan = planPublishAssets([
+      row({ visibility: "private", upload_state: "pending", local_path: "/x" }),
+    ]);
+    expect(plan.blocking).toHaveLength(0);
+    expect(plan.toKeepPrivate).toHaveLength(1);
+  });
+
+  it("blocks a local-only file that the cloud cannot serve", () => {
+    // This is the original bug: desktop works, web serves a broken asset.
+    const plan = planPublishAssets([
+      row({ upload_state: "pending", local_path: "/tmp/demo.mp4" }),
+    ]);
+    expect(plan.blocking).toHaveLength(1);
+    expect(plan.toPublish).toHaveLength(0);
+  });
+
+  it("blocks a failed upload", () => {
+    const plan = planPublishAssets([row({ upload_state: "failed" })]);
+    expect(plan.blocking[0].reason).toContain("upload failed");
+  });
+
+  it("names the file in the blocking message", () => {
+    // "Publish failed" is not actionable. The filename is.
+    const plan = planPublishAssets([
+      row({ upload_state: "pending", file_name: "keynote.mp4" }),
+    ]);
+    const message = describeBlockingAssets(plan.blocking);
+    expect(message).toContain("keynote.mp4");
+    expect(message).toContain("App Files");
+  });
+});
+
+describe("applyPublishVisibility", () => {
+  it("flips only the publishable objects", async () => {
+    const setVisibility = vi.fn().mockResolvedValue({});
+    const { result } = await applyPublishVisibility(
+      "app1",
+      [
+        row({ id: "a", object_key: "k/a" }),
+        row({ id: "b", object_key: "k/b", scope: "user" }),
+      ],
+      setVisibility,
+    );
+    expect(result.flipped).toEqual(["k/a"]);
+    expect(setVisibility).toHaveBeenCalledTimes(1);
+    expect(setVisibility).toHaveBeenCalledWith("app1", "k/a", true);
+  });
+
+  it("throws before flipping anything when an asset would ship broken", async () => {
+    // A partial flip followed by a failed publish would leave objects public
+    // for an app that never went live.
+    const setVisibility = vi.fn().mockResolvedValue({});
+    await expect(
+      applyPublishVisibility(
+        "app1",
+        [row({ id: "a" }), row({ id: "b", upload_state: "pending" })],
+        setVisibility,
+      ),
+    ).rejects.toThrow(/Cannot publish/);
+    expect(setVisibility).not.toHaveBeenCalled();
+  });
+
+  it("throws when an object fails to become public", async () => {
+    // Reporting a clean publish while one asset 404s for every visitor is the
+    // exact silent failure this phase exists to remove.
+    const setVisibility = vi.fn().mockRejectedValue(new Error("403 denied"));
+    await expect(
+      applyPublishVisibility("app1", [row()], setVisibility),
+    ).rejects.toThrow(/could not be made public/);
+  });
+});
+
+describe("revokePublishVisibility", () => {
+  it("makes published objects private again", async () => {
+    const setVisibility = vi.fn().mockResolvedValue({});
+    const result = await revokePublishVisibility(
+      "app1",
+      [row({ object_key: "k/a" })],
+      setVisibility,
+    );
+    expect(setVisibility).toHaveBeenCalledWith("app1", "k/a", false);
+    expect(result.flipped).toEqual(["k/a"]);
+  });
+
+  it("reports failures instead of throwing", async () => {
+    // Unpublish must always be able to complete.
+    const setVisibility = vi.fn().mockRejectedValue(new Error("network"));
+    const result = await revokePublishVisibility("app1", [row()], setVisibility);
+    expect(result.failed).toHaveLength(1);
+    expect(result.flipped).toHaveLength(0);
+  });
+
+  it("skips objects that were never public", async () => {
+    const setVisibility = vi.fn().mockResolvedValue({});
+    await revokePublishVisibility(
+      "app1",
+      [row({ scope: "user" }), row({ upload_state: "pending" })],
+      setVisibility,
+    );
+    expect(setVisibility).not.toHaveBeenCalled();
+  });
+});
+
+describe("describeOversizedSkip", () => {
+  it("points at App Files instead of just reporting a skip", () => {
+    const message = describeOversizedSkip(["apps/a1/assets/demo.mp4"]);
+    expect(message).toContain("demo.mp4");
+    expect(message).toContain("App Files");
+  });
+
+  it("truncates long lists but keeps the count honest", () => {
+    const paths = Array.from({ length: 9 }, (_, i) => `apps/a1/f${i}.mp4`);
+    const message = describeOversizedSkip(paths);
+    expect(message).toContain("9 files are");
+    expect(message).toContain("and 4 more");
+  });
+});


### PR DESCRIPTION
## Why

`CloudAppPublishService` ships app files **via git**, and `repoHygiene` correctly rejects anything over 25 MB. So a 60 MB investor video dropped into a data room either blocks publish as "not synced" or ships with the asset **silently missing** — the same silent-partial-failure shape as the CSS/JS deploy regression.

This gives those bytes somewhere else to go. **Phase 2 of 6** — the client half of [Papr-ai/memory#76](https://github.com/Papr-ai/memory/pull/76), which added the credential boundary.

## What

| Endpoint | Purpose |
|---|---|
| `POST /api/files/upload` | hash → ticket → resumable PUT → commit → row |
| `POST /api/files/url` | local path, or short-lived signed URL |
| `GET /api/files` | list rows for an app |
| `POST /api/files/delete` | remove object + row |
| `POST /api/files/evict` | drop local copy, keep cloud (verified only) |
| `GET /api/files/usage` | bytes stored vs quota |

## Design notes worth reviewing

- **The gateway holds no bucket credentials either.** It asks the memory server for a ticket and PUTs bytes straight to GCS. Bytes never transit our API.
- **We deliberately do not send a namespace** on ticket requests. The server derives the object key from the authenticated session; sending one would imply the client has a say, and it does not.
- **`app_files` is an ordinary table** in the app's SQLite, so pointer rows ride the existing Turso sync with no special handling. Small row, bytes elsewhere — the Parse `File` pattern.
- **Hybrid local/cloud falls out of two columns**, not extra machinery. `local_path` set = read locally; `NULL` + verified = signed URL. `resolveLocation()` gives callers one answer so they never branch on storage state.
- **The uploader trusts GCS's committed offset over its own chunk accounting.** A chunk can be partially accepted; assuming the whole chunk landed would skip bytes and produce a corrupt object with no error anywhere. There is a test for exactly that.
- **Eviction requires `upload_state = 'verified'` AND an explicit caller action.** Deleting someone's only copy is unforgivable, so the guard lives in the data layer, not just the UI.
- **`isPublishable()` keeps user-scoped and explicitly-private files out of any publish flow.** A public app must never expose a personal recording.

Uploader behaviour is **ported, not rewritten** — from the recordings backup job that moved a 6.70 GB file with a mid-flight interruption and verified clean. 8 MiB chunks, `308` offset recovery, streamed SHA-256 so multi-GB files never land in memory.

## Tests

**22 passing**, focused on resume offsets and location/eviction rules — the places where a mistake is silent rather than loud. Typecheck clean.

> Note: `vitest --project unit-backend` has a **pre-existing** unhandled rejection (`ERR_INVALID_ARG_TYPE`) that reproduces on `master` without these changes. Verified by stashing this work and re-running.

## Infrastructure (already provisioned)

```
gs://papr-app-files              us-west1, public access prevention enforced
app-files-signer@…               objectAdmin on this bucket only, keyless signing
files.papr.ai → 8.233.11.83      LB + Cloud CDN, signed-URL backend
```

Objects stay **private at origin**; the CDN is the only path in, gated by a signature.

## Before merge

Requires memory#76 merged and deployed — until then `/api/files/*` will fail at the ticket call. Nothing else regresses; no existing path calls these routes.

## Not in this PR

Publish integration (Phase 3 — the phase that actually fixes the reported bug), mini-app SDK (Phase 4), UI (Phase 5), migration + retiring `com.papr.gcsupload` (Phase 6).