### PR TITLE
fix: Delete button on published apps + stop vitest writing to the real workspace

### DIFF
--- a/src/core/utils/paprRoot.ts
+++ b/src/core/utils/paprRoot.ts
@@ -6,6 +6,7 @@
  * Cloud agent gateway: per-run clone mounted at PAPR_HOME
  */
 
+import fs from "fs";
 import os from "os";
 import path from "path";
 import {
@@ -30,12 +31,54 @@ export function getPaprRoot(): string {
   // Cloud agent runs use ephemeral PAPR_HOME clones — no desktop pointer file.
   if (isCloudAgentGatewayMode() || !pointer?.paprHome) {
     if (override) {
-      return path.resolve(override);
+      return assertNotLeakingIntoRealWorkspace(path.resolve(override));
     }
-    return getPaprBaseDir();
+    return assertNotLeakingIntoRealWorkspace(getPaprBaseDir());
   }
 
-  return path.resolve(pointer.paprHome);
+  return assertNotLeakingIntoRealWorkspace(path.resolve(pointer.paprHome));
+}
+
+/**
+ * Under vitest, a workspace root outside the OS temp dir means a test is about
+ * to write into the developer's REAL workspace. On 2026-08-12 this silently
+ * created ~305 fixture apps and 462 job folders in a live workspace because
+ * suites patched only `os.homedir`, while getPaprRoot() prefers the
+ * .active-workspace.json pointer read from the real home.
+ *
+ * Fail loudly instead. Tests must use tests/setup/isolatedWorkspace.ts.
+ */
+function assertNotLeakingIntoRealWorkspace(resolvedRoot: string): string {
+  if (!process.env.VITEST && process.env.NODE_ENV !== "test") {
+    return resolvedRoot;
+  }
+  if (process.env.PAPR_ALLOW_REAL_WORKSPACE_IN_TESTS === "1") {
+    return resolvedRoot;
+  }
+
+  const tmpRoot = path.resolve(fs.realpathSync.native(os.tmpdir()));
+  let candidate = path.resolve(resolvedRoot);
+  try {
+    // macOS /var/folders is a symlink to /private/var/folders — compare real paths.
+    candidate = path.resolve(fs.realpathSync.native(candidate));
+  } catch {
+    /* not created yet — compare the literal path */
+  }
+
+  if (candidate === tmpRoot || candidate.startsWith(`${tmpRoot}${path.sep}`)) {
+    return resolvedRoot;
+  }
+
+  throw new Error(
+    `[paprRoot] Refusing to use a real Papr workspace during tests: ${candidate}\n` +
+      `Tests must not write to the developer's live workspace.\n` +
+      `Fix: import { useIsolatedPaprWorkspace } from "../tests/setup/isolatedWorkspace.js" ` +
+      `and call it in your describe block.\n` +
+      `Patching os.homedir alone is NOT enough — getPaprRoot() prefers ` +
+      `~/Papr/.active-workspace.json and re-syncs PAPR_HOME from it.\n` +
+      `Escape hatch (only for tests that intentionally read the real workspace): ` +
+      `PAPR_ALLOW_REAL_WORKSPACE_IN_TESTS=1`,
+  );
 }
 
 export function getPaprJobsRoot(): string {

--- a/src/gateway/services/AppService.ts
+++ b/src/gateway/services/AppService.ts
@@ -88,6 +88,36 @@ export const DEFAULT_HOME_APP_ID = "bbb7e17e-c810-47ef-b9ce-c8a83c0cd16c";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+/**
+ * Budget for the pre-delete cloud publish check. cloudApiFetch allows itself
+ * 60s, which exceeded the client's request timeout and surfaced as a bogus
+ * "Request timeout" in the Apps UI. Deleting must stay responsive, so give the
+ * check a short window and fall back to "not published".
+ */
+const CLOUD_PUBLISH_STATUS_TIMEOUT_MS = 8_000;
+
+/** Reject with a descriptive error if `promise` outlives `ms`. */
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Timed out after ${ms}ms: ${label}`)),
+          ms,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export interface MiniAppCloudLineage {
   mode: "fork" | "track";
   sourceAppId: string;
@@ -1729,7 +1759,18 @@ export class AppService {
       const { getCloudAppPublishService } = await import(
         "./CloudAppPublishService.js"
       );
-      cloudStatus = await getCloudAppPublishService().getCloudPublishStatus(id);
+      // This is a network round-trip to the memory server, and cloudApiFetch
+      // allows itself 60s. When it ran long, the whole delete blocked behind
+      // it and the UI reported "Request timeout" even though nothing had
+      // failed. The check is only an optimisation to decide whether to ask
+      // the user for unpublish confirmation, so cap it well under the
+      // client's budget and treat a slow answer as "not published" —
+      // matching the existing behaviour when the request errors.
+      cloudStatus = await withTimeout(
+        getCloudAppPublishService().getCloudPublishStatus(id),
+        CLOUD_PUBLISH_STATUS_TIMEOUT_MS,
+        `cloud publish status for ${id}`,
+      );
     } catch (error) {
       console.warn(
         `[AppService] Could not check cloud publish status for ${id}:`,

--- a/src/gateway/websocket/app.ts
+++ b/src/gateway/websocket/app.ts
@@ -278,11 +278,17 @@ export async function setupAppHandlers(
         const result = await appService.deleteApp(payload.appId, {
           unpublishFromCloud: payload.unpublishFromCloud === true,
         });
+        // requiresUnpublishConfirm is a valid negotiated response, not a
+        // failure. The client transport rejects the promise whenever
+        // success is false (with "Unknown error", since no error string is
+        // set), so marking it false made the Delete button appear to do
+        // nothing and surfaced a bogus retry error. Only a genuinely absent
+        // or failed delete is success: false.
         ws.send(
           JSON.stringify({
             id: message.id,
             type: "app:delete:response",
-            success: result.deleted,
+            success: result.deleted || result.requiresUnpublishConfirm === true,
             data: result,
           }),
         );

--- a/tests/agent-attribution-tracking.test.ts
+++ b/tests/agent-attribution-tracking.test.ts
@@ -23,10 +23,22 @@ describe("Agent Attribution Tracking", () => {
   let documentService: DocumentService;
   let appService: AppService;
   let planService: PlanService;
+  let originalHome: string | undefined;
+  let originalPaprHome: string | undefined;
 
   beforeEach(async () => {
     // Clean up test directory
     await fs.remove(TEST_DATA_PATH);
+
+    // AppService/DocumentService/PlanService all resolve paths via getPaprRoot(),
+    // which prefers ~/Papr/.active-workspace.json from the REAL home. Without
+    // redirecting HOME *and* PAPR_HOME this suite wrote apps, documents and
+    // plans into the developer's live workspace.
+    originalHome = process.env.HOME;
+    originalPaprHome = process.env.PAPR_HOME;
+    process.env.HOME = TEST_DATA_PATH;
+    process.env.PAPR_HOME = path.join(TEST_DATA_PATH, "Papr");
+    await fs.ensureDir(path.join(TEST_DATA_PATH, "Papr"));
 
     // Initialize services
     storageProvider = new LocalStorageProvider(TEST_DATA_PATH);
@@ -49,6 +61,11 @@ describe("Agent Attribution Tracking", () => {
     // Clean up
     storageProvider.close();
     planService.close();
+    appService.cleanup?.();
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalPaprHome === undefined) delete process.env.PAPR_HOME;
+    else process.env.PAPR_HOME = originalPaprHome;
     await fs.remove(TEST_DATA_PATH);
   });
 

--- a/tests/app-delete-publish-confirm.test.ts
+++ b/tests/app-delete-publish-confirm.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Regression: deleting a PUBLISHED mini-app appeared to do nothing, then
+ * surfaced a bogus "Unknown error" retry.
+ *
+ * Chain that caused it:
+ *   1. AppService.deleteApp returns { deleted: false, requiresUnpublishConfirm: true }
+ *      — a negotiation, not a failure.
+ *   2. The app:delete handler set `success: result.deleted` → false.
+ *   3. gateway.ts rejects the promise whenever success is false, using
+ *      `response.error || "Unknown error"` — and no error string is ever set
+ *      for this case.
+ *
+ * So the UI never got to read requiresUnpublishConfirm; the promise had
+ * already rejected. These tests pin the envelope contract on both sides.
+ */
+
+type DeleteAppResult = {
+  deleted: boolean;
+  requiresUnpublishConfirm?: boolean;
+  shareUrl?: string | null;
+  appTitle?: string;
+};
+
+/** Mirrors the envelope rule in src/gateway/websocket/app.ts (app:delete). */
+function buildDeleteEnvelopeSuccess(result: DeleteAppResult): boolean {
+  return result.deleted || result.requiresUnpublishConfirm === true;
+}
+
+/** Mirrors the reject rule in ui/src/lib/gateway.ts send(). */
+function clientWouldReject(envelopeSuccess: boolean): boolean {
+  return !envelopeSuccess;
+}
+
+describe("app:delete envelope contract", () => {
+  it("does not reject when the app is published and needs confirmation", () => {
+    const result: DeleteAppResult = {
+      deleted: false,
+      requiresUnpublishConfirm: true,
+      shareUrl: "https://apps.papr.ai/ns/dash/",
+      appTitle: "Dash",
+    };
+
+    const success = buildDeleteEnvelopeSuccess(result);
+
+    expect(success).toBe(true);
+    // The critical assertion: the client must receive the payload so it can
+    // re-prompt with unpublishFromCloud: true.
+    expect(clientWouldReject(success)).toBe(false);
+  });
+
+  it("reports success for a normal delete", () => {
+    const success = buildDeleteEnvelopeSuccess({ deleted: true });
+    expect(success).toBe(true);
+    expect(clientWouldReject(success)).toBe(false);
+  });
+
+  it("still fails when the app does not exist", () => {
+    const success = buildDeleteEnvelopeSuccess({ deleted: false });
+    expect(success).toBe(false);
+    expect(clientWouldReject(success)).toBe(true);
+  });
+});

--- a/tests/app-delete-timeout.test.ts
+++ b/tests/app-delete-timeout.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Regression: clicking Delete on an app sometimes failed with "Request timeout"
+ * even though the delete succeeded server-side.
+ *
+ * Budget mismatch:
+ *   - gateway.send() default timeout ............ 30s
+ *   - cloudApiFetch() timeout ................... 60s
+ *
+ * deleteApp() awaits getCloudPublishStatus() (one cloudApiFetch) before
+ * deciding anything, and an unpublish then flips every published App Files
+ * object private ONE AT A TIME, each its own cloudApiFetch, before the final
+ * DELETE. So a single slow request could exceed the client budget on its own,
+ * and an app with N published files had roughly N+2 sequential chances to.
+ *
+ * Fixes: raise the client budget to 90s (matching app:list) and cap the
+ * pre-delete status check server-side so it cannot consume the whole budget.
+ */
+
+const CLIENT_DELETE_TIMEOUT_MS = 90_000;
+const CLOUD_API_FETCH_TIMEOUT_MS = 60_000;
+const CLOUD_PUBLISH_STATUS_TIMEOUT_MS = 8_000;
+
+/** Mirrors withTimeout() in AppService.ts. */
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Timed out after ${ms}ms: ${label}`)),
+          ms,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+describe("app delete timeout budget", () => {
+  it("gives the client more time than a single cloud request can consume", () => {
+    expect(CLIENT_DELETE_TIMEOUT_MS).toBeGreaterThan(CLOUD_API_FETCH_TIMEOUT_MS);
+  });
+
+  it("caps the pre-delete publish check well under the client budget", () => {
+    expect(CLOUD_PUBLISH_STATUS_TIMEOUT_MS).toBeLessThan(
+      CLIENT_DELETE_TIMEOUT_MS,
+    );
+    // Must also beat cloudApiFetch's own timeout, otherwise the cap is a no-op.
+    expect(CLOUD_PUBLISH_STATUS_TIMEOUT_MS).toBeLessThan(
+      CLOUD_API_FETCH_TIMEOUT_MS,
+    );
+  });
+
+  it("withTimeout rejects a slow promise with a descriptive message", async () => {
+    const never = new Promise<string>(() => {});
+    await expect(withTimeout(never, 20, "publish status")).rejects.toThrow(
+      /Timed out after 20ms: publish status/,
+    );
+  });
+
+  it("withTimeout passes through a fast result untouched", async () => {
+    await expect(
+      withTimeout(Promise.resolve("published"), 1_000, "publish status"),
+    ).resolves.toBe("published");
+  });
+});

--- a/tests/app-file-edit.test.ts
+++ b/tests/app-file-edit.test.ts
@@ -1,7 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { promises as fs } from "fs";
-import path from "path";
-import os from "os";
+import { describe, it, expect } from "vitest";
+import { useIsolatedPaprWorkspace } from "./setup/isolatedWorkspace.js";
 import {
   applyExactStringReplacement,
   countOccurrences,
@@ -95,19 +93,11 @@ describe("exactStringReplace", () => {
 });
 
 describe("AppService.updateAppFile", () => {
-  let tmpDir: string;
-  let origHome: string;
-
-  beforeEach(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "papr-app-edit-test-"));
-    origHome = os.homedir;
-    (os as { homedir: () => string }).homedir = () => tmpDir;
-  });
-
-  afterEach(async () => {
-    (os as { homedir: () => string }).homedir = () => origHome;
-    await fs.rm(tmpDir, { recursive: true, force: true });
-  });
+  // Patching os.homedir alone is NOT enough — getPaprRoot() prefers
+  // ~/Papr/.active-workspace.json from the REAL home and re-syncs PAPR_HOME
+  // from it, so this suite used to create "Concurrent Edit App_N" fixtures in
+  // the developer's live workspace.
+  useIsolatedPaprWorkspace("papr-app-edit-test");
 
   it("serializes concurrent edits to the same file", async () => {
     const { AppService } = await import(

--- a/tests/bundle-service.test.ts
+++ b/tests/bundle-service.test.ts
@@ -24,6 +24,11 @@ async function createWorkspace(): Promise<{
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "papr-bundle-test-"));
   tmpRoots.push(root);
   process.env.HOME = root;
+  // HOME alone is not enough: getPaprRoot() prefers ~/Papr/.active-workspace.json
+  // (read from the REAL home) and re-syncs PAPR_HOME from it, so without this
+  // every createApp/createJob below lands in the developer's live workspace.
+  process.env.PAPR_HOME = path.join(root, "Papr");
+  await fs.mkdir(process.env.PAPR_HOME, { recursive: true });
   const appService = new AppService();
   const jobsService = new JobsService();
   await appService.initialize();

--- a/tests/data-contract-service.test.ts
+++ b/tests/data-contract-service.test.ts
@@ -9,6 +9,7 @@ import { getDataContractService } from "../src/gateway/services/DataContractServ
 
 describe("DataContractService", () => {
   let originalHome: string | undefined;
+  let originalPaprHome: string | undefined;
   let testHomeDir: string;
   let appService: AppService;
 
@@ -16,12 +17,16 @@ describe("DataContractService", () => {
     resetAppServiceSingletonForTests();
     resetJobsServiceSingletonForTests();
     originalHome = process.env.HOME;
+    originalPaprHome = process.env.PAPR_HOME;
     testHomeDir = path.join(
       os.tmpdir(),
       `paprwork-contract-svc-${Date.now()}`,
     );
     process.env.HOME = testHomeDir;
-    await fs.mkdir(testHomeDir, { recursive: true });
+    // HOME alone is not enough: getPaprRoot() prefers ~/Papr/.active-workspace.json
+    // (read from the REAL home) and re-syncs PAPR_HOME from it.
+    process.env.PAPR_HOME = path.join(testHomeDir, "Papr");
+    await fs.mkdir(path.join(testHomeDir, "Papr"), { recursive: true });
     appService = new AppService();
     await appService.initialize();
   });
@@ -34,6 +39,11 @@ describe("DataContractService", () => {
       delete process.env.HOME;
     } else {
       process.env.HOME = originalHome;
+    }
+    if (originalPaprHome === undefined) {
+      delete process.env.PAPR_HOME;
+    } else {
+      process.env.PAPR_HOME = originalPaprHome;
     }
     try {
       await fs.rm(testHomeDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });

--- a/tests/file-versioning.test.ts
+++ b/tests/file-versioning.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { promises as fs } from "fs";
 import path from "path";
 import os from "os";
+import { useIsolatedPaprWorkspace } from "./setup/isolatedWorkspace.js";
 
 /**
  * Test file versioning for mini-apps and jobs.
@@ -10,20 +11,10 @@ import os from "os";
  * We test the AppService and JobsService version methods directly.
  */
 
-let tmpDir: string;
-let origHome: string;
-
-beforeEach(async () => {
-  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "papr-version-test-"));
-  origHome = os.homedir;
-  // Override homedir to use our temp directory
-  (os as { homedir: () => string }).homedir = () => tmpDir;
-});
-
-afterEach(async () => {
-  (os as { homedir: () => string }).homedir = () => origHome;
-  await fs.rm(tmpDir, { recursive: true, force: true });
-});
+// Patching os.homedir alone leaked ~300 fixture apps into the real workspace
+// on 2026-08-12 — getPaprRoot() prefers ~/Papr/.active-workspace.json and
+// re-syncs PAPR_HOME from it. useIsolatedPaprWorkspace neutralises all paths.
+const workspace = useIsolatedPaprWorkspace("papr-version-test");
 
 describe("AppService file versioning", () => {
   it("should save a version before overwriting a file", async () => {
@@ -203,7 +194,7 @@ describe("Job file versioning (saveJobFileVersion helper)", () => {
     // Test the saveJobFileVersion helper from appJobs.ts directly
     // by creating the version structure manually (same format the helper uses)
     const jobId = "test-job-123";
-    const jobDir = path.join(tmpDir, "Papr", "jobs", jobId);
+    const jobDir = path.join(workspace.paprHome, "jobs", jobId);
     await fs.mkdir(jobDir, { recursive: true });
 
     const scriptPath = path.join(jobDir, "script.py");

--- a/tests/jobs-service.test.ts
+++ b/tests/jobs-service.test.ts
@@ -25,6 +25,11 @@ async function setupService(): Promise<JobsService> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "papr-jobs-test-"));
   tmpRoots.push(root);
   process.env.HOME = root;
+  // HOME alone is not enough: getPaprRoot() prefers ~/Papr/.active-workspace.json
+  // (read from the REAL home) and re-syncs PAPR_HOME from it. Without this the
+  // suite created hundreds of job folders in the developer's live workspace.
+  process.env.PAPR_HOME = path.join(root, "Papr");
+  await fs.mkdir(process.env.PAPR_HOME, { recursive: true });
   resetAppServiceSingletonForTests();
   resetJobsServiceSingletonForTests();
   const service = new JobsService();

--- a/tests/setup/isolatedWorkspace.ts
+++ b/tests/setup/isolatedWorkspace.ts
@@ -1,0 +1,119 @@
+/**
+ * Isolated Papr workspace for tests.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * getPaprRoot() resolves in this order:
+ *   1. ensureActiveWorkspaceEnvSynced() reads ~/Papr/.active-workspace.json
+ *   2. if that pointer exists, it WINS — and it even overwrites process.env.PAPR_HOME
+ *   3. only if there is no pointer does PAPR_HOME / getPaprBaseDir() apply
+ *
+ * getPaprBaseDir() is path.join(os.homedir(), "Papr"), so patching `os.homedir`
+ * or HOME alone is NOT enough: the pointer is read from the developer's REAL
+ * home and every createApp()/createJob() lands in their live workspace.
+ *
+ * That is exactly what happened on 2026-08-12 — a CI/local run leaked ~305
+ * fixture apps ("Subdir App_7", "Backend App_12", …) and 462 job folders into
+ * a real user workspace.
+ *
+ * This helper neutralises all three resolution paths at once by pointing HOME,
+ * PAPR_HOME and the pointer file itself at a temp dir.
+ */
+
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import { randomUUID } from "crypto";
+import { afterEach, beforeEach } from "vitest";
+
+export interface IsolatedWorkspace {
+  /** Fake HOME root for this test. */
+  readonly homeDir: string;
+  /** Resolved PAPR_HOME — the workspace under the fake home. */
+  readonly paprHome: string;
+}
+
+/**
+ * Registers beforeEach/afterEach hooks that redirect the entire Papr workspace
+ * to a per-test temp directory. Call at the top level of a describe block.
+ *
+ * Returns a live handle whose fields are populated before each test.
+ */
+export function useIsolatedPaprWorkspace(
+  label = "papr-test",
+): IsolatedWorkspace {
+  const handle = { homeDir: "", paprHome: "" } as {
+    homeDir: string;
+    paprHome: string;
+  };
+
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+  let originalPaprHome: string | undefined;
+  let originalPaprUserData: string | undefined;
+  let originalHomedir: typeof os.homedir;
+
+  beforeEach(async () => {
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    originalPaprHome = process.env.PAPR_HOME;
+    originalPaprUserData = process.env.PAPR_USER_DATA;
+    originalHomedir = os.homedir;
+
+    // randomUUID, not Date.now(): two tests starting in the same millisecond
+    // would otherwise silently share one workspace.
+    handle.homeDir = path.join(
+      os.tmpdir(),
+      `${label}-${process.pid}-${randomUUID()}`,
+    );
+    handle.paprHome = path.join(handle.homeDir, "Papr");
+
+    await fs.mkdir(handle.paprHome, { recursive: true });
+    await fs.mkdir(path.join(handle.homeDir, ".paprwork-v2"), {
+      recursive: true,
+    });
+
+    process.env.HOME = handle.homeDir;
+    process.env.USERPROFILE = handle.homeDir; // Windows
+    process.env.PAPR_HOME = handle.paprHome;
+    process.env.PAPR_USER_DATA = path.join(handle.homeDir, ".paprwork-v2");
+
+    // Modules that captured os.homedir at import time (AppService constructor
+    // computes legacy paths from it) must also see the temp home.
+    (os as { homedir: () => string }).homedir = () => handle.homeDir;
+
+    // Kill the pointer path: getActiveWorkspacePointerPath() joins
+    // getPaprBaseDir() (= <home>/Papr), so writing nothing here means
+    // readActiveWorkspacePointer() returns null and PAPR_HOME wins.
+    await fs
+      .rm(path.join(handle.paprHome, ".active-workspace.json"), { force: true })
+      .catch(() => {});
+  });
+
+  afterEach(async () => {
+    (os as { homedir: () => string }).homedir = originalHomedir;
+    restoreEnv("HOME", originalHome);
+    restoreEnv("USERPROFILE", originalUserProfile);
+    restoreEnv("PAPR_HOME", originalPaprHome);
+    restoreEnv("PAPR_USER_DATA", originalPaprUserData);
+
+    await fs
+      .rm(handle.homeDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 100,
+      })
+      .catch(() => {});
+  });
+
+  return handle;
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/ui/components/Apps/AppsView.tsx
+++ b/ui/components/Apps/AppsView.tsx
@@ -220,8 +220,30 @@ export function AppsView() {
       return;
     }
 
-    if (confirm("Are you sure you want to delete this app?")) {
-      await deleteArtifact(id, "app");
+    if (!confirm("Are you sure you want to delete this app?")) {
+      return;
+    }
+
+    try {
+      const result = await deleteArtifact(id, "app");
+      // The cached publish state can be stale or absent (e.g. apps published by
+      // a background sync, or a cache cleared on reinstall). In that case the
+      // first delete comes back as requiresUnpublishConfirm instead of
+      // deleting — re-prompt here rather than silently doing nothing.
+      if (result?.requiresUnpublishConfirm) {
+        const title = allApps.find((a) => a.id === id)?.title ?? "This app";
+        const where = result.shareUrl ? `\n${result.shareUrl}\n` : "";
+        if (
+          !confirm(
+            `“${title}” is published to the web.${where}\nDeleting will remove it from this workspace AND unpublish it from apps.papr.ai.\n\nContinue?`,
+          )
+        ) {
+          return;
+        }
+        await deleteArtifact(id, "app", { unpublishFromCloud: true });
+      }
+    } catch {
+      /* useArtifacts sets error */
     }
   };
 

--- a/ui/hooks/useArtifacts.ts
+++ b/ui/hooks/useArtifacts.ts
@@ -208,14 +208,24 @@ export function useArtifacts(scope: "all" | "apps" = "all") {
         const data = response.data as {
           deleted?: boolean;
           requiresUnpublishConfirm?: boolean;
+          shareUrl?: string | null;
         };
+        // Server says the app is live on the web. This is NOT an error — the
+        // caller must re-prompt and retry with unpublishFromCloud: true. The
+        // local publish cache goes stale (deleted/unpublished elsewhere), so
+        // AppsView cannot reliably pre-detect this before calling.
         if (data?.requiresUnpublishConfirm) {
-          throw new Error("Published app requires unpublish confirmation");
+          return {
+            deleted: false,
+            requiresUnpublishConfirm: true,
+            shareUrl: data.shareUrl ?? null,
+          };
         }
         if (data?.deleted === false) {
           throw new Error(`Failed to delete ${type}`);
         }
         removeArtifact(id);
+        return { deleted: true };
       } catch (err) {
         const message =
           err instanceof Error ? err.message : `Failed to delete ${type}`;

--- a/ui/hooks/useArtifacts.ts
+++ b/ui/hooks/useArtifacts.ts
@@ -199,12 +199,24 @@ export function useArtifacts(scope: "all" | "apps" = "all") {
           type === "document" ? "document:delete" : "app:delete";
         const payloadKey = type === "document" ? "documentId" : "appId";
 
-        const response = await gateway.send(messageType, {
-          [payloadKey]: id,
-          ...(type === "app" && options?.unpublishFromCloud
-            ? { unpublishFromCloud: true }
-            : {}),
-        });
+        // Deleting an app is not a local-only operation: the server checks
+        // cloud publish status, and an unpublish additionally flips every
+        // published App Files object to private one-by-one, then calls
+        // DELETE /v1/cloud/apps/publish. Each of those uses cloudApiFetch,
+        // whose own timeout is 60s — already twice the 30s default here, so
+        // a single slow request guaranteed a spurious "Request timeout" in
+        // the UI while the delete kept running server-side.
+        // Matches the 90s budget app:list already uses.
+        const response = await gateway.send(
+          messageType,
+          {
+            [payloadKey]: id,
+            ...(type === "app" && options?.unpublishFromCloud
+              ? { unpublishFromCloud: true }
+              : {}),
+          },
+          { timeoutMs: 90_000 },
+        );
         const data = response.data as {
           deleted?: boolean;
           requiresUnpublishConfirm?: boolean;

--- a/ui/src/lib/gateway.ts
+++ b/ui/src/lib/gateway.ts
@@ -296,7 +296,16 @@ class GatewayClient {
         if (response.success) {
           resolve(response);
         } else {
-          const error = new Error(response.error || "Unknown error");
+          // A handler that sets success: false without an error string used to
+          // surface as a bare "Unknown error" with no way to tell which
+          // request failed. Include the message type and any response data.
+          const error = new Error(
+            response.error ||
+              `Request "${type}" failed without an error message` +
+                (response.data
+                  ? ` (data: ${JSON.stringify(response.data).slice(0, 200)})`
+                  : ""),
+          );
           console.error(
             `[Gateway] Request failed - Type: ${type}, Error:`,
             error,


### PR DESCRIPTION
## Two independent bugs, both found while investigating ~305 stray mini-apps in a live workspace.

### 1. Delete button silently fails on published mini-apps

Clicking **Delete app** on a published app did nothing, then showed a bogus `Unknown error` on retry.

Three-step chain:

1. `AppService.deleteApp` returns `{ deleted: false, requiresUnpublishConfirm: true }` when the app is live on apps.papr.ai. That's a **negotiation, not a failure**.
2. The `app:delete` WS handler set `success: result.deleted` → `false`.
3. `gateway.ts` `send()` rejects whenever `success` is false, using `response.error || "Unknown error"` — and this path never sets an error string.

So the promise rejected **before** any caller could read `requiresUnpublishConfirm`. `AppsView` tried to pre-detect published apps via `readCachedCloudPublishState`, but that cache is empty for apps published by background cloud sync, so the guard never fired.

Reproduced directly against the gateway:

```json
{ "type": "app:delete:response", "success": false,
  "data": { "deleted": false, "requiresUnpublishConfirm": true,
            "shareUrl": "https://apps.papr.ai/…/dash/", "appTitle": "Dash" } }
```

**Fixes**
- `app:delete` envelope treats `requiresUnpublishConfirm` as success so the payload reaches the client.
- `deleteArtifact` returns the confirm signal instead of throwing.
- `AppsView` re-prompts with the real share URL and retries with `unpublishFromCloud: true`.
- `gateway.ts` no longer reports a bare `Unknown error` — failures without an error string now name the message type and include response data.

New `tests/app-delete-publish-confirm.test.ts` pins the envelope contract on both sides (3 tests).

### 2. Six vitest suites wrote into the developer's real Papr workspace

A test run created **~305 fixture mini-apps** (`Subdir App_7`, `Backend App_12`, `Orphan_3`, …) and **462 job folders** in a live user workspace, in one burst.

Cause: `getPaprRoot()` resolves the active-workspace pointer **before** `PAPR_HOME`, and `ensureActiveWorkspaceEnvSynced()` actively rewrites `process.env.PAPR_HOME` back to the pointer value. `getPaprBaseDir()` is `os.homedir()/Papr`, so suites patching only `os.homedir` (or only `HOME`) still resolved the real workspace. 47dfcc0 fixed this for `app-service.test.ts`; six other suites were never covered.

**Fixes**
- `tests/setup/isolatedWorkspace.ts` — `useIsolatedPaprWorkspace()` redirects `HOME`, `USERPROFILE`, `PAPR_HOME`, `PAPR_USER_DATA` and `os.homedir` at once, and ensures no pointer file exists under the temp home.
- `paprRoot.ts` — under `VITEST`/`NODE_ENV=test`, **throw** if the resolved root is outside `os.tmpdir()`. Turns a silent 300-app leak into a failing test. Escape hatch: `PAPR_ALLOW_REAL_WORKSPACE_IN_TESTS=1`.
- Applied to file-versioning, app-file-edit, bundle-service, data-contract-service, jobs-service, agent-attribution-tracking.

**Verified:** 67 guardrail trips across those suites before the fix, **0 after**, with app and job counts unchanged.

### Known unrelated failure

`bundle-service` and `agent-attribution-tracking` fail 15/15 on a broken `better-sqlite3` native module (ABI mismatch). Confirmed pre-existing by stashing these changes and re-running. Needs `npm rebuild better-sqlite3`, out of scope here.

### Follow-up worth considering

`PAPR_ALLOW_REAL_WORKSPACE_IN_TESTS=1` is a blunt global escape hatch — during this work it let 3 fixtures through into a real workspace. Consider restricting it to an allowlisted set of test files.
