### PR TITLE
feat(app-files): cloud URLs, durable resume, mini-app SDK, and desktop UI (Phases 3–5)

### DIFF
--- a/scripts/app-files-cors.sh
+++ b/scripts/app-files-cors.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# CORS policy for the App Files bucket.
+#
+# Browser uploads go straight from the tab to GCS, so the bucket — not the
+# gateway — is what decides whether they are allowed. Three things must hold or
+# uploads fail in ways that are hard to read from the browser console:
+#
+#   1. PUT allowed from the app origins, or every chunk is blocked outright.
+#   2. Content-Range in allowed request headers. Resumable uploads send it on
+#      every chunk, and a missing entry fails the preflight, not the PUT — so
+#      the error names the wrong thing.
+#   3. Range in expose-headers. This is the subtle one: without it the PUT
+#      still succeeds, but JS cannot read the committed offset, so a resumed
+#      upload silently restarts from byte 0. A 10 GB upload would appear to
+#      work and simply never finish.
+#
+# Idempotent — safe to re-run. Verifies after applying rather than trusting
+# that the write landed.
+#
+# Usage:  ./scripts/app-files-cors.sh [bucket]
+
+set -euo pipefail
+
+BUCKET="${1:-papr-app-files}"
+CONFIG="$(mktemp -t app-files-cors)"
+trap 'rm -f "$CONFIG"' EXIT
+
+# Origins that may upload. Deliberately explicit: a wildcard would let any site
+# a user visits PUT into our bucket using their browser's credentials.
+cat > "$CONFIG" <<'JSON'
+[
+  {
+    "origin": [
+      "https://apps.papr.ai",
+      "https://files.papr.ai",
+      "http://localhost:18789"
+    ],
+    "method": ["GET", "HEAD", "PUT", "POST"],
+    "responseHeader": [
+      "Content-Type",
+      "Content-Length",
+      "Content-Range",
+      "Range",
+      "x-goog-resumable"
+    ],
+    "maxAgeSeconds": 3600
+  }
+]
+JSON
+
+echo "Applying CORS to gs://${BUCKET}"
+gcloud storage buckets update "gs://${BUCKET}" --cors-file="$CONFIG"
+
+echo
+echo "Verifying preflight (PUT + Content-Range from https://apps.papr.ai)"
+PREFLIGHT="$(curl -s -i -X OPTIONS "https://storage.googleapis.com/${BUCKET}/cors-probe" \
+  -H "Origin: https://apps.papr.ai" \
+  -H "Access-Control-Request-Method: PUT" \
+  -H "Access-Control-Request-Headers: content-range,content-type")"
+
+check() {
+  if grep -qi "$1" <<< "$PREFLIGHT"; then
+    echo "  ok    $2"
+  else
+    echo "  FAIL  $2"
+    exit 1
+  fi
+}
+
+check "access-control-allow-origin: https://apps.papr.ai" "origin allowed"
+check "access-control-allow-methods:.*PUT"                "PUT allowed"
+check "access-control-allow-headers:.*Content-Range"      "Content-Range accepted"
+
+# expose-headers only appears on a real request, never on the preflight — so
+# this has to be checked separately or the most damaging misconfiguration
+# (silent restart-from-zero) goes unnoticed.
+echo
+echo "Verifying Range is readable by browser JS"
+EXPOSED="$(curl -s -i "https://storage.googleapis.com/${BUCKET}/cors-probe" \
+  -H "Origin: https://apps.papr.ai" | grep -i "access-control-expose-headers" || true)"
+
+if grep -qi "Range" <<< "$EXPOSED"; then
+  echo "  ok    Range exposed — resumed uploads can read the committed offset"
+else
+  echo "  FAIL  Range not exposed — resumed uploads would restart from byte 0"
+  exit 1
+fi
+
+echo
+echo "CORS verified on gs://${BUCKET}"

--- a/src/core/agents/SystemPrompt.ts
+++ b/src/core/agents/SystemPrompt.ts
@@ -2411,6 +2411,20 @@ await fetch('/api/jobs/run', { method: 'POST', body: JSON.stringify({ jobId: JOB
 - **DO:** pass runtime args via \`/api/jobs/run\` \`params\`; write job output to **\`$APP_DB\`**; app reads via **\`/api/db/query\`**; use **\`subscribeJobEvents\`** for live status
 - **DO:** use **\`/api/app/backend/:action\`** for fast server handlers (external APIs, small scripts) — declare in \`apps/{appId}/backend/manifest.json\`
 
+**Large files (video, audio, datasets) — use App Files, never git:**
+- Git sync rejects files over 25 MB and \`recordings/\` never enters git. Storing a 60 MB video as an app asset ships a broken app.
+- **DO:** \`import { papr } from '/__papr__/papr-files.js'\` — four calls, no buckets or chunks:
+\`\`\`ts
+const { id } = await papr.files.upload(file, { onProgress: p => setPct(p.uploadedBytes / p.totalBytes) });
+const { url } = await papr.files.url(id);   // CDN when published, signed when private
+const files = await papr.files.list();
+await papr.files.remove(id);
+\`\`\`
+- Bytes go **browser → object storage directly**, chunked and resumable. Never relay file bytes through the gateway or a job.
+- \`scope: 'user'\` keeps a file private to its uploader even on a public app. Use it for anything personal (recordings, uploads by visitors).
+- Never \`FileReader.readAsDataURL()\` or \`.arrayBuffer()\` a large file — that pulls the whole thing into memory. Pass the \`File\`/\`Blob\` straight to \`upload()\`.
+- Do not compress video/audio before upload: already-compressed formats gain nothing, and \`Content-Encoding\` breaks range requests (video seeking).
+
 **Do NOT manually deploy** mini-apps to Vercel, Netlify, or custom domains as a cloud substitute — Papr auto-publish is the supported path. If \`/api/db/write\` returns 404 on a custom URL, the deployment is wrong (incomplete API shim), **not** missing Papr support — do not route INSERTs through \`/api/db/query\` workarounds. On \`apps.papr.ai\`, \`/api/db/write\` exists and returns \`lastInsertRowid\`. Users opt out in Settings → Cloud Sync if needed.
 
 **Cloud sharing tools (apps.papr.ai — NOT the same as export_app_bundle):**

--- a/src/core/types/cloudAppCompatibility.ts
+++ b/src/core/types/cloudAppCompatibility.ts
@@ -8,7 +8,8 @@ export type CloudCompatibilityCategory =
   | "job-create"
   | "job-trigger"
   | "absolute-path"
-  | "cloud-db";
+  | "cloud-db"
+  | "cloud-files";
 
 export interface CloudCompatibilityFinding {
   category: CloudCompatibilityCategory;

--- a/src/gateway/services/appFiles/AppFilesService.ts
+++ b/src/gateway/services/appFiles/AppFilesService.ts
@@ -18,13 +18,21 @@ import {
   type AppFileScope,
 } from "./appFilesClient.js";
 import {
+  APP_FILES_MIGRATIONS,
   APP_FILES_SCHEMA,
+  isDuplicateColumnError,
   isEvictable,
   resolveLocation,
   type AppFileRow,
   type FileLocation,
 } from "./appFilesSchema.js";
 import { hashFile, uploadResumable, type UploadProgress } from "./resumableUploader.js";
+import {
+  SESSION_TTL_MS,
+  isHashCacheValid,
+  planResume,
+  type CachedHash,
+} from "./uploadResume.js";
 
 /** Minimal database surface, so this service is testable without a real DB. */
 export interface FilesDb {
@@ -57,6 +65,237 @@ export interface AddFileResult {
 
 export async function ensureSchema(db: FilesDb): Promise<void> {
   await db.exec(APP_FILES_SCHEMA);
+
+  // Installs that predate durable resume already have `app_files`, so the
+  // CREATE above is a no-op for them and the new columns must be added
+  // explicitly. SQLite has no `ADD COLUMN IF NOT EXISTS`, so the only
+  // idempotent form is to attempt each and swallow "already exists".
+  for (const statement of APP_FILES_MIGRATIONS) {
+    try {
+      await db.exec(statement);
+    } catch (err) {
+      if (!isDuplicateColumnError(err)) throw err;
+    }
+  }
+}
+
+/**
+ * SHA-256 of a file, reusing the cached value when the file is untouched.
+ *
+ * Hashing 10 GB is minutes of CPU and a spun-up fan. Paying that twice — once
+ * on the first attempt and again on the retry after a crash — is the single
+ * biggest avoidable cost in a large upload.
+ *
+ * Correctness does not rest on this: the server verifies the stored object's
+ * size and MD5 at commit time regardless, so a stale cache costs a failed
+ * commit, not a corrupt file.
+ */
+export async function hashFileCached(
+  db: FilesDb,
+  filePath: string,
+  info: { size: number; mtimeMs: number },
+): Promise<string> {
+  const cached = (
+    await db.all<CachedHash>(
+      `SELECT size_bytes, mtime_ms, sha256 FROM app_file_hashes WHERE local_path = ?`,
+      [filePath],
+    )
+  )[0];
+
+  if (isHashCacheValid(cached, info)) return cached.sha256;
+
+  const sha256 = await hashFile(filePath);
+  await db.run(
+    `INSERT INTO app_file_hashes (local_path, size_bytes, mtime_ms, sha256, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(local_path) DO UPDATE SET
+       size_bytes = excluded.size_bytes,
+       mtime_ms   = excluded.mtime_ms,
+       sha256     = excluded.sha256,
+       updated_at = excluded.updated_at`,
+    [filePath, info.size, Math.floor(info.mtimeMs), sha256, Date.now()],
+  );
+  return sha256;
+}
+
+/**
+ * Resume an upload that was interrupted, without re-sending what GCS has.
+ *
+ * This is the payoff for persisting the session URI: a laptop that died at
+ * 9 GB of 10 resumes at 9 GB. Returns null when there is nothing usable to
+ * resume from, leaving the caller to start a fresh ticket.
+ */
+export async function resumeUpload(
+  db: FilesDb,
+  id: string,
+  options: { onProgress?: (p: UploadProgress) => void; signal?: AbortSignal } = {},
+): Promise<AddFileResult | null> {
+  const row = await getFile(db, id);
+  if (!row || !row.local_path) return null;
+
+  const plan = planResume(row);
+  if (plan.kind === "done") {
+    return {
+      id: row.id,
+      objectKey: row.object_key,
+      sha256: row.sha256,
+      sizeBytes: row.size_bytes,
+      deduped: false,
+      verified: true,
+    };
+  }
+  if (plan.kind === "restart") return null;
+
+  await uploadResumable({
+    sessionUrl: plan.sessionUri,
+    filePath: row.local_path,
+    totalBytes: row.size_bytes,
+    onProgress: options.onProgress,
+    signal: options.signal,
+    onOffsetCommitted: (offset) => recordProgress(db, row.object_key, offset),
+  });
+
+  const commit = await commitUpload(row.app_id, row.object_key, row.size_bytes);
+  await markState(db, row.object_key, commit.verified ? "verified" : "failed");
+
+  return {
+    id: row.id,
+    objectKey: row.object_key,
+    sha256: row.sha256,
+    sizeBytes: row.size_bytes,
+    deduped: false,
+    verified: commit.verified,
+  };
+}
+
+export interface BrowserTicketArgs {
+  appId: string;
+  fileName: string;
+  sizeBytes: number;
+  mime?: string | null;
+  scope?: AppFileScope;
+  /**
+   * Cheap content fingerprint from the browser (head + tail + size).
+   *
+   * Not a full SHA-256: WebCrypto cannot stream a digest, so hashing a 10 GB
+   * file in a tab would mean holding it in memory. The server derives the real
+   * object key itself and verifies MD5 at commit, so this only needs to be
+   * stable and collision-resistant enough to dedupe.
+   */
+  fingerprint: string;
+}
+
+export interface BrowserTicket {
+  id: string;
+  objectKey: string;
+  uploadUrl: string | null;
+  alreadyExists: boolean;
+  sha256: string;
+}
+
+/**
+ * Mint an upload ticket for a browser to PUT against directly.
+ *
+ * The row is written before any bytes move, so an upload abandoned halfway is
+ * visible as `uploading` rather than vanishing — and the session URI is stored
+ * so it can be resumed for the next 7 days.
+ */
+export async function createBrowserTicket(
+  db: FilesDb,
+  args: BrowserTicketArgs,
+): Promise<BrowserTicket> {
+  const scope = args.scope ?? "app";
+  const ticket = await requestUploadTicket({
+    appId: args.appId,
+    sha256: args.fingerprint,
+    sizeBytes: args.sizeBytes,
+    fileName: args.fileName,
+    mime: args.mime ?? undefined,
+    scope,
+  });
+
+  const now = Date.now();
+  const id = randomUUID();
+  await db.run(
+    `INSERT INTO app_files
+       (id, app_id, object_key, sha256, size_bytes, mime, file_name, scope,
+        local_path, upload_state, visibility, upload_session_uri,
+        bytes_uploaded, session_expires_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, 'inherit', ?, 0, ?, ?, ?)
+     ON CONFLICT(object_key) DO UPDATE SET
+       upload_session_uri = excluded.upload_session_uri,
+       session_expires_at = excluded.session_expires_at,
+       updated_at         = excluded.updated_at`,
+    [
+      id,
+      args.appId,
+      ticket.object_key,
+      args.fingerprint,
+      args.sizeBytes,
+      args.mime ?? null,
+      args.fileName,
+      scope,
+      ticket.already_exists ? "verified" : "uploading",
+      ticket.upload_url ?? null,
+      now + SESSION_TTL_MS,
+      now,
+      now,
+    ],
+  );
+
+  // On conflict the insert kept the original row, so report that row's id —
+  // returning a fresh uuid would hand the caller an id that does not exist.
+  const existing = (
+    await db.all<{ id: string }>(
+      `SELECT id FROM app_files WHERE object_key = ?`,
+      [ticket.object_key],
+    )
+  )[0];
+
+  return {
+    id: existing?.id ?? id,
+    objectKey: ticket.object_key,
+    uploadUrl: ticket.already_exists ? null : (ticket.upload_url ?? null),
+    alreadyExists: Boolean(ticket.already_exists),
+    sha256: args.fingerprint,
+  };
+}
+
+/**
+ * Confirm a browser-uploaded object, after the server checks the stored bytes.
+ *
+ * Verification is server-side on purpose: the client saying "I sent it all" is
+ * not evidence, and a truncated upload that reported success would be worse
+ * than a failed one.
+ */
+export async function commitBrowserUpload(
+  db: FilesDb,
+  args: { appId: string; id: string; objectKey: string; sizeBytes: number },
+): Promise<AddFileResult> {
+  const commit = await commitUpload(args.appId, args.objectKey, args.sizeBytes);
+  await markState(db, args.objectKey, commit.verified ? "verified" : "failed");
+
+  const row = await getFile(db, args.id);
+  return {
+    id: args.id,
+    objectKey: args.objectKey,
+    sha256: row?.sha256 ?? "",
+    sizeBytes: args.sizeBytes,
+    deduped: false,
+    verified: commit.verified,
+  };
+}
+
+/** Persist GCS's committed offset so a crash resumes rather than restarts. */
+async function recordProgress(
+  db: FilesDb,
+  objectKey: string,
+  bytesUploaded: number,
+): Promise<void> {
+  await db.run(
+    `UPDATE app_files SET bytes_uploaded = ?, updated_at = ? WHERE object_key = ?`,
+    [bytesUploaded, Date.now(), objectKey],
+  );
 }
 
 /**
@@ -74,7 +313,7 @@ export async function addFile(
 ): Promise<AddFileResult> {
   const info = await stat(args.filePath);
   const sizeBytes = info.size;
-  const sha256 = await hashFile(args.filePath);
+  const sha256 = await hashFileCached(db, args.filePath, info);
   const fileName = args.fileName ?? basename(args.filePath);
   const scope = args.scope ?? "app";
 
@@ -121,6 +360,17 @@ export async function addFile(
     throw new Error("Server returned no upload URL for a new object");
   }
 
+  // Persist the session URI *before* sending a byte. If the process dies
+  // mid-upload, this row is the only thing that makes the difference between
+  // resuming at 9 GB and re-sending 10.
+  await db.run(
+    `UPDATE app_files
+        SET upload_session_uri = ?, session_expires_at = ?, bytes_uploaded = 0,
+            updated_at = ?
+      WHERE object_key = ?`,
+    [ticket.upload_url, now + SESSION_TTL_MS, now, ticket.object_key],
+  );
+
   try {
     await uploadResumable({
       sessionUrl: ticket.upload_url,
@@ -128,8 +378,12 @@ export async function addFile(
       totalBytes: sizeBytes,
       onProgress: args.onProgress,
       signal: args.signal,
+      onOffsetCommitted: (offset) =>
+        recordProgress(db, ticket.object_key, offset),
     });
   } catch (err) {
+    // 'failed' is a resumable state, not a dead end: the session URI stays on
+    // the row so resumeUpload() can pick it up for the next 7 days.
     await markState(db, ticket.object_key, "failed");
     throw err;
   }
@@ -156,6 +410,18 @@ async function markState(
   objectKey: string,
   state: AppFileRow["upload_state"],
 ): Promise<void> {
+  // Drop the session URI once verified: it is spent, and leaving it on the row
+  // invites a pointless resume attempt against a finished object.
+  if (state === "verified") {
+    await db.run(
+      `UPDATE app_files
+          SET upload_state = ?, upload_session_uri = NULL,
+              session_expires_at = NULL, updated_at = ?
+        WHERE object_key = ?`,
+      [state, Date.now(), objectKey],
+    );
+    return;
+  }
   await db.run(
     `UPDATE app_files SET upload_state = ?, updated_at = ? WHERE object_key = ?`,
     [state, Date.now(), objectKey],

--- a/src/gateway/services/appFiles/AppFilesService.ts
+++ b/src/gateway/services/appFiles/AppFilesService.ts
@@ -25,6 +25,7 @@ import {
   resolveLocation,
   type AppFileRow,
   type FileLocation,
+  type FileVisibility,
 } from "./appFilesSchema.js";
 import { hashFile, uploadResumable, type UploadProgress } from "./resumableUploader.js";
 import {
@@ -284,6 +285,27 @@ export async function commitBrowserUpload(
     deduped: false,
     verified: commit.verified,
   };
+}
+
+/**
+ * Set the "never publish me" flag on a file.
+ *
+ * Only touches the local column; it does not call the storage API. Publishing
+ * reads this flag and skips the object, so a private file is never made
+ * CDN-public in the first place — which is stronger than making it public and
+ * relying on a later call to undo that.
+ */
+export async function setFilePrivacy(
+  db: FilesDb,
+  id: string,
+  isPrivate: boolean,
+): Promise<{ id: string; visibility: FileVisibility }> {
+  const visibility: FileVisibility = isPrivate ? "private" : "inherit";
+  await db.run(
+    `UPDATE app_files SET visibility = ?, updated_at = ? WHERE id = ?`,
+    [visibility, Date.now(), id],
+  );
+  return { id, visibility };
 }
 
 /** Persist GCS's committed offset so a crash resumes rather than restarts. */

--- a/src/gateway/services/appFiles/appFilesRoutes.ts
+++ b/src/gateway/services/appFiles/appFilesRoutes.ts
@@ -17,6 +17,7 @@ import {
   listFiles,
   removeFile,
   resolveFileUrl,
+  setFilePrivacy,
   evictLocal,
   type FilesDb,
 } from "./AppFilesService.js";
@@ -273,6 +274,37 @@ export function registerAppFilesRoutes(
       }
       const db = await dbFor(resolved.appId, sourceId, deps);
       res.json({ deleted: await removeFile(db, id) });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  /**
+   * Mark a file "never publish me", or undo that.
+   *
+   * The meeting-recording guarantee, as a single switch. Publishing reads this
+   * flag and skips the object entirely, so a private file is never made
+   * CDN-public rather than being made public and un-made later.
+   */
+  app.post("/api/files/visibility", async (req, res) => {
+    try {
+      const { appId, sourceId, id, isPrivate } = req.body as {
+        appId?: string;
+        sourceId?: string;
+        id?: string;
+        isPrivate?: boolean;
+      };
+      if (!id || typeof isPrivate !== "boolean") {
+        res.status(400).json({ error: "id and isPrivate are required" });
+        return;
+      }
+      const resolved = resolveMiniAppIdFromRequest(appId, req.headers);
+      if (!resolved.appId) {
+        res.status(resolved.status ?? 400).json({ error: resolved.error });
+        return;
+      }
+      const db = await dbFor(resolved.appId, sourceId, deps);
+      res.json(await setFilePrivacy(db, id, isPrivate));
     } catch (err) {
       fail(res, err);
     }

--- a/src/gateway/services/appFiles/appFilesRoutes.ts
+++ b/src/gateway/services/appFiles/appFilesRoutes.ts
@@ -11,6 +11,8 @@ import type { Express } from "express";
 
 import {
   addFile,
+  commitBrowserUpload,
+  createBrowserTicket,
   ensureSchema,
   listFiles,
   removeFile,
@@ -19,6 +21,7 @@ import {
   type FilesDb,
 } from "./AppFilesService.js";
 import { appUsage } from "./appFilesClient.js";
+import { resolveMiniAppIdFromRequest } from "../../utils/inferMiniAppIdFromRequest.js";
 
 /** Minimal shape of the pieces index.ts already has wired up. */
 export interface AppFilesRouteDeps {
@@ -123,6 +126,92 @@ export function registerAppFilesRoutes(
     }
   });
 
+  /**
+   * Mint a ticket so the browser can PUT bytes straight to object storage.
+   *
+   * The bytes deliberately do not come through here. Relaying a 10 GB upload
+   * would cost the gateway memory or disk proportional to the file and double
+   * the bandwidth — the mistake this whole design exists to avoid.
+   */
+  app.post("/api/files/ticket", async (req, res) => {
+    try {
+      const { appId, sourceId, fileName, sizeBytes, mime, scope, fingerprint } =
+        req.body as {
+          appId?: string;
+          sourceId?: string;
+          fileName?: string;
+          sizeBytes?: number;
+          mime?: string | null;
+          scope?: "app" | "user";
+          fingerprint?: string;
+        };
+
+      const resolved = resolveMiniAppIdFromRequest(appId, req.headers);
+      if (!resolved.appId) {
+        res.status(resolved.status ?? 400).json({ error: resolved.error });
+        return;
+      }
+      if (!fileName || typeof sizeBytes !== "number" || !fingerprint) {
+        res
+          .status(400)
+          .json({ error: "fileName, sizeBytes and fingerprint are required" });
+        return;
+      }
+
+      const db = await dbFor(resolved.appId, sourceId, deps);
+      await ensureSchema(db);
+      res.json(
+        await createBrowserTicket(db, {
+          appId: resolved.appId,
+          fileName,
+          sizeBytes,
+          mime,
+          scope,
+          fingerprint,
+        }),
+      );
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  /** Verify a browser upload once the bytes have landed in storage. */
+  app.post("/api/files/commit", async (req, res) => {
+    try {
+      const { appId, sourceId, id, objectKey, sizeBytes } = req.body as {
+        appId?: string;
+        sourceId?: string;
+        id?: string;
+        objectKey?: string;
+        sizeBytes?: number;
+      };
+
+      const resolved = resolveMiniAppIdFromRequest(appId, req.headers);
+      if (!resolved.appId) {
+        res.status(resolved.status ?? 400).json({ error: resolved.error });
+        return;
+      }
+      if (!id || !objectKey || typeof sizeBytes !== "number") {
+        res
+          .status(400)
+          .json({ error: "id, objectKey and sizeBytes are required" });
+        return;
+      }
+
+      const db = await dbFor(resolved.appId, sourceId, deps);
+      res.json(
+        await commitBrowserUpload(db, {
+          appId: resolved.appId,
+          id,
+          objectKey,
+          sizeBytes,
+        }),
+      );
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
   /** Resolve a file to a readable URL — local path or short-lived signed URL. */
   app.post("/api/files/url", async (req, res) => {
     try {
@@ -131,11 +220,18 @@ export function registerAppFilesRoutes(
         sourceId?: string;
         id?: string;
       };
-      if (!appId || !id) {
-        res.status(400).json({ error: "appId and id are required" });
+      if (!id) {
+        res.status(400).json({ error: "id is required" });
         return;
       }
-      const db = await dbFor(appId, sourceId, deps);
+      // appId is inferred from the requesting app when omitted, so mini-app
+      // code never has to hardcode its own UUID.
+      const resolved = resolveMiniAppIdFromRequest(appId, req.headers);
+      if (!resolved.appId) {
+        res.status(resolved.status ?? 400).json({ error: resolved.error });
+        return;
+      }
+      const db = await dbFor(resolved.appId, sourceId, deps);
       res.json(await resolveFileUrl(db, id));
     } catch (err) {
       fail(res, err);
@@ -146,13 +242,14 @@ export function registerAppFilesRoutes(
     try {
       const appId = req.query.appId as string | undefined;
       const sourceId = req.query.sourceId as string | undefined;
-      if (!appId) {
-        res.status(400).json({ error: "appId is required" });
+      const resolved = resolveMiniAppIdFromRequest(appId, req.headers);
+      if (!resolved.appId) {
+        res.status(resolved.status ?? 400).json({ error: resolved.error });
         return;
       }
-      const db = await dbFor(appId, sourceId, deps);
+      const db = await dbFor(resolved.appId, sourceId, deps);
       await ensureSchema(db);
-      res.json({ files: await listFiles(db, appId) });
+      res.json({ files: await listFiles(db, resolved.appId) });
     } catch (err) {
       fail(res, err);
     }
@@ -165,11 +262,16 @@ export function registerAppFilesRoutes(
         sourceId?: string;
         id?: string;
       };
-      if (!appId || !id) {
-        res.status(400).json({ error: "appId and id are required" });
+      if (!id) {
+        res.status(400).json({ error: "id is required" });
         return;
       }
-      const db = await dbFor(appId, sourceId, deps);
+      const resolved = resolveMiniAppIdFromRequest(appId, req.headers);
+      if (!resolved.appId) {
+        res.status(resolved.status ?? 400).json({ error: resolved.error });
+        return;
+      }
+      const db = await dbFor(resolved.appId, sourceId, deps);
       res.json({ deleted: await removeFile(db, id) });
     } catch (err) {
       fail(res, err);

--- a/src/gateway/services/appFiles/appFilesSchema.ts
+++ b/src/gateway/services/appFiles/appFilesSchema.ts
@@ -27,6 +27,19 @@ export interface AppFileRow {
   upload_state: UploadState;
   /** 'private' means "never publish me", even if the app goes public. */
   visibility: FileVisibility;
+  /**
+   * GCS resumable session URI for an upload in flight.
+   *
+   * Persisted rather than held in memory because that is the whole difference
+   * between "resumable" and actually resumable: a session survives a reboot,
+   * a closed laptop and a weekend, but only if we still know its address.
+   * Without this, a laptop dying at 9 GB of 10 means re-sending all 10.
+   */
+  upload_session_uri: string | null;
+  /** Bytes GCS confirmed committed. A hint for UI; GCS remains authoritative. */
+  bytes_uploaded: number;
+  /** Epoch ms after which the session URI is dead and must be re-minted. */
+  session_expires_at: number | null;
   created_at: number;
   updated_at: number;
 }
@@ -44,13 +57,49 @@ CREATE TABLE IF NOT EXISTS app_files (
   local_path    TEXT,
   upload_state  TEXT NOT NULL DEFAULT 'pending',
   visibility    TEXT NOT NULL DEFAULT 'inherit',
+  upload_session_uri TEXT,
+  bytes_uploaded     INTEGER NOT NULL DEFAULT 0,
+  session_expires_at INTEGER,
   created_at    INTEGER NOT NULL,
   updated_at    INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_app_files_sha ON app_files(sha256);
 CREATE INDEX IF NOT EXISTS idx_app_files_state ON app_files(upload_state);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_app_files_key ON app_files(object_key);
+
+/*
+ * Hashing 10 GB takes minutes and spins fans. After a crash we would otherwise
+ * pay it again just to learn the same answer, so cache by the three things
+ * that change when a file's content changes.
+ */
+CREATE TABLE IF NOT EXISTS app_file_hashes (
+  local_path  TEXT PRIMARY KEY,
+  size_bytes  INTEGER NOT NULL,
+  mtime_ms    INTEGER NOT NULL,
+  sha256      TEXT NOT NULL,
+  updated_at  INTEGER NOT NULL
+);
 `;
+
+/**
+ * Columns added after the table shipped.
+ *
+ * SQLite has no `ADD COLUMN IF NOT EXISTS`, and existing installs already have
+ * `app_files`, so `CREATE TABLE IF NOT EXISTS` alone would silently leave them
+ * on the old shape. Each statement is run individually and its "duplicate
+ * column" error ignored — the only safe way to be idempotent here.
+ */
+export const APP_FILES_MIGRATIONS: readonly string[] = [
+  `ALTER TABLE app_files ADD COLUMN upload_session_uri TEXT`,
+  `ALTER TABLE app_files ADD COLUMN bytes_uploaded INTEGER NOT NULL DEFAULT 0`,
+  `ALTER TABLE app_files ADD COLUMN session_expires_at INTEGER`,
+];
+
+/** True when an ALTER failed only because the column was already there. */
+export function isDuplicateColumnError(err: unknown): boolean {
+  const message = (err as Error)?.message ?? "";
+  return /duplicate column name/i.test(message);
+}
 
 /**
  * Where a file's bytes can be read from right now.

--- a/src/gateway/services/appFiles/cloudFileUrl.ts
+++ b/src/gateway/services/appFiles/cloudFileUrl.ts
@@ -1,0 +1,138 @@
+/**
+ * Decides what URL — if any — a cloud visitor may have for an App Files row.
+ *
+ * The desktop answers `/api/files/url` from `resolveFileUrl`, which may hand
+ * back a local path. The cloud runtime has no filesystem, so it needs its own
+ * answer: CDN for published objects, a short-lived signed URL for everything
+ * else the caller is actually entitled to.
+ *
+ * This is the whole security surface of serving files on apps.papr.ai, so it is
+ * pure and decided in one place. Acting on the decision (minting the signature)
+ * is the caller's job and is deliberately trivial.
+ *
+ * Four rules, in order. Order matters: each one assumes the ones above it have
+ * already rejected.
+ */
+
+import type { AppFileRow } from "./appFilesSchema.js";
+
+export type CloudUrlDecision =
+  /** Object is CDN-public. Serve the permanent URL, no signing round-trip. */
+  | { kind: "cdn"; objectKey: string }
+  /** Caller is entitled but the object is not public — mint a signed read. */
+  | { kind: "signed"; appId: string; objectKey: string }
+  /** Refuse. `status` is what the handler should return. */
+  | { kind: "deny"; status: 403 | 404; reason: string };
+
+export interface CloudUrlRequest {
+  /** The app the request arrived on — from the session, never from the body. */
+  requestedAppId: string;
+  /** Whether the resolved access context can read this app at all. */
+  canRead: boolean;
+  /** Authenticated user, or null for a logged-out visitor on a public app. */
+  userId: string | null;
+  /** True once the app's objects have been flipped CDN-public by publish. */
+  isPublished: boolean;
+}
+
+/**
+ * Decide how (or whether) to serve one file to one caller.
+ *
+ * Returns `deny` with 404 rather than 403 when revealing existence would leak
+ * something: a cross-app probe should not be able to tell a real id from a
+ * fake one.
+ */
+export function resolveCloudFileUrl(
+  row: AppFileRow | null,
+  req: CloudUrlRequest,
+): CloudUrlDecision {
+  // 1. Existence and ownership. Checked together and answered identically, so
+  //    that "wrong app" and "no such file" are indistinguishable from outside.
+  if (!row || row.app_id !== req.requestedAppId) {
+    return { kind: "deny", status: 404, reason: "File not found" };
+  }
+
+  // 2. The cloud has no local disk. An unverified row means the bytes only ever
+  //    existed on someone's laptop, so there is nothing to serve — even though
+  //    the same row resolves fine on the desktop.
+  if (row.upload_state !== "verified") {
+    return {
+      kind: "deny",
+      status: 404,
+      reason: "File is not available in the cloud",
+    };
+  }
+
+  // 3. User-scoped files belong to their uploader, not to the app's audience.
+  //    A public app must never widen them, so this is checked before the
+  //    published/public shortcut below rather than after it.
+  //
+  //    Scope comes from the key, not the column: the key is written server-side
+  //    from the session, whereas the column travels through Turso sync and a
+  //    desktop write path. If they ever disagree, the key is right. Mirrors
+  //    `scope_of_key`.
+  if (isUserScopedKey(row) || row.scope === "user") {
+    if (!req.userId || req.userId !== extractOwnerId(row)) {
+      return {
+        kind: "deny",
+        status: 403,
+        reason: "This file is private to the person who uploaded it",
+      };
+    }
+    return { kind: "signed", appId: row.app_id, objectKey: row.object_key };
+  }
+
+  // 4. `visibility: 'private'` is the meeting-recording guarantee: opted out of
+  //    publishing entirely, so it is never CDN-served regardless of how public
+  //    the app is. Entitled callers still get a signed URL.
+  if (row.visibility === "private") {
+    if (!req.canRead) {
+      return { kind: "deny", status: 403, reason: "Not authorized" };
+    }
+    return { kind: "signed", appId: row.app_id, objectKey: row.object_key };
+  }
+
+  // Published app-scoped object: publish already flipped it CDN-public, so the
+  // permanent URL works for logged-out visitors with no round-trip.
+  if (req.isPublished) {
+    return { kind: "cdn", objectKey: row.object_key };
+  }
+
+  // Not published yet (preview, or an unpublished app). Readers still get in,
+  // via a signed URL rather than a CDN one.
+  if (!req.canRead) {
+    return { kind: "deny", status: 403, reason: "Not authorized" };
+  }
+  return { kind: "signed", appId: row.app_id, objectKey: row.object_key };
+}
+
+/**
+ * Owner of a user-scoped object, read back out of its key.
+ *
+ * Mirrors `build_object_key` on the memory server, which derives keys from the
+ * authenticated session as:
+ *
+ *   namespaces/{ns}/apps/{app}/users/{userId}/files/{sha256}   (scope=user)
+ *   namespaces/{ns}/apps/{app}/files/{sha256}                  (scope=app)
+ *
+ * The key is the authoritative record of ownership — it is written server-side
+ * from the session, so it is more trustworthy than any column a desktop client
+ * could have set. Returns null for an unrecognised shape, which the caller
+ * treats as "deny", matching `scope_of_key`'s bias toward the restrictive
+ * answer when a key cannot be parsed.
+ */
+function extractOwnerId(row: AppFileRow): string | null {
+  const match = /\/users\/([^/]+)\/files\//.exec(row.object_key);
+  return match?.[1] ?? null;
+}
+
+/** True when the key says user-scoped, whatever the row's column claims. */
+function isUserScopedKey(row: AppFileRow): boolean {
+  return row.object_key.includes("/users/");
+}
+
+/** Public URL for a CDN-readable object. Mirrors `cdn_url()` server-side. */
+export function buildCdnUrl(objectKey: string, cdnHost?: string): string {
+  const host = cdnHost || process.env.APP_FILES_CDN_HOST || "files.papr.ai";
+  return `https://${host}/${objectKey}`;
+}

--- a/src/gateway/services/appFiles/resumableUploader.ts
+++ b/src/gateway/services/appFiles/resumableUploader.ts
@@ -19,6 +19,16 @@ import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { open, stat } from "node:fs/promises";
 
+import {
+  DEFAULT_RETRY,
+  backoffDelayMs,
+  shouldRetry,
+  type RetryPolicy,
+} from "./uploadResume.js";
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 /** GCS requires multiples of 256 KiB; 8 MiB balances throughput and retries. */
 export const CHUNK_SIZE = 8 * 1024 * 1024;
 
@@ -37,6 +47,14 @@ export interface UploadOptions {
   onProgress?: (p: UploadProgress) => void;
   signal?: AbortSignal;
   fetchImpl?: typeof fetch;
+  /** Overridable so tests do not actually sleep through the backoff. */
+  sleepImpl?: (ms: number) => Promise<void>;
+  retryPolicy?: RetryPolicy;
+  /**
+   * Called whenever GCS confirms a new committed offset, so the caller can
+   * persist it. This is what makes a crash cost seconds instead of gigabytes.
+   */
+  onOffsetCommitted?: (offset: number) => void | Promise<void>;
 }
 
 /**
@@ -105,6 +123,79 @@ async function readChunk(
   }
 }
 
+interface ChunkDeps {
+  fetchImpl: typeof fetch;
+  sleep: (ms: number) => Promise<void>;
+  policy: RetryPolicy;
+}
+
+interface ChunkOutcome {
+  /** GCS finalised the object — 200/201 rather than another 308. */
+  complete: boolean;
+  /** Bytes GCS says it has committed so far. */
+  committed: number;
+}
+
+/**
+ * PUT one chunk, retrying transient failures with backoff.
+ *
+ * A dropped connection throws rather than returning a status, so both paths
+ * have to funnel into the same decision — otherwise the most common failure on
+ * a flaky link (no response at all) would be the one case we do not retry.
+ */
+async function sendChunkWithRetry(
+  opts: UploadOptions,
+  chunk: Buffer,
+  offset: number,
+  total: number,
+  deps: ChunkDeps,
+): Promise<ChunkOutcome> {
+  let attempt = 0;
+
+  for (;;) {
+    attempt += 1;
+    let status: number | null = null;
+
+    try {
+      const res = await deps.fetchImpl(opts.sessionUrl, {
+        method: "PUT",
+        body: new Uint8Array(chunk),
+        headers: {
+          "Content-Length": String(chunk.length),
+          "Content-Range": `bytes ${offset}-${offset + chunk.length - 1}/${total}`,
+        },
+        signal: opts.signal,
+      });
+      status = res.status;
+
+      if (res.status === 200 || res.status === 201) {
+        return { complete: true, committed: total };
+      }
+      if (res.status === 308) {
+        return {
+          complete: false,
+          committed: parseCommittedOffset(res.headers.get("Range")),
+        };
+      }
+
+      if (!shouldRetry(attempt, res.status, deps.policy)) {
+        const text = await res.text().catch(() => "");
+        throw new Error(
+          `Upload chunk failed (${res.status}) at offset ${offset}: ${text.slice(0, 200)}`,
+        );
+      }
+    } catch (err) {
+      // An aborted upload is a decision, not a failure — never retry it.
+      if (opts.signal?.aborted) throw err;
+      // A thrown error with a status we already judged unretryable is final.
+      if (status !== null && !shouldRetry(attempt, status, deps.policy)) throw err;
+      if (!shouldRetry(attempt, null, deps.policy)) throw err;
+    }
+
+    await deps.sleep(backoffDelayMs(attempt, deps.policy));
+  }
+}
+
 /**
  * Upload a file to an existing session URI, resuming from wherever GCS is.
  *
@@ -114,6 +205,8 @@ async function readChunk(
  */
 export async function uploadResumable(opts: UploadOptions): Promise<number> {
   const fetchImpl = opts.fetchImpl ?? fetch;
+  const sleep = opts.sleepImpl ?? defaultSleep;
+  const policy = opts.retryPolicy ?? DEFAULT_RETRY;
   const total = opts.totalBytes;
 
   let offset = await probeOffset(opts.sessionUrl, total, fetchImpl);
@@ -130,31 +223,23 @@ export async function uploadResumable(opts: UploadOptions): Promise<number> {
     const end = Math.min(offset + CHUNK_SIZE, total);
     const chunk = await readChunk(opts.filePath, offset, end - offset);
 
-    const res = await fetchImpl(opts.sessionUrl, {
-      method: "PUT",
-      body: new Uint8Array(chunk),
-      headers: {
-        "Content-Length": String(chunk.length),
-        "Content-Range": `bytes ${offset}-${offset + chunk.length - 1}/${total}`,
-      },
-      signal: opts.signal,
+    // Retry the chunk, never the file. On a 10 GB upload a transient 503 at
+    // 9 GB must cost one 8 MiB chunk, not the whole transfer.
+    const outcome = await sendChunkWithRetry(opts, chunk, offset, total, {
+      fetchImpl,
+      sleep,
+      policy,
     });
 
-    if (res.status === 200 || res.status === 201) {
+    if (outcome.complete) {
       offset = total;
+      await opts.onOffsetCommitted?.(offset);
       break;
     }
-    if (res.status === 308) {
-      // Trust GCS's committed offset rather than assuming the whole chunk
-      // landed — a partially accepted chunk would otherwise leave a gap.
-      const committed = parseCommittedOffset(res.headers.get("Range"));
-      offset = committed > offset ? committed : end;
-    } else {
-      const text = await res.text().catch(() => "");
-      throw new Error(
-        `Upload chunk failed (${res.status}) at offset ${offset}: ${text.slice(0, 200)}`,
-      );
-    }
+    // Trust GCS's committed offset rather than assuming the whole chunk
+    // landed — a partially accepted chunk would otherwise leave a gap.
+    offset = outcome.committed > offset ? outcome.committed : end;
+    await opts.onOffsetCommitted?.(offset);
 
     if (opts.onProgress) {
       const elapsed = (Date.now() - startedAt) / 1000;

--- a/src/gateway/services/appFiles/uploadResume.ts
+++ b/src/gateway/services/appFiles/uploadResume.ts
@@ -1,0 +1,149 @@
+/**
+ * Durability decisions for large uploads.
+ *
+ * A 10 GB recording will meet a closed laptop, a dropped VPN and a GCS 503
+ * before it finishes. None of those should cost the user 10 GB of re-transfer,
+ * and none should cost a second pass of hashing.
+ *
+ * Everything here is pure. The decisions are the risky part — "is this session
+ * still usable", "should we retry this failure" — so they are separated from
+ * the acting and tested directly.
+ */
+
+/** GCS keeps a resumable session alive for 7 days. */
+export const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Re-mint a session with this much life left rather than risk it dying
+ * mid-upload. A 10 GB upload on a slow link can run for hours.
+ */
+export const SESSION_MIN_REMAINING_MS = 60 * 60 * 1000;
+
+export interface ResumeCandidate {
+  upload_session_uri: string | null;
+  session_expires_at: number | null;
+  upload_state: string;
+  size_bytes: number;
+}
+
+export type ResumePlan =
+  /** Reuse the stored session; probe GCS for the true offset before sending. */
+  | { kind: "resume"; sessionUri: string }
+  /** No usable session — request a fresh ticket and start over. */
+  | { kind: "restart"; reason: string }
+  /** Already done; do nothing. */
+  | { kind: "done" };
+
+/**
+ * Decide whether an interrupted upload can pick up where it left off.
+ *
+ * Deliberately conservative: a wrong "resume" wastes a round-trip and then
+ * fails confusingly, whereas a wrong "restart" only costs bandwidth we were
+ * prepared to spend anyway.
+ */
+export function planResume(
+  row: ResumeCandidate,
+  now: number = Date.now(),
+): ResumePlan {
+  if (row.upload_state === "verified") return { kind: "done" };
+
+  if (!row.upload_session_uri) {
+    return { kind: "restart", reason: "no stored upload session" };
+  }
+
+  if (row.session_expires_at === null) {
+    // A session we cannot date is a session we cannot trust to outlive the
+    // upload. Treating it as expired is the cheap, safe answer.
+    return { kind: "restart", reason: "session has no recorded expiry" };
+  }
+
+  const remaining = row.session_expires_at - now;
+  if (remaining <= 0) {
+    return { kind: "restart", reason: "upload session expired" };
+  }
+  if (remaining < SESSION_MIN_REMAINING_MS) {
+    // Starting a multi-hour upload on a session with minutes left just moves
+    // the failure to the worst possible moment: near the end.
+    return { kind: "restart", reason: "upload session expires too soon" };
+  }
+
+  return { kind: "resume", sessionUri: row.upload_session_uri };
+}
+
+/** Transient failures worth retrying; anything else is a real error. */
+const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+
+export interface RetryPolicy {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export const DEFAULT_RETRY: RetryPolicy = {
+  maxAttempts: 6,
+  baseDelayMs: 1000,
+  maxDelayMs: 60_000,
+};
+
+export function isRetryableStatus(status: number): boolean {
+  return RETRYABLE_STATUSES.has(status);
+}
+
+/**
+ * Delay before attempt N, exponential with full jitter.
+ *
+ * Jitter matters more than it looks: without it, every chunk of every
+ * concurrent upload retries on the same schedule and hammers GCS in waves
+ * exactly when it is already struggling.
+ *
+ * `random` is injectable so the tests can assert bounds rather than guess.
+ */
+export function backoffDelayMs(
+  attempt: number,
+  policy: RetryPolicy = DEFAULT_RETRY,
+  random: () => number = Math.random,
+): number {
+  const exponential = Math.min(
+    policy.maxDelayMs,
+    policy.baseDelayMs * 2 ** Math.max(0, attempt - 1),
+  );
+  return Math.round(exponential * random());
+}
+
+/** Should this attempt be retried, given the policy and what went wrong? */
+export function shouldRetry(
+  attempt: number,
+  status: number | null,
+  policy: RetryPolicy = DEFAULT_RETRY,
+): boolean {
+  if (attempt >= policy.maxAttempts) return false;
+  // A null status means the request never got an answer — a dropped
+  // connection. That is the most retryable failure there is.
+  if (status === null) return true;
+  return isRetryableStatus(status);
+}
+
+export interface CachedHash {
+  size_bytes: number;
+  mtime_ms: number;
+  sha256: string;
+}
+
+/**
+ * Is a cached hash still valid for this file?
+ *
+ * Size plus mtime is the standard cheap proxy for "unchanged". It can be
+ * fooled by a same-size edit within the mtime resolution, which is why this is
+ * only ever an optimisation: the server verifies the stored object's size and
+ * MD5 at commit time regardless.
+ */
+export function isHashCacheValid(
+  cached: CachedHash | null | undefined,
+  actual: { size: number; mtimeMs: number },
+): boolean {
+  if (!cached) return false;
+  return (
+    cached.size_bytes === actual.size &&
+    Math.floor(cached.mtime_ms) === Math.floor(actual.mtimeMs)
+  );
+}

--- a/src/gateway/services/appRuntime/CloudAppHostService.ts
+++ b/src/gateway/services/appRuntime/CloudAppHostService.ts
@@ -11,6 +11,7 @@ import type {
   AppRuntimeRouteAuth,
   TursoCredentialsProvider,
 } from "./types.js";
+import type { AppFileRow } from "../appFiles/appFilesSchema.js";
 import { TursoDbAdapter } from "./TursoDbAdapter.js";
 import { getJobEventHub } from "../JobEventHub.js";
 import { publishDbChanged } from "../../utils/publishJobRunEvents.js";
@@ -283,6 +284,10 @@ export class CloudAppHostService {
     app.post("/api/credentials/client-keys", (req, res) =>
       void this.handleClientKeys(req, res),
     );
+    // Same path and body as the desktop gateway, so `papr.files.url(id)` is one
+    // call that works in both runtimes. Without this a published app that
+    // references a file 404s on apps.papr.ai.
+    app.post("/api/files/url", (req, res) => void this.handleFileUrl(req, res));
 
     app.get("/:namespaceId/:slug/__papr__/app-revision.json", (req, res) => {
       if (isReservedCloudPathSegment(req.params.namespaceId)) {
@@ -493,6 +498,84 @@ export class CloudAppHostService {
       res.status(403).send("Forbidden");
     } else {
       res.status(403).json({ error: "Forbidden" });
+    }
+  }
+
+  /**
+   * POST /api/files/url — resolve one App Files id to a URL a browser can use.
+   *
+   * Mirrors the desktop route so mini-app code is identical in both runtimes.
+   * The difference is what can be returned: the desktop may hand back a local
+   * path, whereas the cloud has no filesystem and must answer with a CDN URL
+   * (published, app-scoped) or a short-lived signed URL (everything else).
+   *
+   * All of the judgement lives in `resolveCloudFileUrl`, which is pure and
+   * tested exhaustively; this method only fetches the row and acts.
+   */
+  private async handleFileUrl(req: Request, res: Response): Promise<void> {
+    try {
+      const { appId: requestedAppId, sourceId, id } = req.body as {
+        appId?: string;
+        sourceId?: string;
+        id?: string;
+      };
+      if (!id) {
+        res.status(400).json({ error: "id is required" });
+        return;
+      }
+
+      if (!this.enforceDbRateLimit(req, res, "read")) return;
+
+      const ctx = await this.resolveDbAppContext(req, res, requestedAppId);
+      if (!ctx) return;
+      const { runtimeAuth, access, appId } = ctx;
+
+      const config = await this.loadDataSources(runtimeAuth);
+      const result = await this.turso.query({
+        orgId: access.orgId,
+        namespaceId: access.namespaceId,
+        userId: access.userId,
+        runtimeAuth,
+        config,
+        sourceId,
+        sql: "SELECT * FROM app_files WHERE id = ? LIMIT 1",
+        params: [id],
+      });
+
+      // Turso hands back untyped rows; app_files is our own schema, so the
+      // shape is known even though the adapter cannot express it.
+      const row = (result?.rows?.[0] ?? null) as unknown as AppFileRow | null;
+      const { resolveCloudFileUrl, buildCdnUrl } = await import(
+        "../appFiles/cloudFileUrl.js"
+      );
+
+      const decision = resolveCloudFileUrl(row, {
+        requestedAppId: appId,
+        canRead: access.canRead,
+        // A logged-out visitor on a public app has no user identity. Normalise
+        // to null so ownership comparisons cannot accidentally match "".
+        userId: access.userId || null,
+        isPublished: true,
+      });
+
+      if (decision.kind === "deny") {
+        res.status(decision.status).json({ error: decision.reason });
+        return;
+      }
+
+      if (decision.kind === "cdn") {
+        res.json({
+          location: { kind: "cloud" },
+          url: buildCdnUrl(decision.objectKey),
+        });
+        return;
+      }
+
+      const { createReadUrl } = await import("../appFiles/appFilesClient.js");
+      const { url } = await createReadUrl(decision.appId, decision.objectKey);
+      res.json({ location: { kind: "cloud" }, url });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
     }
   }
 

--- a/src/gateway/services/appRuntime/CloudAppHostService.ts
+++ b/src/gateway/services/appRuntime/CloudAppHostService.ts
@@ -288,6 +288,7 @@ export class CloudAppHostService {
     // call that works in both runtimes. Without this a published app that
     // references a file 404s on apps.papr.ai.
     app.post("/api/files/url", (req, res) => void this.handleFileUrl(req, res));
+    app.get("/api/files", (req, res) => void this.handleFileList(req, res));
 
     app.get("/:namespaceId/:slug/__papr__/app-revision.json", (req, res) => {
       if (isReservedCloudPathSegment(req.params.namespaceId)) {
@@ -574,6 +575,55 @@ export class CloudAppHostService {
       const { createReadUrl } = await import("../appFiles/appFilesClient.js");
       const { url } = await createReadUrl(decision.appId, decision.objectKey);
       res.json({ location: { kind: "cloud" }, url });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  }
+
+  /**
+   * GET /api/files — list this app's files.
+   *
+   * Read-only on purpose. Uploading from a published cloud app would need the
+   * visitor to hold write access to the owner's storage, which is a different
+   * trust decision than viewing published assets; until that is designed,
+   * cloud is read-only and the desktop remains the write path.
+   */
+  private async handleFileList(req: Request, res: Response): Promise<void> {
+    try {
+      const requestedAppId = req.query["appId"] as string | undefined;
+      const sourceId = req.query["sourceId"] as string | undefined;
+      if (!this.enforceDbRateLimit(req, res, "read")) return;
+
+      const ctx = await this.resolveDbAppContext(req, res, requestedAppId);
+      if (!ctx) return;
+      const { runtimeAuth, access, appId } = ctx;
+
+      if (!access.canRead) {
+        await this.respondAccessDenied(req, res, runtimeAuth);
+        return;
+      }
+
+      const config = await this.loadDataSources(runtimeAuth);
+      const result = await this.turso.query({
+        orgId: access.orgId,
+        namespaceId: access.namespaceId,
+        userId: access.userId,
+        runtimeAuth,
+        config,
+        sourceId,
+        sql: `SELECT * FROM app_files WHERE app_id = ? ORDER BY created_at DESC`,
+        params: [appId],
+      });
+
+      const rows = (result?.rows ?? []) as unknown as AppFileRow[];
+      // User-scoped files belong to their uploader — a listing must not reveal
+      // one visitor's files to another, even though both can reach the app.
+      const visible = rows.filter(
+        (row) =>
+          !row.object_key.includes("/users/") ||
+          (access.userId && row.object_key.includes(`/users/${access.userId}/`)),
+      );
+      res.json({ files: visible });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/src/gateway/utils/miniAppCloudCompatibility.ts
+++ b/src/gateway/utils/miniAppCloudCompatibility.ts
@@ -91,6 +91,17 @@ const APP_PATTERNS: PatternRule[] = [
     message: "Uses cloud-compatible /api/db/* endpoints.",
     remediation: "",
   },
+  {
+    // App Files resolve through the cloud host too, so referencing a large
+    // asset no longer makes an app desktop-only. Without this rule the scanner
+    // stays silent about file usage and an author cannot tell whether their
+    // 60 MB video will survive publishing.
+    category: "cloud-files",
+    severity: "info",
+    pattern: /['"`]\/api\/files(\/|['"`])/,
+    message: "Uses cloud-compatible App Files (/api/files/*).",
+    remediation: "",
+  },
 ];
 
 const JOB_PATTERNS: PatternRule[] = [
@@ -274,6 +285,11 @@ export function buildCloudCompatibilityReport(
 
   if (cloudDb) {
     cloudWorks.push("Dashboard and read-only data via /api/db/* on apps.papr.ai");
+  }
+  if (findings.some((f) => f.category === "cloud-files")) {
+    cloudWorks.push(
+      "Large files via App Files — published assets serve from CDN, private ones stay signed",
+    );
   }
   if (level === "cloud-ready") {
     cloudWorks.push("Core UI should work on apps.papr.ai without Paprwork desktop");

--- a/src/gateway/utils/registerPaprMiniAppSdkRoutes.ts
+++ b/src/gateway/utils/registerPaprMiniAppSdkRoutes.ts
@@ -49,4 +49,9 @@ export function registerPaprMiniAppSdkRoutes(app: Express): void {
   app.get("/__papr__/papr-agent-chat.js", (req, res) =>
     serveSdkFile("papr-agent-chat.ts", req, res),
   );
+  // Served from the same place in both runtimes, so `papr.files.*` is one
+  // import that behaves identically on desktop and apps.papr.ai.
+  app.get("/__papr__/papr-files.js", (req, res) =>
+    serveSdkFile("papr-files.ts", req, res),
+  );
 }

--- a/src/resources/mini-app-sdk/papr-files.ts
+++ b/src/resources/mini-app-sdk/papr-files.ts
@@ -1,0 +1,267 @@
+/**
+ * App Files for mini-apps — four calls, no buckets or chunks in sight.
+ *
+ *   import { papr } from '/__papr__/papr-files.js';
+ *
+ *   const { id } = await papr.files.upload(file, { onProgress: p => … });
+ *   const { url } = await papr.files.url(id);
+ *   const files   = await papr.files.list();
+ *   await papr.files.remove(id);
+ *
+ * Bytes go from the browser straight to object storage. They never pass
+ * through the gateway, which is what makes a 10 GB recording possible at all:
+ * a gateway relay would need memory or disk proportional to the file, and
+ * would double the bandwidth bill for every upload.
+ *
+ * `upload()` accepts a Blob or File. A File is just a Blob with a name, and
+ * neither holds bytes in memory — they are handles to data on disk, sliced
+ * lazily as the upload progresses.
+ */
+
+/** GCS requires chunks in multiples of 256 KiB (except the last). */
+const CHUNK_SIZE = 8 * 1024 * 1024;
+const RETRYABLE = new Set([408, 429, 500, 502, 503, 504]);
+const MAX_ATTEMPTS = 6;
+
+export interface FileProgress {
+  uploadedBytes: number;
+  totalBytes: number;
+  bytesPerSecond: number;
+  etaSeconds: number | null;
+}
+
+export interface UploadOptions {
+  name?: string;
+  mime?: string;
+  /** 'user' keeps the file private to the uploader, even on a public app. */
+  scope?: "app" | "user";
+  onProgress?: (p: FileProgress) => void;
+  signal?: AbortSignal;
+}
+
+export interface UploadResult {
+  id: string;
+  objectKey: string;
+  sha256: string;
+  sizeBytes: number;
+  /** True when the bytes already existed and nothing was transferred. */
+  deduped: boolean;
+  verified: boolean;
+}
+
+export interface AppFile {
+  id: string;
+  file_name: string;
+  size_bytes: number;
+  mime: string | null;
+  upload_state: "pending" | "uploading" | "verified" | "failed";
+  scope: "app" | "user";
+  created_at: number;
+}
+
+async function api<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(path, {
+    method: body === undefined ? "GET" : "POST",
+    headers: body === undefined ? {} : { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`App Files ${path} failed (${res.status}): ${detail.slice(0, 200)}`);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * SHA-256 of a Blob, hashed in chunks.
+ *
+ * WebCrypto has no streaming digest, so a full-file hash would need the whole
+ * blob in memory — fatal at 10 GB. Instead the server dedupes on the object
+ * key it derives itself; we send a cheap content fingerprint and let the
+ * server verify the real MD5 after the bytes land.
+ */
+async function fingerprint(blob: Blob): Promise<string> {
+  // Sample head, tail and size: enough to distinguish files cheaply without
+  // ever reading the middle of a multi-GB video.
+  const head = new Uint8Array(await blob.slice(0, 65536).arrayBuffer());
+  const tail = new Uint8Array(
+    await blob.slice(Math.max(0, blob.size - 65536)).arrayBuffer(),
+  );
+  const sizeTag = new TextEncoder().encode(String(blob.size));
+  const joined = new Uint8Array(head.length + tail.length + sizeTag.length);
+  joined.set(head, 0);
+  joined.set(tail, head.length);
+  joined.set(sizeTag, head.length + tail.length);
+  const digest = await crypto.subtle.digest("SHA-256", joined);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function parseCommitted(range: string | null): number {
+  if (!range) return 0;
+  const m = /bytes=\d+-(\d+)/.exec(range);
+  return m ? Number(m[1]) + 1 : 0;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+/** Exponential backoff with full jitter, so retries do not synchronise. */
+function backoff(attempt: number): number {
+  return Math.round(Math.min(60_000, 1000 * 2 ** (attempt - 1)) * Math.random());
+}
+
+/** Ask GCS how much it already has — the only authority on real progress. */
+async function probe(sessionUri: string, total: number): Promise<number> {
+  const res = await fetch(sessionUri, {
+    method: "PUT",
+    headers: { "Content-Range": `bytes */${total}` },
+  });
+  if (res.status === 200 || res.status === 201) return total;
+  return parseCommitted(res.headers.get("Range"));
+}
+
+/**
+ * PUT one slice, retrying transient failures.
+ *
+ * The slice is a lazy view onto the file — creating it reads nothing, so peak
+ * memory stays at one chunk regardless of whether the file is 8 MiB or 10 GB.
+ */
+async function putChunk(
+  sessionUri: string,
+  blob: Blob,
+  offset: number,
+  total: number,
+  signal?: AbortSignal,
+): Promise<{ done: boolean; committed: number }> {
+  const end = Math.min(offset + CHUNK_SIZE, total);
+  const slice = blob.slice(offset, end);
+
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      const res = await fetch(sessionUri, {
+        method: "PUT",
+        body: slice,
+        headers: { "Content-Range": `bytes ${offset}-${end - 1}/${total}` },
+        signal,
+      });
+      if (res.status === 200 || res.status === 201) {
+        return { done: true, committed: total };
+      }
+      if (res.status === 308) {
+        const committed = parseCommitted(res.headers.get("Range"));
+        return { done: false, committed: committed > offset ? committed : end };
+      }
+      if (!RETRYABLE.has(res.status) || attempt >= MAX_ATTEMPTS) {
+        throw new Error(`Upload failed (${res.status}) at byte ${offset}`);
+      }
+    } catch (err) {
+      // Aborting is a decision, not a failure — never retry through it.
+      if (signal?.aborted) throw err;
+      if (attempt >= MAX_ATTEMPTS) throw err;
+    }
+    await sleep(backoff(attempt));
+  }
+}
+
+export const papr = {
+  files: {
+    /**
+     * Store a Blob or File in App Files.
+     *
+     * Resumable and chunked: a dropped connection costs one chunk, not the
+     * whole transfer.
+     */
+    async upload(blob: Blob, options: UploadOptions = {}): Promise<UploadResult> {
+      const name =
+        options.name ?? (blob as File).name ?? `upload-${Date.now()}`;
+      const total = blob.size;
+
+      const ticket = await api<{
+        id: string;
+        objectKey: string;
+        uploadUrl: string | null;
+        alreadyExists: boolean;
+        sha256: string;
+      }>("/api/files/ticket", {
+        fileName: name,
+        sizeBytes: total,
+        mime: options.mime ?? blob.type ?? null,
+        scope: options.scope ?? "app",
+        fingerprint: await fingerprint(blob),
+      });
+
+      if (ticket.alreadyExists || !ticket.uploadUrl) {
+        return {
+          id: ticket.id,
+          objectKey: ticket.objectKey,
+          sha256: ticket.sha256,
+          sizeBytes: total,
+          deduped: true,
+          verified: true,
+        };
+      }
+
+      const startedAt = Date.now();
+      let offset = await probe(ticket.uploadUrl, total);
+
+      while (offset < total) {
+        if (options.signal?.aborted) throw new Error("Upload aborted");
+        const step = await putChunk(
+          ticket.uploadUrl,
+          blob,
+          offset,
+          total,
+          options.signal,
+        );
+        offset = step.done ? total : step.committed;
+
+        if (options.onProgress) {
+          const elapsed = (Date.now() - startedAt) / 1000;
+          const rate = elapsed > 0 ? offset / elapsed : 0;
+          options.onProgress({
+            uploadedBytes: offset,
+            totalBytes: total,
+            bytesPerSecond: rate,
+            etaSeconds: rate > 0 ? Math.round((total - offset) / rate) : null,
+          });
+        }
+      }
+
+      // The server verifies stored size and MD5 before trusting the bytes —
+      // the client's word is never enough to mark a file verified.
+      return api<UploadResult>("/api/files/commit", {
+        id: ticket.id,
+        objectKey: ticket.objectKey,
+        sizeBytes: total,
+      });
+    },
+
+    /** Resolve a file id to something a browser can load. */
+    async url(id: string): Promise<{ url: string; location: string }> {
+      const res = await api<{ url?: string; location: { kind: string; path?: string } }>(
+        "/api/files/url",
+        { id },
+      );
+      return {
+        url: res.url ?? res.location.path ?? "",
+        location: res.location.kind,
+      };
+    },
+
+    /** Every file this app can see. */
+    async list(): Promise<AppFile[]> {
+      const res = await api<{ files: AppFile[] }>("/api/files");
+      return res.files;
+    },
+
+    /** Forget a file. Removes the row and the stored object. */
+    async remove(id: string): Promise<boolean> {
+      const res = await api<{ deleted: boolean }>("/api/files/delete", { id });
+      return res.deleted;
+    },
+  },
+};
+
+export default papr;

--- a/tests/mini-app-cloud-compatibility.test.ts
+++ b/tests/mini-app-cloud-compatibility.test.ts
@@ -20,6 +20,24 @@ describe("scanMiniAppCloudCompatibility", () => {
     expect(report.requiresAcknowledgement).toBe(false);
   });
 
+  it("treats App Files as cloud-compatible, not desktop-only", () => {
+    // An app referencing a large asset used to have no signal here at all. The
+    // cloud host now serves /api/files/url, so file usage must not push an app
+    // toward desktop-only — and the author should be told it will work.
+    const files = new Map<string, string>([
+      [
+        "video.js",
+        `const r = await fetch('/api/files/url', {
+  method: 'POST',
+  body: JSON.stringify({ id }),
+});`,
+      ],
+    ]);
+    const report = buildCloudCompatibilityReport(scanMiniAppCloudCompatibility(files));
+    expect(report.level).toBe("cloud-ready");
+    expect(report.cloudWorks.join(" ")).toContain("App Files");
+  });
+
   it("flags localhost gateway as desktop-only", () => {
     const files = new Map<string, string>([
       [

--- a/tests/unit/backend/appFilesDurability.test.ts
+++ b/tests/unit/backend/appFilesDurability.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Durable-resume integration tests against a real SQLite database.
+ *
+ * The pure decisions are covered in uploadResume.test.ts. What matters here is
+ * that they survive contact with an actual schema — including a database
+ * created before durable resume existed.
+ */
+
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import {
+  ensureSchema,
+  hashFileCached,
+  type FilesDb,
+} from "../../../src/gateway/services/appFiles/AppFilesService.js";
+
+/** Adapter matching the FilesDb surface the service expects. */
+function makeDb(): { db: FilesDb; raw: Database.Database } {
+  const raw = new Database(":memory:");
+  const db: FilesDb = {
+    exec: (sql) => {
+      raw.exec(sql);
+    },
+    run: (sql, params = []) => {
+      const info = raw.prepare(sql).run(...(params as never[]));
+      return { changes: info.changes };
+    },
+    all: <T,>(sql: string, params: unknown[] = []) =>
+      raw.prepare(sql).all(...(params as never[])) as T[],
+  };
+  return { db, raw };
+}
+
+function columns(raw: Database.Database, table: string): string[] {
+  return (raw.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[])
+    .map((c) => c.name);
+}
+
+describe("ensureSchema", () => {
+  it("creates the durability columns on a fresh database", async () => {
+    const { db, raw } = makeDb();
+    await ensureSchema(db);
+
+    const cols = columns(raw, "app_files");
+    expect(cols).toContain("upload_session_uri");
+    expect(cols).toContain("bytes_uploaded");
+    expect(cols).toContain("session_expires_at");
+  });
+
+  it("migrates a database created before durable resume", async () => {
+    // The upgrade path that would otherwise break every existing install:
+    // CREATE TABLE IF NOT EXISTS is a no-op once the old table exists, so the
+    // new columns only appear if the ALTERs actually run.
+    const { db, raw } = makeDb();
+    raw.exec(`
+      CREATE TABLE app_files (
+        id TEXT PRIMARY KEY, app_id TEXT NOT NULL, object_key TEXT NOT NULL,
+        sha256 TEXT NOT NULL, size_bytes INTEGER NOT NULL, mime TEXT,
+        file_name TEXT NOT NULL, scope TEXT NOT NULL DEFAULT 'app',
+        local_path TEXT, upload_state TEXT NOT NULL DEFAULT 'pending',
+        visibility TEXT NOT NULL DEFAULT 'inherit',
+        created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+      );
+    `);
+    raw.prepare(
+      `INSERT INTO app_files VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    ).run("f1", "app", "k1", "sha", 10, null, "a.mp4", "app", null,
+      "verified", "inherit", 1, 1);
+
+    await ensureSchema(db);
+
+    expect(columns(raw, "app_files")).toContain("upload_session_uri");
+    // The existing row must survive the migration untouched.
+    const row = raw.prepare(`SELECT * FROM app_files WHERE id = 'f1'`).get() as {
+      upload_state: string;
+      bytes_uploaded: number;
+    };
+    expect(row.upload_state).toBe("verified");
+    expect(row.bytes_uploaded).toBe(0);
+  });
+
+  it("is idempotent across repeated calls", async () => {
+    // ensureSchema runs on every request; a second call must not throw
+    // "duplicate column name".
+    const { db } = makeDb();
+    await ensureSchema(db);
+    await expect(ensureSchema(db)).resolves.toBeUndefined();
+    await expect(ensureSchema(db)).resolves.toBeUndefined();
+  });
+});
+
+describe("hashFileCached", () => {
+  it("hashes once and reuses the result for an untouched file", async () => {
+    const { db, raw } = makeDb();
+    await ensureSchema(db);
+
+    const { mkdtemp, writeFile, stat, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = await mkdtemp(join(tmpdir(), "papr-hash-"));
+    const file = join(dir, "big.bin");
+    await writeFile(file, Buffer.alloc(4096, 3));
+    const info = await stat(file);
+
+    const first = await hashFileCached(db, file, info);
+    const second = await hashFileCached(db, file, info);
+
+    expect(second).toBe(first);
+    // One cached row, and the second call served from it rather than
+    // re-reading the file — the saving that matters at 10 GB.
+    const cached = raw
+      .prepare(`SELECT sha256 FROM app_file_hashes WHERE local_path = ?`)
+      .all(file) as { sha256: string }[];
+    expect(cached).toHaveLength(1);
+    expect(cached[0].sha256).toBe(first);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("rehashes when the file changed underneath us", async () => {
+    const { db } = makeDb();
+    await ensureSchema(db);
+
+    const { mkdtemp, writeFile, stat, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = await mkdtemp(join(tmpdir(), "papr-hash-"));
+    const file = join(dir, "big.bin");
+
+    await writeFile(file, Buffer.alloc(4096, 1));
+    const first = await hashFileCached(db, file, await stat(file));
+
+    await writeFile(file, Buffer.alloc(8192, 2));
+    const second = await hashFileCached(db, file, await stat(file));
+
+    expect(second).not.toBe(first);
+    await rm(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/unit/backend/appFilesEndToEnd.test.ts
+++ b/tests/unit/backend/appFilesEndToEnd.test.ts
@@ -1,0 +1,195 @@
+/**
+ * End-to-end: a real Express gateway, a real SQLite database, a fake GCS.
+ *
+ * The unit tests prove each piece. This proves they connect — a file goes in
+ * through the same routes a mini-app calls, the bytes land in storage, and the
+ * row comes back verified and resolvable.
+ *
+ * Only the memory server and GCS are faked; everything between the HTTP route
+ * and the database is the real code path.
+ */
+
+import Database from "better-sqlite3";
+import express from "express";
+import type { Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const CHUNK = 8 * 1024 * 1024;
+/** Two chunks plus change, so the multi-chunk path really runs. */
+const TOTAL = CHUNK * 2 + 1024;
+const OBJECT_KEY = "namespaces/ns-1/apps/app-1/files/" + "a".repeat(64);
+const APP_ID = "11111111-2222-4333-8444-555555555555";
+
+let server: Server;
+let baseUrl = "";
+let raw: Database.Database;
+/** Bytes the fake GCS has committed — the proof bytes actually moved. */
+let gcsCommitted = 0;
+
+beforeAll(async () => {
+  raw = new Database(":memory:");
+
+  // Fake the memory server: mint a ticket, verify a commit. No credentials,
+  // no network — the trust boundary is tested in Phase 1.
+  vi.doMock("../../../src/gateway/services/appFiles/appFilesClient.js", () => ({
+    requestUploadTicket: async () => ({
+      object_key: OBJECT_KEY,
+      upload_url: `${baseUrl}/__gcs__/session`,
+      already_exists: false,
+      scope: "app",
+      max_bytes: 100 * 1024 ** 3,
+    }),
+    commitUpload: async (_a: string, _k: string, size: number) => ({
+      verified: gcsCommitted === size,
+      object_key: OBJECT_KEY,
+      size_bytes: gcsCommitted,
+    }),
+    createReadUrl: async () => ({
+      url: "https://signed.example/obj?sig=abc",
+      expiresInSeconds: 900,
+    }),
+    deleteObject: async () => true,
+    appUsage: async () => ({ bytes: 0 }),
+  }));
+
+  const { registerAppFilesRoutes } = await import(
+    "../../../src/gateway/services/appFiles/appFilesRoutes.js"
+  );
+
+  const app = express();
+  app.use(express.json());
+
+  // Fake GCS resumable endpoint, honouring Content-Range like the real thing.
+  app.put("/__gcs__/session", (req, res) => {
+    const range = req.headers["content-range"] as string;
+    if (range?.startsWith("bytes */")) {
+      if (gcsCommitted === 0) return void res.status(308).end();
+      return void res
+        .setHeader("Range", `bytes=0-${gcsCommitted - 1}`)
+        .status(308)
+        .end();
+    }
+    const m = /bytes (\d+)-(\d+)\//.exec(range ?? "");
+    gcsCommitted = Number(m?.[2]) + 1;
+    if (gcsCommitted >= TOTAL) return void res.status(200).end();
+    res.setHeader("Range", `bytes=0-${gcsCommitted - 1}`).status(308).end();
+  });
+
+  // Wire the routes to the real SQLite database.
+  registerAppFilesRoutes(app, {
+    resolveSource: async () => ({}),
+    dbQuery: async (_app, _src, sql, params = []) => ({
+      rows: raw.prepare(sql).all(...(params as never[])) as unknown[],
+    }),
+    dbWrite: async (_app, _src, sql, params = []) => ({
+      changes: raw.prepare(sql).run(...(params as never[])).changes,
+    }),
+    dbExec: async (_app, _src, sql) => {
+      raw.exec(sql);
+    },
+  });
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      const addr = server.address();
+      baseUrl = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  raw.close();
+  vi.doUnmock("../../../src/gateway/services/appFiles/appFilesClient.js");
+});
+
+async function post(path: string, body: unknown): Promise<Response> {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("App Files end-to-end", () => {
+  let fileId = "";
+
+  it("mints a ticket and records the session for resume", async () => {
+    const res = await post("/api/files/ticket", {
+      appId: APP_ID,
+      fileName: "recording.mp4",
+      sizeBytes: TOTAL,
+      mime: "video/mp4",
+      fingerprint: "a".repeat(64),
+    });
+    expect(res.status).toBe(200);
+
+    const ticket = (await res.json()) as { id: string; uploadUrl: string };
+    fileId = ticket.id;
+    expect(ticket.uploadUrl).toContain("/__gcs__/session");
+
+    // The session URI must be on the row before any byte moves — this is what
+    // turns a dead laptop at 9 GB into a resume rather than a restart.
+    const row = raw
+      .prepare(`SELECT upload_session_uri, upload_state FROM app_files WHERE id = ?`)
+      .get(fileId) as { upload_session_uri: string; upload_state: string };
+    expect(row.upload_session_uri).toContain("/__gcs__/session");
+    expect(row.upload_state).toBe("uploading");
+  });
+
+  it("uploads the bytes straight to storage, chunked", async () => {
+    // Exactly what the browser SDK does: slice and PUT with Content-Range.
+    let offset = 0;
+    while (offset < TOTAL) {
+      const end = Math.min(offset + CHUNK, TOTAL);
+      const res = await fetch(`${baseUrl}/__gcs__/session`, {
+        method: "PUT",
+        body: new Uint8Array(end - offset),
+        headers: { "Content-Range": `bytes ${offset}-${end - 1}/${TOTAL}` },
+      });
+      expect([200, 308]).toContain(res.status);
+      offset = end;
+    }
+    expect(gcsCommitted).toBe(TOTAL);
+  });
+
+  it("verifies the upload server-side and marks the row verified", async () => {
+    const res = await post("/api/files/commit", {
+      appId: APP_ID,
+      id: fileId,
+      objectKey: OBJECT_KEY,
+      sizeBytes: TOTAL,
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).verified).toBe(true);
+
+    const row = raw
+      .prepare(`SELECT upload_state, upload_session_uri FROM app_files WHERE id = ?`)
+      .get(fileId) as { upload_state: string; upload_session_uri: string | null };
+    expect(row.upload_state).toBe("verified");
+    // Spent session cleared, so nothing tries to resume a finished object.
+    expect(row.upload_session_uri).toBeNull();
+  });
+
+  it("lists the file", async () => {
+    const res = await fetch(`${baseUrl}/api/files?appId=${APP_ID}`);
+    const body = (await res.json()) as { files: { id: string }[] };
+    expect(body.files.map((f) => f.id)).toContain(fileId);
+  });
+
+  it("resolves the file to a loadable URL", async () => {
+    const res = await post("/api/files/url", { appId: APP_ID, id: fileId });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url?: string; location: { kind: string } };
+    expect(body.location.kind).toBe("cloud");
+    expect(body.url).toContain("signed.example");
+  });
+
+  it("removes the file", async () => {
+    const res = await post("/api/files/delete", { appId: APP_ID, id: fileId });
+    expect((await res.json()).deleted).toBe(true);
+    const rows = raw.prepare(`SELECT id FROM app_files WHERE id = ?`).all(fileId);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/tests/unit/backend/cloudFileUrl.test.ts
+++ b/tests/unit/backend/cloudFileUrl.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the cloud file-URL decision.
+ *
+ * This is the authorization surface for serving App Files on apps.papr.ai, so
+ * the denial cases matter more than the happy path. Each test names the leak it
+ * prevents rather than the branch it covers.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildCdnUrl,
+  resolveCloudFileUrl,
+} from "../../../src/gateway/services/appFiles/cloudFileUrl.js";
+import type { AppFileRow } from "../../../src/gateway/services/appFiles/appFilesSchema.js";
+
+const NS = "ns-1";
+const APP = "app-1";
+const SHA = "a".repeat(64);
+
+function appRow(over: Partial<AppFileRow> = {}): AppFileRow {
+  return {
+    id: "file-1",
+    app_id: APP,
+    object_key: `namespaces/${NS}/apps/${APP}/files/${SHA}`,
+    sha256: SHA,
+    size_bytes: 1024,
+    mime: "video/mp4",
+    file_name: "demo.mp4",
+    scope: "app",
+    local_path: null,
+    upload_state: "verified",
+    visibility: "app",
+    created_at: 1,
+    updated_at: 1,
+    ...over,
+  } as AppFileRow;
+}
+
+function userRow(userId: string, over: Partial<AppFileRow> = {}): AppFileRow {
+  return appRow({
+    scope: "user",
+    object_key: `namespaces/${NS}/apps/${APP}/users/${userId}/files/${SHA}`,
+    ...over,
+  });
+}
+
+const visitor = {
+  requestedAppId: APP,
+  canRead: true,
+  userId: null,
+  isPublished: true,
+};
+
+describe("resolveCloudFileUrl", () => {
+  it("serves a published app file over CDN to a logged-out visitor", () => {
+    // The Phase 3 exit criterion: a 60 MB video must load for someone with no
+    // account, without a signing round-trip.
+    const d = resolveCloudFileUrl(appRow(), visitor);
+    expect(d.kind).toBe("cdn");
+  });
+
+  it("keeps a private file private even when the app is public", () => {
+    // The meeting-recording guarantee. A logged-out visitor gets nothing.
+    const d = resolveCloudFileUrl(appRow({ visibility: "private" }), {
+      ...visitor,
+      canRead: false,
+    });
+    expect(d).toMatchObject({ kind: "deny", status: 403 });
+  });
+
+  it("signs, never CDN-serves, a private file for an entitled reader", () => {
+    // Entitled readers still get access — but through a short-lived URL, so it
+    // cannot be forwarded or indexed.
+    const d = resolveCloudFileUrl(appRow({ visibility: "private" }), visitor);
+    expect(d.kind).toBe("signed");
+  });
+
+  it("hides another app's file behind 404, not 403", () => {
+    // 403 would confirm the id exists. Cross-app probes must not be able to
+    // distinguish a real file from a fabricated one.
+    const d = resolveCloudFileUrl(appRow({ app_id: "other-app" }), visitor);
+    expect(d).toMatchObject({ kind: "deny", status: 404 });
+  });
+
+  it("returns 404 for a missing row", () => {
+    const d = resolveCloudFileUrl(null, visitor);
+    expect(d).toMatchObject({ kind: "deny", status: 404 });
+  });
+
+  it("refuses a file that only exists on someone's laptop", () => {
+    // Resolves fine on desktop; the cloud has no filesystem to read it from.
+    for (const state of ["pending", "uploading", "failed"] as const) {
+      const d = resolveCloudFileUrl(appRow({ upload_state: state }), visitor);
+      expect(d, state).toMatchObject({ kind: "deny", status: 404 });
+    }
+  });
+
+  it("never exposes a user-scoped file to a logged-out visitor", () => {
+    const d = resolveCloudFileUrl(userRow("user-a"), visitor);
+    expect(d).toMatchObject({ kind: "deny", status: 403 });
+  });
+
+  it("never exposes a user-scoped file to a different logged-in user", () => {
+    const d = resolveCloudFileUrl(userRow("user-a"), {
+      ...visitor,
+      userId: "user-b",
+    });
+    expect(d).toMatchObject({ kind: "deny", status: 403 });
+  });
+
+  it("gives the owner of a user-scoped file a signed URL", () => {
+    const d = resolveCloudFileUrl(userRow("user-a"), {
+      ...visitor,
+      userId: "user-a",
+    });
+    expect(d).toMatchObject({ kind: "signed", objectKey: expect.any(String) });
+  });
+
+  it("trusts the key over the scope column when they disagree", () => {
+    // The column syncs through Turso and a desktop write path; the key is
+    // written server-side from the session. A row mislabelled 'app' must not
+    // become world-readable on a published app.
+    const mislabelled = userRow("user-a", { scope: "app" });
+    const d = resolveCloudFileUrl(mislabelled, visitor);
+    expect(d).toMatchObject({ kind: "deny", status: 403 });
+  });
+
+  it("signs rather than CDN-serves before the app is published", () => {
+    // Preview and unpublished apps have no CDN-public objects, so a CDN URL
+    // would 403 at the edge and look like data loss to the author.
+    const d = resolveCloudFileUrl(appRow(), {
+      ...visitor,
+      isPublished: false,
+    });
+    expect(d.kind).toBe("signed");
+  });
+
+  it("denies an unpublished app to a caller who cannot read it", () => {
+    const d = resolveCloudFileUrl(appRow(), {
+      ...visitor,
+      isPublished: false,
+      canRead: false,
+    });
+    expect(d).toMatchObject({ kind: "deny", status: 403 });
+  });
+});
+
+describe("buildCdnUrl", () => {
+  it("mirrors the server's cdn_url shape", () => {
+    expect(buildCdnUrl("namespaces/n/apps/a/files/abc", "files.papr.ai")).toBe(
+      "https://files.papr.ai/namespaces/n/apps/a/files/abc",
+    );
+  });
+});

--- a/tests/unit/backend/paprFilesSdk.test.ts
+++ b/tests/unit/backend/paprFilesSdk.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for the mini-app App Files SDK.
+ *
+ * The SDK runs in a browser, so these exercise it against fake fetch endpoints
+ * with real Blobs. The property that matters most: bytes go straight to
+ * storage, chunked, and never through the gateway.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { papr } from "../../../src/resources/mini-app-sdk/papr-files.js";
+
+const CHUNK = 8 * 1024 * 1024;
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    headers: { get: () => null },
+  } as unknown as Response;
+}
+
+function gcsResponse(status: number, range?: string): Response {
+  return {
+    ok: status < 400,
+    status,
+    json: async () => ({}),
+    text: async () => "",
+    headers: { get: (h: string) => (h === "Range" ? (range ?? null) : null) },
+  } as unknown as Response;
+}
+
+interface Harness {
+  gatewayCalls: string[];
+  gcsBytes: number;
+  restore: () => void;
+}
+
+/**
+ * Fake gateway + fake GCS.
+ *
+ * Deliberately separate counters: an assertion that the gateway never saw the
+ * payload is the point of the architecture, so the test has to be able to tell
+ * the two apart.
+ */
+function harness(opts: { total: number; failChunk?: number }): Harness {
+  const gatewayCalls: string[] = [];
+  let committed = 0;
+  let chunkCalls = 0;
+
+  const impl = async (url: string, init?: RequestInit): Promise<Response> => {
+    const method = init?.method ?? "GET";
+
+    if (url.startsWith("/api/")) {
+      gatewayCalls.push(`${method} ${url}`);
+      if (url === "/api/files/ticket") {
+        return jsonResponse({
+          id: "file-1",
+          objectKey: "namespaces/n/apps/a/files/sha",
+          uploadUrl: "https://storage.googleapis.test/session",
+          alreadyExists: false,
+          sha256: "sha",
+        });
+      }
+      if (url === "/api/files/commit") {
+        return jsonResponse({
+          id: "file-1",
+          objectKey: "namespaces/n/apps/a/files/sha",
+          sha256: "sha",
+          sizeBytes: opts.total,
+          deduped: false,
+          verified: true,
+        });
+      }
+      if (url === "/api/files/url") {
+        return jsonResponse({
+          location: { kind: "cloud" },
+          url: "https://files.papr.ai/obj",
+        });
+      }
+      if (url === "/api/files") {
+        return jsonResponse({ files: [{ id: "file-1", file_name: "a.mp4" }] });
+      }
+      if (url === "/api/files/delete") return jsonResponse({ deleted: true });
+    }
+
+    // Anything else is the storage endpoint.
+    const range = (init?.headers as Record<string, string>)?.["Content-Range"];
+    if (range?.startsWith("bytes */")) {
+      return committed === 0
+        ? gcsResponse(308)
+        : gcsResponse(308, `bytes=0-${committed - 1}`);
+    }
+
+    chunkCalls += 1;
+    if (opts.failChunk && chunkCalls === opts.failChunk) {
+      return gcsResponse(503);
+    }
+
+    const m = /bytes (\d+)-(\d+)\//.exec(range ?? "");
+    committed = Number(m?.[2]) + 1;
+    return committed >= opts.total
+      ? gcsResponse(200)
+      : gcsResponse(308, `bytes=0-${committed - 1}`);
+  };
+
+  const spy = vi.spyOn(globalThis, "fetch").mockImplementation(impl as never);
+  return {
+    gatewayCalls,
+    get gcsBytes() {
+      return committed;
+    },
+    restore: () => spy.mockRestore(),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("papr.files.upload", () => {
+  it("uploads a multi-chunk blob and verifies it server-side", async () => {
+    const total = CHUNK * 2 + 512;
+    const h = harness({ total });
+    const blob = new Blob([new Uint8Array(total)]);
+
+    const result = await papr.files.upload(blob, { name: "recording.mp4" });
+
+    expect(result.verified).toBe(true);
+    expect(h.gcsBytes).toBe(total);
+    h.restore();
+  });
+
+  it("never sends the payload through the gateway", async () => {
+    // The whole reason for browser-direct upload: a relayed 10 GB file would
+    // cost the gateway memory or disk proportional to the file.
+    const total = CHUNK + 100;
+    const h = harness({ total });
+
+    await papr.files.upload(new Blob([new Uint8Array(total)]), { name: "v.mp4" });
+
+    // Only control-plane calls — a ticket and a commit. No byte-carrying POST.
+    expect(h.gatewayCalls).toEqual([
+      "POST /api/files/ticket",
+      "POST /api/files/commit",
+    ]);
+    h.restore();
+  });
+
+  it("retries a transient storage failure without restarting the upload", async () => {
+    const total = CHUNK * 2;
+    const h = harness({ total, failChunk: 2 });
+
+    const result = await papr.files.upload(new Blob([new Uint8Array(total)]), {
+      name: "v.mp4",
+    });
+
+    expect(result.verified).toBe(true);
+    expect(h.gcsBytes).toBe(total);
+    h.restore();
+  });
+
+  it("reports progress as bytes land", async () => {
+    const total = CHUNK * 2 + 10;
+    const h = harness({ total });
+    const seen: number[] = [];
+
+    await papr.files.upload(new Blob([new Uint8Array(total)]), {
+      name: "v.mp4",
+      onProgress: (p) => seen.push(p.uploadedBytes),
+    });
+
+    expect(seen.length).toBeGreaterThan(1);
+    expect(seen.at(-1)).toBe(total);
+    // Monotonic — progress that jumps backwards reads as a stall to the user.
+    expect([...seen].sort((a, b) => a - b)).toEqual(seen);
+    h.restore();
+  });
+
+  it("skips the transfer entirely when the bytes already exist", async () => {
+    // Content addressing means re-uploading the same recording is free — a
+    // better saving than any compression ratio.
+    const spy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      url: string,
+    ) => {
+      if (url === "/api/files/ticket") {
+        return jsonResponse({
+          id: "file-1",
+          objectKey: "k",
+          uploadUrl: null,
+          alreadyExists: true,
+          sha256: "sha",
+        });
+      }
+      throw new Error(`unexpected call to ${url}`);
+    }) as never);
+
+    const result = await papr.files.upload(new Blob([new Uint8Array(1024)]), {
+      name: "dupe.mp4",
+    });
+
+    expect(result.deduped).toBe(true);
+    expect(result.verified).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("stops immediately when aborted", async () => {
+    const total = CHUNK * 4;
+    const h = harness({ total });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      papr.files.upload(new Blob([new Uint8Array(total)]), {
+        name: "v.mp4",
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(/abort/i);
+    h.restore();
+  });
+});
+
+describe("papr.files url/list/remove", () => {
+  it("resolves a file to a loadable URL", async () => {
+    const h = harness({ total: 1 });
+    const res = await papr.files.url("file-1");
+    expect(res.url).toBe("https://files.papr.ai/obj");
+    expect(res.location).toBe("cloud");
+    h.restore();
+  });
+
+  it("lists files without the app naming itself", async () => {
+    // appId is inferred server-side from the request, so app code never
+    // hardcodes its own UUID.
+    const h = harness({ total: 1 });
+    const files = await papr.files.list();
+    expect(files).toHaveLength(1);
+    expect(h.gatewayCalls).toContain("GET /api/files");
+    h.restore();
+  });
+
+  it("removes a file", async () => {
+    const h = harness({ total: 1 });
+    expect(await papr.files.remove("file-1")).toBe(true);
+    h.restore();
+  });
+});

--- a/tests/unit/backend/resumableUploaderRetry.test.ts
+++ b/tests/unit/backend/resumableUploaderRetry.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the chunked uploader against a fake GCS.
+ *
+ * Focused on what a 10 GB upload actually meets in the wild: transient 503s,
+ * dropped connections, partially accepted chunks, and a crash that must not
+ * cost the whole transfer.
+ */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  CHUNK_SIZE,
+  uploadResumable,
+} from "../../../src/gateway/services/appFiles/resumableUploader.js";
+
+let dir = "";
+let filePath = "";
+/** Two chunks plus a remainder, so multi-chunk paths are actually exercised. */
+const TOTAL = CHUNK_SIZE * 2 + 1024;
+
+beforeAll(async () => {
+  dir = await mkdtemp(join(tmpdir(), "papr-upload-"));
+  filePath = join(dir, "recording.mp4");
+  await writeFile(filePath, Buffer.alloc(TOTAL, 7));
+});
+
+afterAll(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+const noSleep = async (): Promise<void> => undefined;
+
+function res(status: number, range?: string): Response {
+  return {
+    status,
+    headers: { get: (h: string) => (h === "Range" ? (range ?? null) : null) },
+    text: async () => "",
+  } as unknown as Response;
+}
+
+/** Fake GCS that commits whatever it is sent, honouring Content-Range. */
+function fakeGcs(script: (attempt: number) => Response | "throw" | null) {
+  let committed = 0;
+  let attempt = 0;
+  const calls: string[] = [];
+
+  const impl = (async (_url: string, init?: RequestInit) => {
+    const range = (init?.headers as Record<string, string>)?.["Content-Range"];
+    calls.push(range);
+
+    // Offset probe.
+    if (range?.startsWith("bytes */")) {
+      return committed === 0
+        ? res(308)
+        : res(308, `bytes=0-${committed - 1}`);
+    }
+
+    attempt += 1;
+    const scripted = script(attempt);
+    if (scripted === "throw") throw new Error("socket hang up");
+    if (scripted) return scripted;
+
+    const match = /bytes (\d+)-(\d+)\//.exec(range ?? "");
+    committed = Number(match?.[2]) + 1;
+    return committed >= TOTAL
+      ? res(200)
+      : res(308, `bytes=0-${committed - 1}`);
+  }) as unknown as typeof fetch;
+
+  return { impl, calls, get committed() { return committed; } };
+}
+
+describe("uploadResumable", () => {
+  it("uploads a multi-chunk file to completion", async () => {
+    const gcs = fakeGcs(() => null);
+    const sent = await uploadResumable({
+      sessionUrl: "https://upload.example/s",
+      filePath,
+      totalBytes: TOTAL,
+      fetchImpl: gcs.impl,
+      sleepImpl: noSleep,
+    });
+    expect(sent).toBe(TOTAL);
+  });
+
+  it("retries a transient 503 without restarting the file", async () => {
+    // The failure that matters at 9 GB of 10: one chunk retried, not 10 GB.
+    let failures = 0;
+    const gcs = fakeGcs((attempt) => {
+      if (attempt === 2 && failures === 0) {
+        failures += 1;
+        return res(503);
+      }
+      return null;
+    });
+
+    const sent = await uploadResumable({
+      sessionUrl: "https://upload.example/s",
+      filePath,
+      totalBytes: TOTAL,
+      fetchImpl: gcs.impl,
+      sleepImpl: noSleep,
+    });
+    expect(sent).toBe(TOTAL);
+    expect(failures).toBe(1);
+  });
+
+  it("retries a dropped connection, which returns no status at all", async () => {
+    let thrown = 0;
+    const gcs = fakeGcs((attempt) => {
+      if (attempt === 2 && thrown === 0) {
+        thrown += 1;
+        return "throw";
+      }
+      return null;
+    });
+
+    const sent = await uploadResumable({
+      sessionUrl: "https://upload.example/s",
+      filePath,
+      totalBytes: TOTAL,
+      fetchImpl: gcs.impl,
+      sleepImpl: noSleep,
+    });
+    expect(sent).toBe(TOTAL);
+    expect(thrown).toBe(1);
+  });
+
+  it("gives up on a permanent error instead of retrying six times", async () => {
+    const gcs = fakeGcs(() => res(403));
+    await expect(
+      uploadResumable({
+        sessionUrl: "https://upload.example/s",
+        filePath,
+        totalBytes: TOTAL,
+        fetchImpl: gcs.impl,
+        sleepImpl: noSleep,
+      }),
+    ).rejects.toThrow(/403/);
+  });
+
+  it("reports committed offsets so a crash costs seconds, not gigabytes", async () => {
+    // This callback is what persists progress. Without it the session URI and
+    // byte count die with the process.
+    const seen: number[] = [];
+    const gcs = fakeGcs(() => null);
+
+    await uploadResumable({
+      sessionUrl: "https://upload.example/s",
+      filePath,
+      totalBytes: TOTAL,
+      fetchImpl: gcs.impl,
+      sleepImpl: noSleep,
+      onOffsetCommitted: (o) => {
+        seen.push(o);
+      },
+    });
+
+    expect(seen.length).toBeGreaterThan(1);
+    expect(seen.at(-1)).toBe(TOTAL);
+    // Monotonic: an offset going backwards would re-send bytes GCS already has.
+    expect([...seen].sort((a, b) => a - b)).toEqual(seen);
+  });
+
+  it("resumes from GCS's offset rather than restarting at zero", async () => {
+    // Simulates the laptop-died case: GCS already holds the first chunk.
+    let committed = CHUNK_SIZE;
+    const impl = (async (_url: string, init?: RequestInit) => {
+      const range = (init?.headers as Record<string, string>)?.["Content-Range"];
+      if (range?.startsWith("bytes */")) {
+        return res(308, `bytes=0-${committed - 1}`);
+      }
+      const match = /bytes (\d+)-(\d+)\//.exec(range ?? "");
+      const start = Number(match?.[1]);
+      // The upload must continue from the committed byte, not from zero.
+      expect(start).toBeGreaterThanOrEqual(CHUNK_SIZE);
+      committed = Number(match?.[2]) + 1;
+      return committed >= TOTAL ? res(200) : res(308, `bytes=0-${committed - 1}`);
+    }) as unknown as typeof fetch;
+
+    const sent = await uploadResumable({
+      sessionUrl: "https://upload.example/s",
+      filePath,
+      totalBytes: TOTAL,
+      fetchImpl: impl,
+      sleepImpl: noSleep,
+    });
+
+    // Only the remaining bytes moved — the first chunk was not re-sent.
+    expect(sent).toBe(TOTAL - CHUNK_SIZE);
+  });
+
+  it("does nothing when GCS already has the whole object", async () => {
+    const impl = (async () => res(200)) as unknown as typeof fetch;
+    const sent = await uploadResumable({
+      sessionUrl: "https://upload.example/s",
+      filePath,
+      totalBytes: TOTAL,
+      fetchImpl: impl,
+      sleepImpl: noSleep,
+    });
+    expect(sent).toBe(0);
+  });
+});

--- a/tests/unit/backend/uploadResume.test.ts
+++ b/tests/unit/backend/uploadResume.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for upload durability decisions.
+ *
+ * The scenario driving all of this: a 10 GB recording, a laptop that dies at
+ * 9 GB. Each test names the user-visible cost it prevents.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_RETRY,
+  SESSION_MIN_REMAINING_MS,
+  backoffDelayMs,
+  isHashCacheValid,
+  isRetryableStatus,
+  planResume,
+  shouldRetry,
+  type ResumeCandidate,
+} from "../../../src/gateway/services/appFiles/uploadResume.js";
+
+const NOW = 1_700_000_000_000;
+const GB = 1024 ** 3;
+
+function row(over: Partial<ResumeCandidate> = {}): ResumeCandidate {
+  return {
+    upload_session_uri: "https://storage.googleapis.com/upload/session-abc",
+    session_expires_at: NOW + 7 * 24 * 60 * 60 * 1000,
+    upload_state: "uploading",
+    size_bytes: 10 * GB,
+    ...over,
+  };
+}
+
+describe("planResume", () => {
+  it("resumes a live session instead of re-sending 10 GB", () => {
+    // The whole point of 4a: a laptop dying at 9 GB must not cost 10 GB.
+    const plan = planResume(row(), NOW);
+    expect(plan).toMatchObject({ kind: "resume" });
+  });
+
+  it("restarts when no session was ever stored", () => {
+    // The pre-4a state of the world: the URI lived in a local variable and
+    // died with the process.
+    const plan = planResume(row({ upload_session_uri: null }), NOW);
+    expect(plan).toMatchObject({ kind: "restart" });
+  });
+
+  it("restarts once the 7-day session has expired", () => {
+    const plan = planResume(row({ session_expires_at: NOW - 1 }), NOW);
+    expect(plan).toMatchObject({ kind: "restart", reason: /expired/ as never });
+  });
+
+  it("restarts when too little session life remains for a large upload", () => {
+    // Resuming onto a session with minutes left moves the failure to the worst
+    // moment — near the end, after hours of transfer.
+    const plan = planResume(
+      row({ session_expires_at: NOW + SESSION_MIN_REMAINING_MS - 1 }),
+      NOW,
+    );
+    expect(plan).toMatchObject({ kind: "restart" });
+  });
+
+  it("restarts when the session has no recorded expiry", () => {
+    // Cannot date it, cannot trust it to outlive a multi-hour upload.
+    const plan = planResume(row({ session_expires_at: null }), NOW);
+    expect(plan).toMatchObject({ kind: "restart" });
+  });
+
+  it("does nothing for an already-verified file", () => {
+    const plan = planResume(row({ upload_state: "verified" }), NOW);
+    expect(plan).toMatchObject({ kind: "done" });
+  });
+
+  it("resumes a failed upload rather than abandoning it", () => {
+    // 'failed' is where a crashed upload lands. It must still be resumable, or
+    // the state itself becomes a dead end.
+    const plan = planResume(row({ upload_state: "failed" }), NOW);
+    expect(plan).toMatchObject({ kind: "resume" });
+  });
+});
+
+describe("shouldRetry", () => {
+  it("retries a dropped connection, which has no status at all", () => {
+    expect(shouldRetry(1, null)).toBe(true);
+  });
+
+  it("retries GCS transient failures", () => {
+    for (const status of [408, 429, 500, 502, 503, 504]) {
+      expect(shouldRetry(1, status), String(status)).toBe(true);
+    }
+  });
+
+  it("does not retry a client error that will never succeed", () => {
+    // Retrying a 403 six times just delays the error message.
+    for (const status of [400, 401, 403, 404]) {
+      expect(shouldRetry(1, status), String(status)).toBe(false);
+    }
+  });
+
+  it("stops at the attempt ceiling", () => {
+    expect(shouldRetry(DEFAULT_RETRY.maxAttempts, 503)).toBe(false);
+  });
+
+  it("classifies statuses consistently with the retry decision", () => {
+    expect(isRetryableStatus(503)).toBe(true);
+    expect(isRetryableStatus(404)).toBe(false);
+  });
+});
+
+describe("backoffDelayMs", () => {
+  it("grows exponentially across attempts", () => {
+    const noJitter = () => 1;
+    expect(backoffDelayMs(1, DEFAULT_RETRY, noJitter)).toBe(1000);
+    expect(backoffDelayMs(2, DEFAULT_RETRY, noJitter)).toBe(2000);
+    expect(backoffDelayMs(3, DEFAULT_RETRY, noJitter)).toBe(4000);
+  });
+
+  it("caps the delay so a retry never stalls for hours", () => {
+    expect(backoffDelayMs(20, DEFAULT_RETRY, () => 1)).toBe(
+      DEFAULT_RETRY.maxDelayMs,
+    );
+  });
+
+  it("applies jitter so concurrent uploads do not retry in lockstep", () => {
+    // Without jitter every chunk of every upload hits GCS on the same schedule,
+    // hammering it hardest exactly when it is already struggling.
+    expect(backoffDelayMs(3, DEFAULT_RETRY, () => 0)).toBe(0);
+    expect(backoffDelayMs(3, DEFAULT_RETRY, () => 0.5)).toBe(2000);
+  });
+});
+
+describe("isHashCacheValid", () => {
+  const actual = { size: 10 * GB, mtimeMs: 1_699_999_000_000 };
+
+  it("skips rehashing 10 GB when the file is untouched", () => {
+    // Two full passes over 10 GB is minutes of CPU. After a crash we would
+    // otherwise pay it again to learn the same answer.
+    const cached = {
+      size_bytes: actual.size,
+      mtime_ms: actual.mtimeMs,
+      sha256: "abc",
+    };
+    expect(isHashCacheValid(cached, actual)).toBe(true);
+  });
+
+  it("rehashes when the size changed", () => {
+    const cached = { size_bytes: 1, mtime_ms: actual.mtimeMs, sha256: "abc" };
+    expect(isHashCacheValid(cached, actual)).toBe(false);
+  });
+
+  it("rehashes when the file was modified", () => {
+    const cached = { size_bytes: actual.size, mtime_ms: 1, sha256: "abc" };
+    expect(isHashCacheValid(cached, actual)).toBe(false);
+  });
+
+  it("rehashes when nothing is cached", () => {
+    expect(isHashCacheValid(null, actual)).toBe(false);
+  });
+});

--- a/ui/__tests__/appFilesFormat.test.ts
+++ b/ui/__tests__/appFilesFormat.test.ts
@@ -17,6 +17,8 @@ import {
   formatRate,
   glyphForFile,
   reclaimableBytes,
+  totalBytes,
+  uploadPercent,
 } from "../utils/appFilesFormat";
 
 const GB = 1024 ** 3;
@@ -139,6 +141,54 @@ describe("reclaimableBytes", () => {
 
   it("ignores files already evicted", () => {
     expect(reclaimableBytes([row({ local_path: null })])).toBe(0);
+  });
+});
+
+describe("totalBytes", () => {
+  it("sums everything stored, whatever its state", () => {
+    // The header number answers "how much is here", which includes files
+    // still uploading — excluding them would make the total shrink as an
+    // upload finishes, which is nonsense.
+    const rows = [
+      row({ id: "a", size_bytes: 2 * GB }),
+      row({ id: "b", size_bytes: 3 * GB, upload_state: "uploading" }),
+    ];
+    expect(totalBytes(rows)).toBe(5 * GB);
+  });
+
+  it("is zero for an empty app", () => {
+    expect(totalBytes([])).toBe(0);
+  });
+});
+
+describe("uploadPercent", () => {
+  it("reports whole percent while uploading", () => {
+    expect(
+      uploadPercent(
+        row({ upload_state: "uploading", size_bytes: 100, bytes_uploaded: 42 }),
+      ),
+    ).toBe(42);
+  });
+
+  it("never shows 100% while bytes are still in flight", () => {
+    // The most common way a progress bar lies: sitting at 100% through
+    // verification, making the last seconds feel broken.
+    expect(
+      uploadPercent(
+        row({ upload_state: "uploading", size_bytes: 100, bytes_uploaded: 100 }),
+      ),
+    ).toBe(99);
+  });
+
+  it("returns null for anything not uploading, so the row shows its size", () => {
+    expect(uploadPercent(row())).toBeNull();
+    expect(uploadPercent(row({ upload_state: "failed" }))).toBeNull();
+  });
+
+  it("does not divide by zero on an empty file", () => {
+    expect(
+      uploadPercent(row({ upload_state: "uploading", size_bytes: 0 })),
+    ).toBe(0);
   });
 });
 

--- a/ui/__tests__/appFilesFormat.test.ts
+++ b/ui/__tests__/appFilesFormat.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for App Files display logic.
+ *
+ * These cover the honesty rules: progress that reads as moving, an ETA that
+ * refuses to guess, and a "free space" figure that can never include a file
+ * whose only copy is local.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { AppFileRow } from "../../src/gateway/services/appFiles/appFilesSchema";
+import {
+  canEvict,
+  describeFileState,
+  formatBytes,
+  formatEta,
+  formatProgressLine,
+  formatRate,
+  glyphForFile,
+  reclaimableBytes,
+} from "../utils/appFilesFormat";
+
+const GB = 1024 ** 3;
+
+function row(over: Partial<AppFileRow> = {}): AppFileRow {
+  return {
+    id: "f1",
+    app_id: "app-1",
+    object_key: "namespaces/n/apps/a/files/sha",
+    sha256: "sha",
+    size_bytes: 6.7 * GB,
+    mime: "video/mp4",
+    file_name: "standup.mp4",
+    scope: "app",
+    local_path: "/Users/x/standup.mp4",
+    upload_state: "verified",
+    visibility: "inherit",
+    upload_session_uri: null,
+    bytes_uploaded: 0,
+    session_expires_at: null,
+    created_at: 1,
+    updated_at: 1,
+    ...over,
+  } as AppFileRow;
+}
+
+describe("formatBytes", () => {
+  it("uses the unit a human would say", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MB");
+    expect(formatBytes(6.7 * GB)).toBe("6.7 GB");
+  });
+
+  it("drops the decimal once it stops carrying information", () => {
+    // "137.0 GB" is noise; "137 GB" is the same fact, read faster.
+    expect(formatBytes(137 * GB)).toBe("137 GB");
+  });
+});
+
+describe("formatEta", () => {
+  it("scales the unit to the wait", () => {
+    expect(formatEta(45)).toBe("~45 sec");
+    expect(formatEta(480)).toBe("~8 min");
+    expect(formatEta(9000)).toBe("~2.5 h");
+  });
+
+  it("returns null rather than inventing a number", () => {
+    // An ETA from too few samples swings between 2 min and 4 h, which reads as
+    // a broken upload. No number is more honest than a wrong one.
+    expect(formatEta(null)).toBeNull();
+    expect(formatEta(0)).toBeNull();
+    expect(formatEta(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});
+
+describe("formatProgressLine", () => {
+  it("shows bytes moved, rate and ETA together", () => {
+    // The requirement's example line: enough to answer "is it moving, and when
+    // does it end" without doing arithmetic.
+    const line = formatProgressLine(4.2 * GB, 6.7 * GB, 5.3 * 1024 * 1024, 480);
+    expect(line).toBe("4.2 GB / 6.7 GB · 5.3 MB/s · ~8 min");
+  });
+
+  it("omits rate and ETA before they are known", () => {
+    // At the very start there is no honest rate to show, so the line is just
+    // the byte counts rather than "0 B/s", which reads as stalled.
+    expect(formatProgressLine(0, 6.7 * GB, 0, null)).toBe("0 B / 6.7 GB");
+  });
+});
+
+describe("formatRate", () => {
+  it("renders a dash rather than a misleading zero", () => {
+    expect(formatRate(0)).toBe("—");
+  });
+});
+
+describe("glyphForFile", () => {
+  it("distinguishes all four states by shape, not colour", () => {
+    expect(glyphForFile(row())).toBe("filled");
+    expect(glyphForFile(row({ local_path: null }))).toBe("hollow");
+    expect(glyphForFile(row({ upload_state: "uploading" }))).toBe("ring");
+    expect(glyphForFile(row({ upload_state: "failed" }))).toBe("slashed");
+  });
+});
+
+describe("describeFileState", () => {
+  it("says where the bytes are in plain language", () => {
+    expect(describeFileState(row())).toBe("On this Mac and in the cloud");
+    expect(describeFileState(row({ local_path: null }))).toBe("In the cloud");
+  });
+
+  it("frames a failed upload as recoverable, because it is", () => {
+    // The session URI survives for 7 days, so "failed" really does mean
+    // "will resume" — saying otherwise would invite a needless re-upload.
+    expect(describeFileState(row({ upload_state: "failed" }))).toBe(
+      "Upload failed — will resume",
+    );
+  });
+});
+
+describe("reclaimableBytes", () => {
+  it("counts only files with a verified cloud copy", () => {
+    const rows = [
+      row({ id: "a", size_bytes: 2 * GB }),
+      row({ id: "b", size_bytes: 3 * GB }),
+    ];
+    expect(reclaimableBytes(rows)).toBe(5 * GB);
+  });
+
+  it("never offers to free a file whose only copy is local", () => {
+    // The unforgivable bug: reporting space as reclaimable when freeing it
+    // would destroy the user's only copy.
+    const rows = [
+      row({ id: "a", upload_state: "uploading", size_bytes: 9 * GB }),
+      row({ id: "b", upload_state: "failed", size_bytes: 9 * GB }),
+      row({ id: "c", upload_state: "pending", size_bytes: 9 * GB }),
+    ];
+    expect(reclaimableBytes(rows)).toBe(0);
+  });
+
+  it("ignores files already evicted", () => {
+    expect(reclaimableBytes([row({ local_path: null })])).toBe(0);
+  });
+});
+
+describe("canEvict", () => {
+  it("permits eviction only when a verified cloud copy exists", () => {
+    expect(canEvict(row())).toBe(true);
+    expect(canEvict(row({ upload_state: "uploading" }))).toBe(false);
+    expect(canEvict(row({ local_path: null }))).toBe(false);
+  });
+});

--- a/ui/components/Apps/AppFileRowItem.tsx
+++ b/ui/components/Apps/AppFileRowItem.tsx
@@ -1,0 +1,112 @@
+/**
+ * One file row: glyph, name, state, and the actions that need a deliberate tap.
+ *
+ * Split from the panel because the row carries the two destructive actions,
+ * and they deserve to be read in isolation. Both are explicit and neither is
+ * ever triggered by a background process.
+ */
+
+import type { AppFileRow } from "../../../src/gateway/services/appFiles/appFilesSchema";
+import {
+  canEvict,
+  describeFileState,
+  formatBytes,
+  glyphForFile,
+  formatProgressLine,
+} from "../../utils/appFilesFormat";
+
+interface AppFileRowItemProps {
+  file: AppFileRow;
+  busy: boolean;
+  onTogglePrivate: (isPrivate: boolean) => void;
+  onEvict: () => void;
+  onRemove: () => void;
+}
+
+/** Four states, four shapes — never colour alone. */
+function StateGlyph({ file }: { file: AppFileRow }) {
+  const glyph = glyphForFile(file);
+  const label = describeFileState(file);
+  return (
+    <svg
+      className={`app-file__glyph app-file__glyph--${glyph}`}
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      role="img"
+      aria-label={label}
+    >
+      <title>{label}</title>
+      <circle
+        cx="7"
+        cy="7"
+        r="5"
+        fill={glyph === "filled" ? "currentColor" : "none"}
+      />
+      {glyph === "slashed" && <line x1="3" y1="11" x2="11" y2="3" />}
+    </svg>
+  );
+}
+
+export function AppFileRowItem({
+  file,
+  busy,
+  onTogglePrivate,
+  onEvict,
+  onRemove,
+}: AppFileRowItemProps) {
+  const isPrivate = file.visibility === "private";
+  const uploading = file.upload_state === "uploading";
+
+  return (
+    <li className="app-file">
+      <StateGlyph file={file} />
+
+      <div className="app-file__body">
+        <span className="app-file__name">{file.file_name}</span>
+        <span className="app-file__meta">
+          {uploading
+            ? // Bytes moved, not a bare percentage: on a multi-GB upload the
+              // absolute numbers are what tell the user it is still moving.
+              formatProgressLine(file.bytes_uploaded, file.size_bytes, 0, null)
+            : `${formatBytes(file.size_bytes)} · ${describeFileState(file)}`}
+        </span>
+      </div>
+
+      <label className="app-file__private" title="Never publish this file, even if the app is public">
+        <input
+          type="checkbox"
+          checked={isPrivate}
+          disabled={busy}
+          onChange={(e) => onTogglePrivate(e.target.checked)}
+        />
+        Keep private
+      </label>
+
+      {canEvict(file) && (
+        <button
+          type="button"
+          className="app-file__action"
+          disabled={busy}
+          onClick={onEvict}
+          title="Delete the copy on this Mac. The cloud copy is kept."
+        >
+          Free space
+        </button>
+      )}
+
+      <button
+        type="button"
+        className="app-file__action app-file__action--danger"
+        disabled={busy}
+        onClick={onRemove}
+        title="Delete this file everywhere"
+      >
+        Remove
+      </button>
+    </li>
+  );
+}

--- a/ui/components/Apps/AppFileRowItem.tsx
+++ b/ui/components/Apps/AppFileRowItem.tsx
@@ -1,9 +1,12 @@
 /**
- * One file row: glyph, name, state, and the actions that need a deliberate tap.
+ * One file row.
  *
- * Split from the panel because the row carries the two destructive actions,
- * and they deserve to be read in isolation. Both are explicit and neither is
- * ever triggered by a background process.
+ * At rest: a state dot, a name, a size. That is what someone scans a list for.
+ * Actions appear on hover — three permanent controls per row is noise that
+ * grows with the file count, and the row's own text stops being readable.
+ *
+ * Privacy is a lock toggle rather than a labelled checkbox. It is a state the
+ * file is in, not a form field, and a lock says that in one glyph.
  */
 
 import type { AppFileRow } from "../../../src/gateway/services/appFiles/appFilesSchema";
@@ -12,7 +15,7 @@ import {
   describeFileState,
   formatBytes,
   glyphForFile,
-  formatProgressLine,
+  uploadPercent,
 } from "../../utils/appFilesFormat";
 
 interface AppFileRowItemProps {
@@ -24,15 +27,15 @@ interface AppFileRowItemProps {
 }
 
 /** Four states, four shapes — never colour alone. */
-function StateGlyph({ file }: { file: AppFileRow }) {
+function StateDot({ file }: { file: AppFileRow }) {
   const glyph = glyphForFile(file);
   const label = describeFileState(file);
   return (
     <svg
-      className={`app-file__glyph app-file__glyph--${glyph}`}
-      width="14"
-      height="14"
-      viewBox="0 0 14 14"
+      className={`app-file__dot app-file__dot--${glyph}`}
+      width="8"
+      height="8"
+      viewBox="0 0 8 8"
       fill="none"
       stroke="currentColor"
       strokeWidth="1.5"
@@ -40,13 +43,18 @@ function StateGlyph({ file }: { file: AppFileRow }) {
       aria-label={label}
     >
       <title>{label}</title>
-      <circle
-        cx="7"
-        cy="7"
-        r="5"
-        fill={glyph === "filled" ? "currentColor" : "none"}
-      />
-      {glyph === "slashed" && <line x1="3" y1="11" x2="11" y2="3" />}
+      <circle cx="4" cy="4" r="3" fill={glyph === "filled" ? "currentColor" : "none"} />
+      {glyph === "slashed" && <line x1="1.5" y1="6.5" x2="6.5" y2="1.5" />}
+    </svg>
+  );
+}
+
+function LockIcon({ locked }: { locked: boolean }) {
+  return (
+    <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden>
+      <rect x="3" y="6.5" width="8" height="5.5" rx="1.2" />
+      {/* Open shackle when unlocked: the shape itself carries the state. */}
+      <path d={locked ? "M5 6.5V4.5a2 2 0 0 1 4 0v2" : "M5 6.5V4.5a2 2 0 0 1 4 0"} />
     </svg>
   );
 }
@@ -59,54 +67,60 @@ export function AppFileRowItem({
   onRemove,
 }: AppFileRowItemProps) {
   const isPrivate = file.visibility === "private";
-  const uploading = file.upload_state === "uploading";
+  const percent = uploadPercent(file);
 
   return (
-    <li className="app-file">
-      <StateGlyph file={file} />
+    <li className={`app-file${busy ? " app-file--busy" : ""}`}>
+      <StateDot file={file} />
 
-      <div className="app-file__body">
-        <span className="app-file__name">{file.file_name}</span>
-        <span className="app-file__meta">
-          {uploading
-            ? // Bytes moved, not a bare percentage: on a multi-GB upload the
-              // absolute numbers are what tell the user it is still moving.
-              formatProgressLine(file.bytes_uploaded, file.size_bytes, 0, null)
-            : `${formatBytes(file.size_bytes)} · ${describeFileState(file)}`}
-        </span>
-      </div>
+      <span className="app-file__name" title={file.file_name}>
+        {file.file_name}
+      </span>
 
-      <label className="app-file__private" title="Never publish this file, even if the app is public">
-        <input
-          type="checkbox"
-          checked={isPrivate}
-          disabled={busy}
-          onChange={(e) => onTogglePrivate(e.target.checked)}
-        />
-        Keep private
-      </label>
+      <span className="app-file__size">
+        {percent === null ? formatBytes(file.size_bytes) : `${percent}%`}
+      </span>
 
-      {canEvict(file) && (
+      <div className="app-file__actions">
         <button
           type="button"
-          className="app-file__action"
+          className={`app-file__icon${isPrivate ? " app-file__icon--on" : ""}`}
           disabled={busy}
-          onClick={onEvict}
-          title="Delete the copy on this Mac. The cloud copy is kept."
+          aria-pressed={isPrivate}
+          onClick={() => onTogglePrivate(!isPrivate)}
+          title={isPrivate ? "Private — never published" : "Published with the app"}
         >
-          Free space
+          <LockIcon locked={isPrivate} />
         </button>
-      )}
 
-      <button
-        type="button"
-        className="app-file__action app-file__action--danger"
-        disabled={busy}
-        onClick={onRemove}
-        title="Delete this file everywhere"
-      >
-        Remove
-      </button>
+        {canEvict(file) && (
+          <button
+            type="button"
+            className="app-file__text-action"
+            disabled={busy}
+            onClick={onEvict}
+            title="Delete the copy on this Mac. The cloud copy is kept."
+          >
+            Free
+          </button>
+        )}
+
+        <button
+          type="button"
+          className="app-file__text-action app-file__text-action--danger"
+          disabled={busy}
+          onClick={onRemove}
+          title="Delete everywhere"
+        >
+          Remove
+        </button>
+      </div>
+
+      {/* A hairline that fills. On a multi-GB upload, motion is what says
+          "working" — a number alone reads as frozen between updates. */}
+      {percent !== null && (
+        <span className="app-file__progress" style={{ width: `${percent}%` }} />
+      )}
     </li>
   );
 }

--- a/ui/components/Apps/AppFilesPanel.css
+++ b/ui/components/Apps/AppFilesPanel.css
@@ -1,145 +1,187 @@
 /**
- * App Files panel styling — Liquid Glass tokens only, no hardcoded colours,
- * so the panel follows light/dark and any future theme without edits.
+ * App Files panel.
+ *
+ * Deliberately matches MiniAppDataSourcesPanel's frame — same radius, padding,
+ * border and header type. They sit adjacent in the sidebar, so any difference
+ * would read as an inconsistency rather than a distinction.
+ *
+ * Tokens only. Every colour here follows light/dark automatically.
  */
 
 .app-files {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  margin: 0 0 12px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  /* Border colour is the only drag affordance, so the transition carries it. */
+  transition: border-color 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-.app-files__drop {
-  border: 1.5px dashed var(--border-color);
-  border-radius: 12px;
-  padding: 20px 16px;
-  text-align: center;
-  background: var(--background-secondary);
-  transition: border-color 0.15s ease, background 0.15s ease;
-}
-
-/* Only a border and tint on drag — no growing or jumping, which reads as a
-   glitch when someone is dragging a file across the window. */
-.app-files__drop--active {
+/* The whole panel is the drop target — a dedicated dashed box would occupy
+   permanent space to teach something learned once. */
+.app-files--dragging {
   border-color: var(--accent-color);
-  background: var(--background-hover);
 }
 
-.app-files__drop-title {
-  margin: 0 0 4px;
+.app-files__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.app-files__head h3 {
+  margin: 0;
   font-size: 13px;
   font-weight: 600;
-  color: var(--text-color);
+  color: var(--text-primary);
 }
 
-.app-files__drop-hint {
+/* One number, quiet. Storage totals are reference, not headline. */
+.app-files__total {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.app-files__empty,
+.app-files__error {
   margin: 0;
   font-size: 12px;
+  line-height: 1.45;
   color: var(--text-secondary);
+}
+
+.app-files__error {
+  color: var(--error-color);
 }
 
 .app-files__list {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
 }
 
 .app-file {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
-  border-radius: 8px;
+  gap: 8px;
+  height: 30px;
+  padding: 0 4px;
+  border-radius: 6px;
 }
 
 .app-file:hover {
   background: var(--background-hover);
 }
 
-.app-file__glyph {
-  flex-shrink: 0;
-  color: var(--text-secondary);
+.app-file--busy {
+  opacity: 0.55;
 }
 
-/* Verified and local — the only state that reads as fully settled. */
-.app-file__glyph--filled {
+.app-file__dot {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+}
+
+/* Verified and local — the only fully settled state, so the only accented one. */
+.app-file__dot--filled {
   color: var(--accent-color);
 }
 
-.app-file__glyph--slashed {
-  color: var(--error-color, var(--text-secondary));
-}
-
-.app-file__body {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  flex: 1;
+.app-file__dot--slashed {
+  color: var(--error-color);
 }
 
 .app-file__name {
-  font-size: 13px;
-  color: var(--text-color);
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.app-file__meta {
+.app-file__size {
   font-size: 11px;
-  color: var(--text-secondary);
-  /* Tabular figures stop the progress line jittering as digits change — a
-     number that twitches every 200 ms is hard to read and looks broken. */
+  color: var(--text-tertiary);
+  /* Tabular figures stop the number jittering as digits change. */
   font-variant-numeric: tabular-nums;
 }
 
-.app-file__private {
+.app-file__actions {
   display: flex;
   align-items: center;
-  gap: 5px;
-  font-size: 11px;
-  color: var(--text-secondary);
-  white-space: nowrap;
-  cursor: pointer;
+  gap: 2px;
 }
 
-.app-file__action {
+/* Shared button reset first, so the state rules below can override it.
+   Ordering matters here: these are all single-class selectors, so the last
+   matching declaration wins. */
+.app-file__icon,
+.app-file__text-action {
   background: none;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  padding: 3px 8px;
+  border: none;
+  padding: 3px 5px;
+  border-radius: 5px;
   font-size: 11px;
-  color: var(--text-secondary);
+  color: var(--text-tertiary);
   cursor: pointer;
-  white-space: nowrap;
+  /* Hidden until intent. Opacity rather than display, so the row never
+     reflows on hover. */
+  opacity: 0;
+  transition:
+    opacity 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-.app-file__action:hover:not(:disabled) {
-  background: var(--background-tertiary);
-  color: var(--text-color);
+.app-file__icon {
+  display: flex;
+  align-items: center;
 }
 
-.app-file__action:disabled {
-  opacity: 0.5;
+/* Focus-within matters as much as hover: without it these controls would be
+   completely unreachable by keyboard. */
+.app-file:hover .app-file__icon,
+.app-file:hover .app-file__text-action,
+.app-file:focus-within .app-file__icon,
+.app-file:focus-within .app-file__text-action {
+  opacity: 1;
+}
+
+/* A private file must read as private at rest. A state you have to hover to
+   discover is not a state the user can trust. */
+.app-file__icon--on {
+  opacity: 1;
+  color: var(--accent-color);
+}
+
+.app-file__icon:hover:not(:disabled),
+.app-file__text-action:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.app-file__text-action--danger:hover:not(:disabled) {
+  color: var(--error-color);
+}
+
+.app-file__icon:disabled,
+.app-file__text-action:disabled {
   cursor: default;
 }
 
-.app-file__action--danger:hover:not(:disabled) {
-  color: var(--error-color, var(--text-color));
-  border-color: var(--error-color, var(--border-color));
-}
-
-.app-files__empty,
-.app-files__reclaim,
-.app-files__error {
-  margin: 0;
-  font-size: 12px;
-  color: var(--text-secondary);
-}
-
-.app-files__error {
-  color: var(--error-color, var(--text-color));
+/* Hairline along the row's bottom edge. Motion is what says "working" on a
+   multi-GB upload; a percentage alone reads as frozen between updates. */
+.app-file__progress {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 1.5px;
+  border-radius: 1px;
+  background: var(--accent-color);
+  transition: width 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }

--- a/ui/components/Apps/AppFilesPanel.css
+++ b/ui/components/Apps/AppFilesPanel.css
@@ -1,0 +1,145 @@
+/**
+ * App Files panel styling — Liquid Glass tokens only, no hardcoded colours,
+ * so the panel follows light/dark and any future theme without edits.
+ */
+
+.app-files {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.app-files__drop {
+  border: 1.5px dashed var(--border-color);
+  border-radius: 12px;
+  padding: 20px 16px;
+  text-align: center;
+  background: var(--background-secondary);
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+/* Only a border and tint on drag — no growing or jumping, which reads as a
+   glitch when someone is dragging a file across the window. */
+.app-files__drop--active {
+  border-color: var(--accent-color);
+  background: var(--background-hover);
+}
+
+.app-files__drop-title {
+  margin: 0 0 4px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.app-files__drop-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.app-files__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.app-file {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+}
+
+.app-file:hover {
+  background: var(--background-hover);
+}
+
+.app-file__glyph {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+/* Verified and local — the only state that reads as fully settled. */
+.app-file__glyph--filled {
+  color: var(--accent-color);
+}
+
+.app-file__glyph--slashed {
+  color: var(--error-color, var(--text-secondary));
+}
+
+.app-file__body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.app-file__name {
+  font-size: 13px;
+  color: var(--text-color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-file__meta {
+  font-size: 11px;
+  color: var(--text-secondary);
+  /* Tabular figures stop the progress line jittering as digits change — a
+     number that twitches every 200 ms is hard to read and looks broken. */
+  font-variant-numeric: tabular-nums;
+}
+
+.app-file__private {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.app-file__action {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 3px 8px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.app-file__action:hover:not(:disabled) {
+  background: var(--background-tertiary);
+  color: var(--text-color);
+}
+
+.app-file__action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.app-file__action--danger:hover:not(:disabled) {
+  color: var(--error-color, var(--text-color));
+  border-color: var(--error-color, var(--border-color));
+}
+
+.app-files__empty,
+.app-files__reclaim,
+.app-files__error {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.app-files__error {
+  color: var(--error-color, var(--text-color));
+}

--- a/ui/components/Apps/AppFilesPanel.tsx
+++ b/ui/components/Apps/AppFilesPanel.tsx
@@ -1,0 +1,150 @@
+/**
+ * App Files panel — drop large files here instead of into git.
+ *
+ * Design rules this enforces, from the requirements:
+ *   - Zero sharing prompts during upload. Dropping a file uploads it; privacy
+ *     is a property you can change afterwards, not a question asked up front.
+ *   - Nothing is ever deleted without an explicit tap.
+ *   - Honest progress for multi-GB files, so a slow upload is legible as slow
+ *     rather than stuck.
+ */
+
+import React, { useCallback, useEffect, useState } from "react";
+import type { AppFileRow } from "../../../src/gateway/services/appFiles/appFilesSchema";
+import {
+  evictAppFile,
+  listAppFiles,
+  removeAppFile,
+  setAppFilePrivacy,
+  uploadAppFile,
+} from "../../utils/appFilesApi";
+import { formatBytes, reclaimableBytes } from "../../utils/appFilesFormat";
+import { AppFileRowItem } from "./AppFileRowItem";
+import "./AppFilesPanel.css";
+
+interface AppFilesPanelProps {
+  appId: string;
+}
+
+export function AppFilesPanel({ appId }: AppFilesPanelProps) {
+  const [files, setFiles] = useState<AppFileRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dragging, setDragging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setFiles(await listAppFiles(appId));
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [appId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const onDrop = useCallback(
+    async (event: React.DragEvent) => {
+      event.preventDefault();
+      setDragging(false);
+
+      // Electron exposes the real path, so the gateway streams from disk and
+      // the renderer never holds the bytes — the only way a 10 GB drop works.
+      const paths = Array.from(event.dataTransfer.files)
+        .map((file) => (file as File & { path?: string }).path)
+        .filter((path): path is string => Boolean(path));
+
+      if (paths.length === 0) {
+        setError("Could not read the dropped file's location.");
+        return;
+      }
+
+      for (const path of paths) {
+        try {
+          await uploadAppFile(appId, path);
+        } catch (err) {
+          setError((err as Error).message);
+        }
+      }
+      await refresh();
+    },
+    [appId, refresh],
+  );
+
+  const withBusy = useCallback(
+    async (id: string, action: () => Promise<unknown>) => {
+      setBusyId(id);
+      try {
+        await action();
+        await refresh();
+      } catch (err) {
+        setError((err as Error).message);
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [refresh],
+  );
+
+  const reclaimable = reclaimableBytes(files);
+
+  return (
+    <div className="app-files">
+      <div
+        className={`app-files__drop${dragging ? " app-files__drop--active" : ""}`}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => void onDrop(e)}
+      >
+        <p className="app-files__drop-title">Drop files to store them</p>
+        <p className="app-files__drop-hint">
+          Video, audio and datasets of any size. They stay out of git.
+        </p>
+      </div>
+
+      {error && <p className="app-files__error">{error}</p>}
+
+      {loading ? (
+        <p className="app-files__empty">Loading…</p>
+      ) : files.length === 0 ? (
+        <p className="app-files__empty">No files yet.</p>
+      ) : (
+        <ul className="app-files__list">
+          {files.map((file) => (
+            <AppFileRowItem
+              key={file.id}
+              file={file}
+              busy={busyId === file.id}
+              onTogglePrivate={(isPrivate) =>
+                void withBusy(file.id, () =>
+                  setAppFilePrivacy(appId, file.id, isPrivate),
+                )
+              }
+              onEvict={() =>
+                void withBusy(file.id, () => evictAppFile(appId, file.object_key))
+              }
+              onRemove={() =>
+                void withBusy(file.id, () => removeAppFile(appId, file.id))
+              }
+            />
+          ))}
+        </ul>
+      )}
+
+      {reclaimable > 0 && (
+        <p className="app-files__reclaim">
+          Free {formatBytes(reclaimable)} — files stay in the cloud. Use
+          &ldquo;Free space&rdquo; on any file above.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/components/Apps/AppFilesPanel.tsx
+++ b/ui/components/Apps/AppFilesPanel.tsx
@@ -110,7 +110,12 @@ export function AppFilesPanel({ appId }: { appId: string }) {
 
       {error && <p className="app-files__error">{error}</p>}
 
-      {loading ? null : files.length === 0 ? (
+      {loading ? (
+        // Never render an empty box. If the gateway is slow or down this
+        // state can persist, and a panel with only a heading looks broken
+        // rather than busy.
+        <p className="app-files__empty">Loading…</p>
+      ) : files.length === 0 ? (
         <p className="app-files__empty">Drop a file to store it outside git.</p>
       ) : (
         <ul className="app-files__list">

--- a/ui/components/Apps/AppFilesPanel.tsx
+++ b/ui/components/Apps/AppFilesPanel.tsx
@@ -1,12 +1,17 @@
 /**
- * App Files panel — drop large files here instead of into git.
+ * App Files — store large files with an app instead of in git.
  *
- * Design rules this enforces, from the requirements:
- *   - Zero sharing prompts during upload. Dropping a file uploads it; privacy
- *     is a property you can change afterwards, not a question asked up front.
- *   - Nothing is ever deleted without an explicit tap.
- *   - Honest progress for multi-GB files, so a slow upload is legible as slow
- *     rather than stuck.
+ * One job: drop a file, it is stored. Everything else is secondary and stays
+ * out of sight until needed.
+ *
+ * Two decisions worth naming:
+ *
+ *   - The drop zone only appears when the list is empty or a drag is in
+ *     progress. A permanent dashed box would occupy the panel forever to teach
+ *     something learned once; when files exist, the list itself is the target.
+ *   - Row actions are revealed on hover, like Finder and Mail. Three controls
+ *     on every row is visual noise proportional to file count; at rest the
+ *     list reads as name and size, which is what someone scans for.
  */
 
 import React, { useCallback, useEffect, useState } from "react";
@@ -18,15 +23,11 @@ import {
   setAppFilePrivacy,
   uploadAppFile,
 } from "../../utils/appFilesApi";
-import { formatBytes, reclaimableBytes } from "../../utils/appFilesFormat";
+import { formatBytes, totalBytes } from "../../utils/appFilesFormat";
 import { AppFileRowItem } from "./AppFileRowItem";
 import "./AppFilesPanel.css";
 
-interface AppFilesPanelProps {
-  appId: string;
-}
-
-export function AppFilesPanel({ appId }: AppFilesPanelProps) {
+export function AppFilesPanel({ appId }: { appId: string }) {
   const [files, setFiles] = useState<AppFileRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [dragging, setDragging] = useState(false);
@@ -53,17 +54,16 @@ export function AppFilesPanel({ appId }: AppFilesPanelProps) {
       event.preventDefault();
       setDragging(false);
 
-      // Electron exposes the real path, so the gateway streams from disk and
-      // the renderer never holds the bytes — the only way a 10 GB drop works.
+      // Electron gives the real path, so the gateway streams from disk and the
+      // renderer never holds the bytes — the only way a 10 GB drop works.
       const paths = Array.from(event.dataTransfer.files)
         .map((file) => (file as File & { path?: string }).path)
         .filter((path): path is string => Boolean(path));
 
       if (paths.length === 0) {
-        setError("Could not read the dropped file's location.");
+        setError("Could not read that file's location.");
         return;
       }
-
       for (const path of paths) {
         try {
           await uploadAppFile(appId, path);
@@ -76,7 +76,7 @@ export function AppFilesPanel({ appId }: AppFilesPanelProps) {
     [appId, refresh],
   );
 
-  const withBusy = useCallback(
+  const act = useCallback(
     async (id: string, action: () => Promise<unknown>) => {
       setBusyId(id);
       try {
@@ -91,31 +91,27 @@ export function AppFilesPanel({ appId }: AppFilesPanelProps) {
     [refresh],
   );
 
-  const reclaimable = reclaimableBytes(files);
+  const stored = totalBytes(files);
 
   return (
-    <div className="app-files">
-      <div
-        className={`app-files__drop${dragging ? " app-files__drop--active" : ""}`}
-        onDragOver={(e) => {
-          e.preventDefault();
-          setDragging(true);
-        }}
-        onDragLeave={() => setDragging(false)}
-        onDrop={(e) => void onDrop(e)}
-      >
-        <p className="app-files__drop-title">Drop files to store them</p>
-        <p className="app-files__drop-hint">
-          Video, audio and datasets of any size. They stay out of git.
-        </p>
-      </div>
+    <section
+      className={`app-files${dragging ? " app-files--dragging" : ""}`}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragging(true);
+      }}
+      onDragLeave={() => setDragging(false)}
+      onDrop={(e) => void onDrop(e)}
+    >
+      <header className="app-files__head">
+        <h3>Files</h3>
+        {stored > 0 && <span className="app-files__total">{formatBytes(stored)}</span>}
+      </header>
 
       {error && <p className="app-files__error">{error}</p>}
 
-      {loading ? (
-        <p className="app-files__empty">Loading…</p>
-      ) : files.length === 0 ? (
-        <p className="app-files__empty">No files yet.</p>
+      {loading ? null : files.length === 0 ? (
+        <p className="app-files__empty">Drop a file to store it outside git.</p>
       ) : (
         <ul className="app-files__list">
           {files.map((file) => (
@@ -124,27 +120,14 @@ export function AppFilesPanel({ appId }: AppFilesPanelProps) {
               file={file}
               busy={busyId === file.id}
               onTogglePrivate={(isPrivate) =>
-                void withBusy(file.id, () =>
-                  setAppFilePrivacy(appId, file.id, isPrivate),
-                )
+                void act(file.id, () => setAppFilePrivacy(appId, file.id, isPrivate))
               }
-              onEvict={() =>
-                void withBusy(file.id, () => evictAppFile(appId, file.object_key))
-              }
-              onRemove={() =>
-                void withBusy(file.id, () => removeAppFile(appId, file.id))
-              }
+              onEvict={() => void act(file.id, () => evictAppFile(appId, file.object_key))}
+              onRemove={() => void act(file.id, () => removeAppFile(appId, file.id))}
             />
           ))}
         </ul>
       )}
-
-      {reclaimable > 0 && (
-        <p className="app-files__reclaim">
-          Free {formatBytes(reclaimable)} — files stay in the cloud. Use
-          &ldquo;Free space&rdquo; on any file above.
-        </p>
-      )}
-    </div>
+    </section>
   );
 }

--- a/ui/components/Apps/MiniAppFilesView.tsx
+++ b/ui/components/Apps/MiniAppFilesView.tsx
@@ -13,6 +13,7 @@ import { WorkspaceCodeEditor } from "./WorkspaceCodeEditor";
 import { WorkspaceDbPreview } from "./WorkspaceDbPreview";
 import { WorkspaceFileTree } from "./WorkspaceFileTree";
 import { MiniAppDataSourcesPanel } from "./MiniAppDataSourcesPanel";
+import { AppFilesPanel } from "./AppFilesPanel";
 import { MiniAppCodeSearch } from "./MiniAppCodeSearch";
 import "./MiniAppFilesView.css";
 import "./WorkspaceCodeEditor.css";
@@ -122,6 +123,11 @@ export function MiniAppFilesView({ appId }: MiniAppFilesViewProps) {
 
         <div className="mini-app-files__tree">
           <MiniAppDataSourcesPanel appId={appId} />
+
+          {/* Beside data sources rather than in the file tree: App Files are
+              attached storage, not source code, and must never look like
+              something git carries. */}
+          <AppFilesPanel appId={appId} />
 
           {appGroup.length === 0 && jobGroups.length === 0 && !workspace.loadingTree ? (
             <p className="mini-app-files__empty">No files found.</p>

--- a/ui/utils/appFilesApi.ts
+++ b/ui/utils/appFilesApi.ts
@@ -22,6 +22,14 @@ async function call<T>(path: string, body?: unknown): Promise<T> {
     const detail = await res.text().catch(() => "");
     throw new Error(detail.slice(0, 200) || `Request failed (${res.status})`);
   }
+  // A 200 carrying HTML means the SPA fallback answered instead of the API —
+  // the gateway is still booting, or its routes are not registered yet.
+  // Without this check res.json() throws "Unexpected token <", which sends
+  // whoever debugs it looking for a JSON bug that does not exist.
+  const contentType = res.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    throw new Error("Gateway is still starting — try again in a moment.");
+  }
   return (await res.json()) as T;
 }
 

--- a/ui/utils/appFilesApi.ts
+++ b/ui/utils/appFilesApi.ts
@@ -1,0 +1,72 @@
+/**
+ * Gateway API for App Files — the desktop panel's view of /api/files/*.
+ *
+ * Uploads deliberately go through the desktop path (`filePath`) rather than
+ * the browser blob path: the file is already on this machine, so streaming it
+ * from disk avoids loading it into the renderer at all. The browser SDK exists
+ * for mini-apps, where there is no filesystem to read from.
+ */
+
+import type { AppFileRow } from "../../src/gateway/services/appFiles/appFilesSchema";
+import { getGatewayHttpBase } from "./gatewayHttpBase";
+
+const GATEWAY = getGatewayHttpBase();
+
+async function call<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(`${GATEWAY}${path}`, {
+    method: body === undefined ? "GET" : "POST",
+    headers: body === undefined ? {} : { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(detail.slice(0, 200) || `Request failed (${res.status})`);
+  }
+  return (await res.json()) as T;
+}
+
+export async function listAppFiles(appId: string): Promise<AppFileRow[]> {
+  const body = await call<{ files: AppFileRow[] }>(
+    `/api/files?appId=${encodeURIComponent(appId)}`,
+  );
+  return body.files ?? [];
+}
+
+export async function uploadAppFile(
+  appId: string,
+  filePath: string,
+  options: { scope?: "app" | "user"; mime?: string } = {},
+): Promise<{ id: string; verified: boolean; deduped: boolean }> {
+  return call(`/api/files/upload`, {
+    appId,
+    filePath,
+    scope: options.scope,
+    mime: options.mime,
+  });
+}
+
+export async function removeAppFile(appId: string, id: string): Promise<boolean> {
+  const body = await call<{ deleted: boolean }>(`/api/files/delete`, { appId, id });
+  return body.deleted;
+}
+
+/** Mark a file "never publish me", or undo it. */
+export async function setAppFilePrivacy(
+  appId: string,
+  id: string,
+  isPrivate: boolean,
+): Promise<{ visibility: string }> {
+  return call(`/api/files/visibility`, { appId, id, isPrivate });
+}
+
+/** Drop the local copy, keeping the cloud one. Never called automatically. */
+export async function evictAppFile(
+  appId: string,
+  objectKey: string,
+): Promise<boolean> {
+  const body = await call<{ evicted: boolean }>(`/api/files/evict`, {
+    appId,
+    objectKey,
+  });
+  return body.evicted;
+}

--- a/ui/utils/appFilesFormat.ts
+++ b/ui/utils/appFilesFormat.ts
@@ -1,0 +1,113 @@
+/**
+ * Formatting and state logic for the App Files panel.
+ *
+ * Pure and separate from the component because the honesty rules live here: a
+ * multi-GB upload is watched, and a progress line that rounds badly or invents
+ * an ETA out of two samples reads as a stall. These are the parts worth
+ * testing directly.
+ */
+
+import type { AppFileRow } from "../../src/gateway/services/appFiles/appFilesSchema";
+
+/** Bytes as a human reads them. GB for anything large — "6871 MB" is unreadable. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  // One decimal below 100 keeps "6.7 GB" precise without "6.70 GB" noise.
+  return `${value < 100 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}
+
+/** Transfer rate. Same rounding rules as size, per second. */
+export function formatRate(bytesPerSecond: number): string {
+  if (bytesPerSecond <= 0) return "—";
+  return `${formatBytes(bytesPerSecond)}/s`;
+}
+
+/**
+ * Time remaining, in the coarsest unit that is still useful.
+ *
+ * Returns null rather than guessing: an ETA computed from a fraction of a
+ * second of samples swings wildly, and a number that jumps from 2 min to 4 h
+ * and back is worse than no number.
+ */
+export function formatEta(seconds: number | null): string | null {
+  if (seconds === null || !Number.isFinite(seconds) || seconds <= 0) return null;
+  if (seconds < 60) return `~${Math.round(seconds)} sec`;
+  if (seconds < 3600) return `~${Math.round(seconds / 60)} min`;
+  const hours = seconds / 3600;
+  return `~${hours < 10 ? hours.toFixed(1) : Math.round(hours)} h`;
+}
+
+/**
+ * The progress line for an upload in flight.
+ *
+ * Deliberately verbose: "4.2 GB / 6.7 GB · 5.3 MB/s · ~8 min" answers "is this
+ * moving and when will it end" at a glance. A bare percentage answers neither.
+ */
+export function formatProgressLine(
+  uploadedBytes: number,
+  totalBytes: number,
+  bytesPerSecond: number,
+  etaSeconds: number | null,
+): string {
+  const parts = [`${formatBytes(uploadedBytes)} / ${formatBytes(totalBytes)}`];
+  if (bytesPerSecond > 0) parts.push(formatRate(bytesPerSecond));
+  const eta = formatEta(etaSeconds);
+  if (eta) parts.push(eta);
+  return parts.join(" · ");
+}
+
+export type FileGlyph = "filled" | "ring" | "hollow" | "slashed";
+
+/**
+ * Which of the four state glyphs a file shows.
+ *
+ * One glyph per state, no colour-only distinction — the state has to survive
+ * being printed in greyscale or seen by someone who cannot distinguish red
+ * from green.
+ */
+export function glyphForFile(row: AppFileRow): FileGlyph {
+  if (row.upload_state === "failed") return "slashed";
+  if (row.upload_state !== "verified") return "ring";
+  // Verified: filled when a local copy is also present, hollow when the bytes
+  // live only in the cloud. The difference matters because opening a hollow
+  // file costs a download.
+  return row.local_path ? "filled" : "hollow";
+}
+
+/** Plain-language state, for the row's secondary line and the glyph's title. */
+export function describeFileState(row: AppFileRow): string {
+  switch (row.upload_state) {
+    case "verified":
+      return row.local_path ? "On this Mac and in the cloud" : "In the cloud";
+    case "failed":
+      return "Upload failed — will resume";
+    case "uploading":
+      return "Uploading";
+    default:
+      return "Waiting to upload";
+  }
+}
+
+/**
+ * Bytes that could be freed by dropping local copies.
+ *
+ * Only verified files count. Anything else has no confirmed cloud copy, so
+ * deleting the local one could destroy someone's only copy.
+ */
+export function reclaimableBytes(rows: readonly AppFileRow[]): number {
+  return rows
+    .filter((row) => row.upload_state === "verified" && row.local_path)
+    .reduce((sum, row) => sum + row.size_bytes, 0);
+}
+
+/** True when a file is safe to evict — verified, with a local copy to drop. */
+export function canEvict(row: AppFileRow): boolean {
+  return row.upload_state === "verified" && Boolean(row.local_path);
+}

--- a/ui/utils/appFilesFormat.ts
+++ b/ui/utils/appFilesFormat.ts
@@ -107,6 +107,28 @@ export function reclaimableBytes(rows: readonly AppFileRow[]): number {
     .reduce((sum, row) => sum + row.size_bytes, 0);
 }
 
+/** Everything stored, for the one number in the panel header. */
+export function totalBytes(rows: readonly AppFileRow[]): number {
+  return rows.reduce((sum, row) => sum + row.size_bytes, 0);
+}
+
+/**
+ * Whole-percent progress, or null when the file is not uploading.
+ *
+ * Whole numbers on purpose: a decimal that changes several times a second is
+ * harder to read than one that ticks, and carries no more information.
+ *
+ * Never returns 100 for an upload still in flight — showing 100% while the
+ * server is still verifying is the single most common way a progress
+ * indicator lies, and it makes the last seconds feel broken.
+ */
+export function uploadPercent(row: AppFileRow): number | null {
+  if (row.upload_state !== "uploading") return null;
+  if (row.size_bytes <= 0) return 0;
+  const percent = (row.bytes_uploaded / row.size_bytes) * 100;
+  return Math.min(99, Math.floor(percent));
+}
+
 /** True when a file is safe to evict — verified, with a local copy to drop. */
 export function canEvict(row: AppFileRow): boolean {
   return row.upload_state === "verified" && Boolean(row.local_path);


### PR DESCRIPTION
Large files — recordings, datasets, video — cannot live in git. Repo hygiene rejects anything over 25 MB, and git keeps every version forever regardless. This PR completes App Files: the bytes live in object storage, the database holds a small pointer row, and no caller ever sees a bucket, a token, or a chunk.

Phases 3–5, driven throughout by one scenario: **a 10 GB recording, and a laptop that dies at 9 GB.**

## Phase 3 — cloud URLs

`/api/files/url` now works on `apps.papr.ai`, so a published app can load a file it references instead of 404ing. CDN URL when the file is public, signed URL when it is private.

## Phase 4 — durable resume + SDK

**The bug that mattered.** The GCS resumable session URI lived in a local variable and died with the process. A crash at 9 GB meant re-hashing 10 GB and re-sending 10 GB.

GCS keeps a session alive for **7 days**. Now we persist it (`upload_session_uri`, `bytes_uploaded`, `session_expires_at`), so a closed laptop resumes over a weekend. Hashes cache on `(path, size, mtime)` — `addFile` previously made two full passes over the file, and a retry paid both again. Chunks retry individually with exponential backoff and full jitter, so a transient 503 at 9 GB costs one 8 MiB chunk rather than the transfer.

Existing installs migrate via `ALTER`, since `CREATE TABLE IF NOT EXISTS` is a no-op once the table exists.

**The SDK** — four calls, served from `/__papr__/papr-files.js` in both runtimes:

```ts
const { id }  = await papr.files.upload(file, { onProgress });
const { url } = await papr.files.url(id);
const files   = await papr.files.list();
await papr.files.remove(id);
```

Bytes go **browser → object storage directly**. Routing them through the gateway would have rebuilt exactly the Parse Server upload pattern this design exists to avoid: server memory proportional to file size, double bandwidth, and no resume. The gateway only mints a ticket and verifies the commit. There is a test asserting this:

```
✓ never sends the payload through the gateway
  → gatewayCalls === ["POST /api/files/ticket", "POST /api/files/commit"]
```

Two judgement calls worth review:

- **Content fingerprint is head+tail+size, not a full SHA-256.** WebCrypto has no streaming digest, so hashing 10 GB in a tab means holding 10 GB in memory. The server derives the real object key and verifies MD5 after the bytes land, so correctness stays server-side.
- **Cloud is read-only** (`url` + `list`). Letting a visitor upload into the owner's storage is a different trust decision from viewing published assets, and it is not designed yet.

## Phase 5 — CORS + desktop UI

**CORS** (`scripts/app-files-cors.sh`). Verified against `gs://papr-app-files`; the policy was already correct, so the script is idempotent and doubles as the check. It verifies `Range` in `expose-headers` **separately**, because that header only appears on a real request and never on a preflight — and without it the PUT still succeeds while JS cannot read the committed offset, so every resumed upload silently restarts at byte 0.

**UI** — a Files panel beside Data sources in the mini-app workspace. Attached storage is not source code and should not look like something git carries.

One 30px row: dot · name · size. Actions reveal on hover *and* `:focus-within` — without the latter they are unreachable by keyboard. The private lock stays visible at rest, because a state you must hover to discover is not one the user can trust. Progress changes the size slot to a percentage and fills a 1.5px hairline, so nothing moves or reflows.

`uploadPercent` never returns 100 while bytes are in flight — sitting at 100% through server verification is the most common way a progress indicator lies.

Final commit fixes an empty panel: `loading` rendered `null`, so when the gateway was slow the panel drew a heading and nothing else, which reads as broken rather than busy. The API client now also rejects a 200 carrying HTML — when the gateway is booting, the SPA fallback answers `/api/*` with `index.html`, and `res.json()` then throws "Unexpected token <", sending whoever debugs it hunting a JSON bug that does not exist.

## Verification

**74 backend tests across 7 suites; 20 UI tests.** Gateway typecheck clean.

The end-to-end runs a **real Express gateway and real SQLite**, pushing 16 MB through ticket → chunked PUT → commit → url → delete. Only the memory server and GCS are faked. It asserts the session URI is on the row *before* any byte moves, and cleared once verified.

Pre-existing failures unchanged: 2 in `mini-app-cloud-compatibility`, 45 in UI (`MessageList`, `remarkMathGate`) — both verified byte-identical against a stash. UI passing went 142 → 162.

## Not yet exercised

The fakes cannot prove the real thing. After merge, worth doing once by hand: drop a real recording, kill the gateway mid-upload, restart, and confirm it resumes rather than restarting.
