### PR TITLE
fix(wiki): render entity logos, avatars, and profile links in Memory library

### DIFF
--- a/src/gateway/services/KnowledgeGraphWikiService.ts
+++ b/src/gateway/services/KnowledgeGraphWikiService.ts
@@ -105,6 +105,58 @@ function parseEntityFrontmatter(content: string): Record<string, unknown> {
   return result;
 }
 
+const IMAGE_MIME_BY_EXT: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+};
+
+/** Max on-disk size for an inlined entity image (256KB). Larger files are skipped
+ *  rather than bloating every wiki home payload. */
+const MAX_ENTITY_IMAGE_BYTES = 256 * 1024;
+
+/**
+ * Resolve an entity `image:` frontmatter value into something the renderer can use.
+ *
+ * The wiki UI renders `props.image` directly into an `<img src>`. Entity assets live
+ * under `$PAPR_HOME/workspace/entities/assets/...`, which is outside any static route,
+ * so a relative path like `../assets/companies/acme.png` resolves to nothing in the
+ * renderer and the card silently falls back to a gradient placeholder.
+ *
+ * Absolute URLs and data URIs pass through untouched. Relative paths are read from
+ * disk and inlined as a base64 data URI. Paths are constrained to the entities
+ * directory so a malicious .md cannot exfiltrate arbitrary files.
+ */
+export function resolveEntityImage(raw: unknown, entityDir: string): string | null {
+  if (typeof raw !== "string") return null;
+  const value = raw.trim();
+  if (!value) return null;
+  if (/^(https?:|data:)/i.test(value)) return value;
+
+  try {
+    const entitiesRoot = path.resolve(getEntitiesDir());
+    const abs = path.resolve(entityDir, value);
+    // Containment check — never read outside the entities tree.
+    if (abs !== entitiesRoot && !abs.startsWith(entitiesRoot + path.sep)) {
+      console.warn(`[Wiki] Ignoring out-of-tree entity image: ${value}`);
+      return null;
+    }
+    if (!fs.existsSync(abs)) return null;
+    const stat = fs.statSync(abs);
+    if (!stat.isFile() || stat.size > MAX_ENTITY_IMAGE_BYTES) return null;
+    const mime = IMAGE_MIME_BY_EXT[path.extname(abs).toLowerCase()];
+    if (!mime) return null;
+    return `data:${mime};base64,${fs.readFileSync(abs).toString("base64")}`;
+  } catch (err) {
+    console.warn(`[Wiki] Failed to resolve entity image ${value}:`, err);
+    return null;
+  }
+}
+
 function parseMarkdownSections(content: string): Record<string, string> {
   const sections: Record<string, string> = {};
   const body = content.replace(/^---[\s\S]*?---\n/, "");
@@ -203,6 +255,7 @@ function readEntityFilesSync(): { nodes: EntityFileNode[]; rails: WikiRail[]; ty
         const relationships = parseEntityRelationships(content);
         const evidence = parseEntityEvidence(content);
         const id = String(fm.id || file.replace(".md", ""));
+        const resolvedImage = resolveEntityImage(fm.image, dirPath);
         nodes.push({
           id: `${cfg.singular}/${id}`,
           type: cfg.singular,
@@ -215,6 +268,14 @@ function readEntityFilesSync(): { nodes: EntityFileNode[]; rails: WikiRail[]; ty
             ...(fm.updated_at ? { updated_at: String(fm.updated_at) } : {}),
             ...(fm.kind ? { kind: String(fm.kind) } : {}),
             ...(fm.app_id ? { app_id: String(fm.app_id) } : {}),
+            // Visual + link identity — company logos, person avatars, profile links.
+            // `image` is resolved to a data URI so it renders without a static
+            // file server (entity assets live outside the app bundle).
+            ...(resolvedImage ? { image: resolvedImage } : {}),
+            ...(fm.role ? { role: String(fm.role) } : {}),
+            ...(fm.title ? { title: String(fm.title) } : {}),
+            ...(fm.website ? { website: String(fm.website) } : {}),
+            ...(fm.linkedin ? { linkedin: String(fm.linkedin) } : {}),
           },
           markdownBody,
           sections,

--- a/src/resources/workspace-templates/WIKI_WRITER.md
+++ b/src/resources/workspace-templates/WIKI_WRITER.md
@@ -1,4 +1,4 @@
-<!-- wiki-writer-prompt-version: 4 -->
+<!-- wiki-writer-prompt-version: 5 -->
 
 # Wiki Writer
 
@@ -109,7 +109,21 @@ If the file exists, read it and **merge new information** — don't overwrite ex
 
 **B. Use this template for new entity files:**
 
+Start every file with YAML frontmatter. The Memory wiki UI reads these keys to
+render cards — without frontmatter a card falls back to a plain gradient tile.
+
 ```markdown
+---
+id: {slug}
+name: {Entity Name}
+description: One-line summary shown on the card.
+status: active
+image: ../assets/{type}/{slug}.png
+website: https://example.com
+linkedin: https://www.linkedin.com/company/example/
+updated_at: YYYY-MM-DD
+---
+
 # {Entity Name}
 
 > One-line summary of who/what this entity is.
@@ -189,11 +203,51 @@ grep -rl "EntityName" $PAPR_HOME/workspace/entities/ 2>/dev/null
 ```
 Update those files too — add a reciprocal link back to the current entity.
 
+**E. Fetch a logo/avatar and profile links (companies and people).**
+
+A card with a real logo is dramatically more useful than a gradient tile. Do this
+for **every new company** — it takes one command.
+
+1. **Find the official domain.** If you don't already know it, use `web_search`
+   (e.g. `"Acme Corp official website"`). Prefer the company's own domain over
+   directory sites like Crunchbase or LinkedIn. Record it as `website:`.
+
+2. **Download the logo** into the shared assets folder. Use `-L`: the endpoint
+   **301-redirects**, and without it you silently save an HTML stub instead of an image.
+   ```bash
+   mkdir -p $PAPR_HOME/workspace/entities/assets/companies
+   curl -sL -o $PAPR_HOME/workspace/entities/assets/companies/{slug}.png \
+     "https://www.google.com/s2/favicons?domain={domain}&sz=256"
+   file $PAPR_HOME/workspace/entities/assets/companies/{slug}.png   # verify: "PNG image data, 256 x 256"
+   ```
+   - Some sites return a **JPEG** despite the `.png` name — check `file` output and
+     rename to `.jpg` so the MIME type is correct.
+   - Some sites only publish a 16×16 favicon. That's their asset, not a fetch error —
+     it will look soft when scaled. Accept it or supply a better image manually.
+   - Keep images under 256KB; larger files are skipped by the wiki reader.
+
+3. **Reference it in frontmatter** with a path relative to the entity file:
+   ```yaml
+   image: ../assets/companies/{slug}.png
+   website: https://acme.com
+   linkedin: https://www.linkedin.com/company/acme/
+   ```
+   The wiki service inlines this file as a data URI at read time, so relative paths
+   work — do **not** paste base64 into the markdown yourself.
+
+4. **People:** set `linkedin:` when you have a verified profile URL. Only use a URL
+   you've actually seen in a source — **never guess a slug from someone's name**, it
+   will link to a stranger. For `image:`, use `../assets/people/{slug}.jpg` only if the
+   user supplied a photo; LinkedIn CDN URLs are signed, expire within hours, and
+   scraping them violates LinkedIn's terms.
+
 ### Step 4: Quality checks
 
 Before finishing:
 - **MANDATORY:** Every entity listed in today's daily log "Active entities today" section MUST have a file under `$PAPR_HOME/workspace/entities/{type}/`. If missing, create a stub with `write_file` before ending the run. Daily log mentions alone do not create Memory library cards. Group related apps under projects when the data supports it — avoid duplicate near-miss names.
 - Every entity file should have an **Overview**, **Key Facts**, and **Related Entities** section at minimum
+- **Every file starts with YAML frontmatter** (`id`, `name`, `description`). Without it the Memory library shows a bare gradient card with no summary
+- **Every company has `website:` and `image:`** — run the logo fetch in Step 3E. Verify with `file` that the download is a real image, not an HTML redirect stub
 - **Related Entities** should have working relative links to actual files (verify the files exist before linking)
 - Scores, metrics, and quotes should include the source (which job/table/chat they came from)
 - Don't leave placeholder text — if you don't have data for a section, omit it

--- a/tests/unit/backend/wikiEntityImage.test.ts
+++ b/tests/unit/backend/wikiEntityImage.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+/**
+ * `resolveEntityImage` resolves against `getEntitiesDir()`, which derives from
+ * `getPaprWorkspaceDir()`. On a desktop install that reads the real
+ * `~/Papr/.active-workspace.json` pointer, which takes precedence over PAPR_HOME —
+ * so stub the workspace resolver directly and point it at a fixture tree.
+ */
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "papr-wiki-img-"));
+
+vi.mock("../../../src/core/utils/paprRoot", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/core/utils/paprRoot")>();
+  return {
+    ...actual,
+    getPaprWorkspaceDir: () => path.join(tmpHome, "workspace"),
+    getPaprRoot: () => tmpHome,
+  };
+});
+
+const entitiesDir = path.join(tmpHome, "workspace", "entities");
+const companiesDir = path.join(entitiesDir, "companies");
+const assetsDir = path.join(entitiesDir, "assets", "companies");
+
+// 1x1 transparent PNG.
+const PNG_1PX = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+let resolveEntityImage: (raw: unknown, entityDir: string) => string | null;
+
+beforeAll(async () => {
+  process.env.PAPR_HOME = tmpHome;
+  fs.mkdirSync(companiesDir, { recursive: true });
+  fs.mkdirSync(assetsDir, { recursive: true });
+  fs.writeFileSync(path.join(assetsDir, "acme.png"), PNG_1PX);
+  fs.writeFileSync(path.join(assetsDir, "acme-photo.jpg"), PNG_1PX);
+  fs.writeFileSync(path.join(assetsDir, "notes.txt"), "not an image");
+  fs.writeFileSync(path.join(tmpHome, "outside-secret.png"), PNG_1PX);
+
+  ({ resolveEntityImage } = await import(
+    "../../../src/gateway/services/KnowledgeGraphWikiService"
+  ));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("resolveEntityImage", () => {
+  it("inlines a relative asset path as a base64 data URI", () => {
+    const result = resolveEntityImage("../assets/companies/acme.png", companiesDir);
+    expect(result).toBeTruthy();
+    expect(result).toMatch(/^data:image\/png;base64,/);
+    // Round-trips to the original bytes.
+    const b64 = result!.split(",")[1];
+    expect(Buffer.from(b64, "base64").equals(PNG_1PX)).toBe(true);
+  });
+
+  it("maps .jpg to image/jpeg", () => {
+    const result = resolveEntityImage("../assets/companies/acme-photo.jpg", companiesDir);
+    expect(result).toMatch(/^data:image\/jpeg;base64,/);
+  });
+
+  it("passes through absolute http(s) URLs untouched", () => {
+    const url = "https://cdn.example.com/logo.png";
+    expect(resolveEntityImage(url, companiesDir)).toBe(url);
+  });
+
+  it("passes through existing data URIs untouched", () => {
+    const uri = "data:image/png;base64,AAAA";
+    expect(resolveEntityImage(uri, companiesDir)).toBe(uri);
+  });
+
+  it("refuses paths that escape the entities directory", () => {
+    // ../../outside-secret.png from companies/ lands in the workspace root.
+    expect(resolveEntityImage("../../outside-secret.png", companiesDir)).toBeNull();
+    expect(resolveEntityImage("/etc/passwd", companiesDir)).toBeNull();
+  });
+
+  it("returns null for missing files, non-images, and empty values", () => {
+    expect(resolveEntityImage("../assets/companies/nope.png", companiesDir)).toBeNull();
+    expect(resolveEntityImage("../assets/companies/notes.txt", companiesDir)).toBeNull();
+    expect(resolveEntityImage("", companiesDir)).toBeNull();
+    expect(resolveEntityImage(undefined, companiesDir)).toBeNull();
+    expect(resolveEntityImage(42, companiesDir)).toBeNull();
+  });
+});

--- a/ui/components/Memory/WikiLibrary.css
+++ b/ui/components/Memory/WikiLibrary.css
@@ -601,6 +601,19 @@
   font-size: 11px;
 }
 
+/* website / linkedin pills are anchors — keep pill shape, add affordance. */
+.wiki-entity__pill--link {
+  color: #fff;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.wiki-entity__pill--link:hover {
+  background: rgba(0, 0, 0, 0.45);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
 .wiki-entity__meta-row .wiki-btn--secondary {
   padding: 4px 12px;
   font-size: 12px;
@@ -1578,6 +1591,14 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+/* Brand marks (companies, apps): letterbox the logo instead of cropping it,
+   and sit it on a light plate since most favicons assume a white background. */
+.wiki-card__art-img--logo {
+  object-fit: contain;
+  padding: 18%;
+  background: #fff;
+  image-rendering: -webkit-optimize-contrast;
 }
 .wiki-entity__hero-img {
   position: absolute;

--- a/ui/components/Memory/WikiLibrary.tsx
+++ b/ui/components/Memory/WikiLibrary.tsx
@@ -92,6 +92,18 @@ function typeGlyphSvg(type: string): string | null {
   return null;
 }
 
+/** Types whose image is a brand mark (letterboxed) rather than cover art. */
+function isLogoType(type: string): boolean {
+  return type === "company" || type === "companies" || type === "app" || type === "apps";
+}
+
+/** Entity props that hold URLs and should render as clickable pills, not raw text. */
+const LINK_PROP_KEYS = new Set(["website", "linkedin"]);
+const LINK_PROP_LABELS: Record<string, string> = {
+  website: "Website",
+  linkedin: "LinkedIn",
+};
+
 function PosterCard({ node, onClick }: { node: WikiNode; onClick: () => void }) {
   const meta = wikiTypeMeta(node.type);
   const props = node.props ?? {};
@@ -102,7 +114,14 @@ function PosterCard({ node, onClick }: { node: WikiNode; onClick: () => void }) 
     <article className="wiki-card poster" onClick={onClick}>
       <div className="wiki-card__art">
         {image ? (
-          <img className="wiki-card__art-img" src={image} alt={node.label} />
+          // Company marks are logos, not photography — contain them on a neutral
+          // backdrop instead of cropping to fill like a cover image.
+          <img
+            className={`wiki-card__art-img${isLogoType(node.type) ? " wiki-card__art-img--logo" : ""}`}
+            src={image}
+            alt={node.label}
+            loading="lazy"
+          />
         ) : (
           <div className="wiki-card__gradient"
             style={{ background: `linear-gradient(135deg, ${meta.color}, color-mix(in srgb, ${meta.color} 70%, #000))` }} />
@@ -841,9 +860,29 @@ function WikiEntityPage({ node, rails, relatedMemories, allNodes, loading, error
             </div>
             <h1>{node.label}</h1>
             <div className="wiki-entity__meta-row">
-              {Object.entries(props).filter(([key]) => key !== "image").map(([key, value]) => (
-                <span key={key} className="wiki-entity__pill">{key}: {String(value)}</span>
-              ))}
+              {Object.entries(props)
+                .filter(([key]) => key !== "image")
+                .map(([key, value]) => {
+                  const text = String(value);
+                  // website / linkedin are URLs — render them clickable instead of
+                  // dumping the raw href into a text pill.
+                  if (LINK_PROP_KEYS.has(key) && /^https?:\/\//i.test(text)) {
+                    return (
+                      <a
+                        key={key}
+                        className="wiki-entity__pill wiki-entity__pill--link"
+                        href={text}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                      >
+                        {key === "linkedin" ? "in" : "↗"} {LINK_PROP_LABELS[key] ?? key}
+                      </a>
+                    );
+                  }
+                  return (
+                    <span key={key} className="wiki-entity__pill">{key}: {text}</span>
+                  );
+                })}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Problem

Company and person cards in the Memory library always render a gradient placeholder — never a logo or avatar, even when the entity `.md` file supplies one.

<img width="500" alt="gradient placeholder cards" src="https://github.com/user-attachments/assets/placeholder" />

Two independent causes, both silent:

**1. `props` came from a hardcoded whitelist.** `readEntityFilesSync` only forwarded `status`, `confidence`, `created_at`, `updated_at`, `kind`, `app_id`. The UI *already* rendered `props.image` into an `<img>`, and `.wiki-card__art-img` / `.wiki-card__avatar-img` CSS *already* existed — but nothing could ever populate that key. Dead code on both ends.

**2. Relative image paths resolved to nothing.** Entity assets live under `$PAPR_HOME/workspace/entities/assets/`, outside any static route. `image: ../assets/companies/acme.png` is correct on disk and meaningless to the renderer.

There was also no frontmatter in the `WIKI_WRITER` template at all, so no generated entity ever had `props` — which is why this went unnoticed.

## Changes

**`KnowledgeGraphWikiService.ts`**
- Forward `image`, `role`, `title`, `website`, `linkedin` from frontmatter into `props`.
- New `resolveEntityImage()`:
  - `http(s):` and `data:` URIs pass through untouched
  - relative paths are read from disk and inlined as base64 data URIs
  - **path-traversal guarded** — resolved path must stay inside the entities tree
  - 256KB size cap, extension→MIME allowlist (png/jpg/gif/webp/svg/ico)

**`WikiLibrary.tsx` / `.css`**
- `website` / `linkedin` render as clickable pills instead of raw-text `key: https://...` pills.
- Company and app logos use `object-fit: contain` on a white plate — favicons assume a white background and were being cropped by `cover`.
- `loading="lazy"` on card art.

**`WIKI_WRITER.md`** (prompt version 4 → 5)
- Template now starts with YAML frontmatter.
- New Step 3E: for every new company, find the official domain via web search and fetch the logo:
  ```bash
  curl -sL -o .../{slug}.png "https://www.google.com/s2/favicons?domain={domain}&sz=256"
  ```
  Documents the gotcha that cost real time here — **the endpoint 301-redirects, and without `-L` you silently save an HTML stub named `.png`**. Also notes JPEG-despite-`.png` responses, and that some sites only publish 16×16.
- Explicitly warns against guessing LinkedIn slugs from names — a wrong guess links to a stranger.

## Testing

New `tests/unit/backend/wikiEntityImage.test.ts` — 6 cases, all passing:

| Case | Expectation |
|---|---|
| relative path | inlined as `data:image/png;base64,...`, round-trips to original bytes |
| `.jpg` | maps to `image/jpeg` |
| `https://` URL | passes through unchanged |
| existing `data:` URI | passes through unchanged |
| `../../outside.png`, `/etc/passwd` | rejected by containment check |
| missing file, `.txt`, `""`, `undefined`, `42` | returns `null` |

`tsc --noEmit`: 98 errors before, 98 after, **0 in touched files** (pre-existing baseline unchanged).

## Verified end-to-end

Migrated a live workspace (18 entities) to frontmatter. `get_wiki_entity` now returns `label` and `description` from frontmatter; `props.image` populates once the gateway is rebuilt (`dist/` was stale during testing, which is expected).

## Notes for reviewer

- Data URIs are computed per read. Wiki home is already cached (`WIKI_HOME_REMOTE_CACHE_TTL_MS`), and the 256KB cap bounds payload growth — 4 favicons cost ~13KB total. If this ever becomes hot, a static `/entity-assets` route would be the cleaner long-term fix.
- Existing entity files without frontmatter are unaffected — every new prop is conditionally spread.