### PR TITLE
feat(wiki): add company and person media uploads

### DIFF
--- a/src/gateway/services/KnowledgeGraphWikiService.ts
+++ b/src/gateway/services/KnowledgeGraphWikiService.ts
@@ -7,16 +7,16 @@
 
 import type Papr from "@papr/memory";
 import { getPaprWorkspaceDir } from "../../core/utils/paprRoot.js";
-import { getPaprClient, isPaprNotFoundError } from "../../core/tools/paprClient.js";
+import {
+  getPaprClient,
+  isPaprNotFoundError,
+} from "../../core/tools/paprClient.js";
 import {
   getMemoryScopeContext,
   paprMemorySearchScopeSpread,
 } from "../utils/memoryScopeResolver.js";
 import { buildMemorySearchScopeFields } from "../../core/utils/memoryScope.js";
-import {
-  isWikiRailExcluded,
-  pickWikiLabel,
-} from "./wikiGraphHelpers.js";
+import { isWikiRailExcluded, pickWikiLabel } from "./wikiGraphHelpers.js";
 import { syncWikiGraphEntity } from "./wikiGraphEntitySync.js";
 import {
   graphqlNameContainsWhere,
@@ -73,18 +73,23 @@ function setCachedWikiHomeRemote(result: WikiHomeResult): void {
   };
 }
 
-function getEntitiesDir(): string { return path.join(getPaprWorkspaceDir(), "entities"); }
+function getEntitiesDir(): string {
+  return path.join(getPaprWorkspaceDir(), "entities");
+}
 
-const ENTITY_DIR_CONFIG: Record<string, { railTitle: string; singular: string }> = {
-  projects:    { railTitle: "Projects",    singular: "project" },
-  apps:        { railTitle: "Apps",        singular: "app" },
-  people:      { railTitle: "People",      singular: "person" },
-  companies:   { railTitle: "Companies",   singular: "company" },
-  meetings:    { railTitle: "Meetings",    singular: "meeting" },
-  decisions:   { railTitle: "Decisions",   singular: "decision" },
-  ideas:       { railTitle: "Ideas",       singular: "idea" },
-  workflows:   { railTitle: "Workflows",   singular: "workflow" },
-  learnings:   { railTitle: "Learnings",   singular: "learning" },
+const ENTITY_DIR_CONFIG: Record<
+  string,
+  { railTitle: string; singular: string }
+> = {
+  projects: { railTitle: "Projects", singular: "project" },
+  apps: { railTitle: "Apps", singular: "app" },
+  people: { railTitle: "People", singular: "person" },
+  companies: { railTitle: "Companies", singular: "company" },
+  meetings: { railTitle: "Meetings", singular: "meeting" },
+  decisions: { railTitle: "Decisions", singular: "decision" },
+  ideas: { railTitle: "Ideas", singular: "idea" },
+  workflows: { railTitle: "Workflows", singular: "workflow" },
+  learnings: { railTitle: "Learnings", singular: "learning" },
   collections: { railTitle: "Collections", singular: "collection" },
 };
 
@@ -102,9 +107,10 @@ const ENTITY_RAIL_ORDER = [
 ] as const;
 
 /** Resolve rail metadata for a folder under workspace/entities/. */
-export function resolveEntityDirConfig(
-  dirName: string,
-): { railTitle: string; singular: string } {
+export function resolveEntityDirConfig(dirName: string): {
+  railTitle: string;
+  singular: string;
+} {
   const known = ENTITY_DIR_CONFIG[dirName];
   if (known) {
     return known;
@@ -112,7 +118,8 @@ export function resolveEntityDirConfig(
 
   const singular = dirName.endsWith("s") ? dirName.slice(0, -1) : dirName;
   const railTitle =
-    singular.charAt(0).toUpperCase() + singular.slice(1) +
+    singular.charAt(0).toUpperCase() +
+    singular.slice(1) +
     (singular.endsWith("s") ? "" : "s");
 
   return { railTitle, singular };
@@ -126,7 +133,8 @@ function railTitleForSingular(singular: string): string {
     return fromConfig.railTitle;
   }
   return (
-    singular.charAt(0).toUpperCase() + singular.slice(1) +
+    singular.charAt(0).toUpperCase() +
+    singular.slice(1) +
     (singular.endsWith("s") ? "" : "s")
   );
 }
@@ -141,12 +149,27 @@ function parseEntityFrontmatter(content: string): Record<string, unknown> {
   let inList = false;
   for (const line of lines) {
     const listItem = line.match(/^  - (.+)$/);
-    if (listItem && inList) { currentList.push(listItem[1].trim()); continue; }
-    if (inList) { result[currentKey] = currentList; inList = false; currentList = []; }
+    if (listItem && inList) {
+      currentList.push(listItem[1].trim());
+      continue;
+    }
+    if (inList) {
+      result[currentKey] = currentList;
+      inList = false;
+      currentList = [];
+    }
     const kv = line.match(/^(\w[\w_]*): (.+)$/);
-    if (kv) { result[kv[1]] = kv[2].trim().replace(/^["']|["']$/g, ""); currentKey = ""; continue; }
+    if (kv) {
+      result[kv[1]] = kv[2].trim().replace(/^["']|["']$/g, "");
+      currentKey = "";
+      continue;
+    }
     const listStart = line.match(/^(\w[\w_]*):\s*$/);
-    if (listStart) { currentKey = listStart[1]; inList = true; currentList = []; }
+    if (listStart) {
+      currentKey = listStart[1];
+      inList = true;
+      currentList = [];
+    }
   }
   if (inList) result[currentKey] = currentList;
   return result;
@@ -165,6 +188,9 @@ const IMAGE_MIME_BY_EXT: Record<string, string> = {
 /** Max on-disk size for an inlined entity image (256KB). Larger files are skipped
  *  rather than bloating every wiki home payload. */
 const MAX_ENTITY_IMAGE_BYTES = 256 * 1024;
+const MAX_ENTITY_HERO_BYTES = 1024 * 1024;
+const MAX_MEDIA_UPLOAD_BYTES = 12 * 1024 * 1024;
+const EDITABLE_MEDIA_TYPES = new Set(["company", "person"]);
 
 /**
  * Resolve an entity `image:` frontmatter value into something the renderer can use.
@@ -178,7 +204,11 @@ const MAX_ENTITY_IMAGE_BYTES = 256 * 1024;
  * disk and inlined as a base64 data URI. Paths are constrained to the entities
  * directory so a malicious .md cannot exfiltrate arbitrary files.
  */
-export function resolveEntityImage(raw: unknown, entityDir: string): string | null {
+export function resolveEntityImage(
+  raw: unknown,
+  entityDir: string,
+  maxBytes = MAX_ENTITY_IMAGE_BYTES,
+): string | null {
   if (typeof raw !== "string") return null;
   const value = raw.trim();
   if (!value) return null;
@@ -194,7 +224,7 @@ export function resolveEntityImage(raw: unknown, entityDir: string): string | nu
     }
     if (!fs.existsSync(abs)) return null;
     const stat = fs.statSync(abs);
-    if (!stat.isFile() || stat.size > MAX_ENTITY_IMAGE_BYTES) return null;
+    if (!stat.isFile() || stat.size > maxBytes) return null;
     const mime = IMAGE_MIME_BY_EXT[path.extname(abs).toLowerCase()];
     if (!mime) return null;
     return `data:${mime};base64,${fs.readFileSync(abs).toString("base64")}`;
@@ -225,12 +255,22 @@ function cleanYamlScalar(value: string): string {
 }
 
 function parseYamlListBlock(content: string, key: string): string[] {
-  const match = content.match(new RegExp(`^${key}:\\n([\\s\\S]*?)(?=^\\w[\\w_]*:|^---|(?![\\s\\S]))`, "m"));
+  const match = content.match(
+    new RegExp(
+      `^${key}:\\n([\\s\\S]*?)(?=^\\w[\\w_]*:|^---|(?![\\s\\S]))`,
+      "m",
+    ),
+  );
   if (!match) return [];
-  return match[1].split(/^  - /m).map((item) => item.trim()).filter(Boolean);
+  return match[1]
+    .split(/^  - /m)
+    .map((item) => item.trim())
+    .filter(Boolean);
 }
 
-function parseEntityRelationships(content: string): Array<{ type: string; target: string; context?: string }> {
+function parseEntityRelationships(
+  content: string,
+): Array<{ type: string; target: string; context?: string }> {
   const rels: Array<{ type: string; target: string; context?: string }> = [];
   const seen = new Set<string>();
   for (const item of parseYamlListBlock(content, "relationships")) {
@@ -243,12 +283,18 @@ function parseEntityRelationships(content: string): Array<{ type: string; target
     const key = `${type}::${targetId}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    rels.push({ type, target: targetId, context: ctx ? cleanYamlScalar(ctx[1]) : undefined });
+    rels.push({
+      type,
+      target: targetId,
+      context: ctx ? cleanYamlScalar(ctx[1]) : undefined,
+    });
   }
   return rels;
 }
 
-function parseEntityEvidence(content: string): Array<{ date: string; source: string; summary: string }> {
+function parseEntityEvidence(
+  content: string,
+): Array<{ date: string; source: string; summary: string }> {
   const evidence: Array<{ date: string; source: string; summary: string }> = [];
   const seen = new Set<string>();
   for (const item of parseYamlListBlock(content, "evidence")) {
@@ -282,7 +328,11 @@ export interface EntityFileNode extends WikiNode {
   evidence: Array<{ date: string; source: string; summary: string }>;
 }
 
-function readEntityFilesSync(): { nodes: EntityFileNode[]; rails: WikiRail[]; typeCounts: Record<string, number> } {
+function readEntityFilesSync(): {
+  nodes: EntityFileNode[];
+  rails: WikiRail[];
+  typeCounts: Record<string, number>;
+} {
   const nodes: EntityFileNode[] = [];
   const typeCounts: Record<string, number> = {};
   if (!fs.existsSync(getEntitiesDir())) return { nodes, rails: [], typeCounts };
@@ -302,11 +352,18 @@ function readEntityFilesSync(): { nodes: EntityFileNode[]; rails: WikiRail[]; ty
         const evidence = parseEntityEvidence(content);
         const id = String(fm.id || file.replace(".md", ""));
         const resolvedImage = resolveEntityImage(fm.image, dirPath);
+        const resolvedHero = resolveEntityImage(
+          fm.hero_image,
+          dirPath,
+          MAX_ENTITY_HERO_BYTES,
+        );
         nodes.push({
           id: `${cfg.singular}/${id}`,
           type: cfg.singular,
           label: String(fm.name || id),
-          description: String(fm.description || sections["Context & Background"] || "").slice(0, 300),
+          description: String(
+            fm.description || sections["Context & Background"] || "",
+          ).slice(0, 300),
           props: {
             ...(fm.status ? { status: String(fm.status) } : {}),
             ...(fm.confidence ? { confidence: String(fm.confidence) } : {}),
@@ -318,6 +375,7 @@ function readEntityFilesSync(): { nodes: EntityFileNode[]; rails: WikiRail[]; ty
             // `image` is resolved to a data URI so it renders without a static
             // file server (entity assets live outside the app bundle).
             ...(resolvedImage ? { image: resolvedImage } : {}),
+            ...(resolvedHero ? { hero_image: resolvedHero } : {}),
             ...(fm.role ? { role: String(fm.role) } : {}),
             ...(fm.title ? { title: String(fm.title) } : {}),
             ...(fm.website ? { website: String(fm.website) } : {}),
@@ -346,7 +404,10 @@ function readEntityFilesSync(): { nodes: EntityFileNode[]; rails: WikiRail[]; ty
 
   const knownOrder = ENTITY_RAIL_ORDER.filter((t) => grouped.has(t));
   const extraTypes = [...grouped.keys()]
-    .filter((t) => !ENTITY_RAIL_ORDER.includes(t as (typeof ENTITY_RAIL_ORDER)[number]))
+    .filter(
+      (t) =>
+        !ENTITY_RAIL_ORDER.includes(t as (typeof ENTITY_RAIL_ORDER)[number]),
+    )
     .sort((a, b) => a.localeCompare(b));
   const railTypeOrder = [...knownOrder, ...extraTypes];
 
@@ -377,7 +438,6 @@ export function searchLocalWikiEntities(query: string): WikiNode[] {
     );
   });
 }
-
 
 export interface WikiNode {
   id: string;
@@ -555,15 +615,33 @@ const SEARCH_RAIL_QUERIES: Array<{
   railTitle: string;
 }> = [
   { query: "goals and objectives", wikiType: "goal", railTitle: "Your goals" },
-  { query: "projects and initiatives", wikiType: "project", railTitle: "Projects" },
-  { query: "people contacts stakeholders", wikiType: "person", railTitle: "People" },
-  { query: "memories notes conversations", wikiType: "memory", railTitle: "Recent memories" },
-  { query: "insights decisions learnings", wikiType: "insight", railTitle: "Insights" },
+  {
+    query: "projects and initiatives",
+    wikiType: "project",
+    railTitle: "Projects",
+  },
+  {
+    query: "people contacts stakeholders",
+    wikiType: "person",
+    railTitle: "People",
+  },
+  {
+    query: "memories notes conversations",
+    wikiType: "memory",
+    railTitle: "Recent memories",
+  },
+  {
+    query: "insights decisions learnings",
+    wikiType: "insight",
+    railTitle: "Insights",
+  },
   { query: "tasks action items todos", wikiType: "task", railTitle: "Tasks" },
 ];
 
 function isConversationBatchMemory(record: Record<string, unknown>): boolean {
-  const content = asString(record.content ?? record.title ?? record.description);
+  const content = asString(
+    record.content ?? record.title ?? record.description,
+  );
   const batchId = asString(record.batch_id);
   const sessionId = asString(record.session_id);
   if (batchId || sessionId) return true;
@@ -576,7 +654,8 @@ function isConversationBatchMemory(record: Record<string, unknown>): boolean {
 
 function asString(value: unknown): string {
   if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
   return "";
 }
 
@@ -681,17 +760,15 @@ function normalizeNode(
 }
 
 function inferWikiTypeFromRecord(record: Record<string, unknown>): string {
-  const label = asString(record.label ?? record.type ?? record.node_type).toLowerCase();
+  const label = asString(
+    record.label ?? record.type ?? record.node_type,
+  ).toLowerCase();
   if (label.includes("goal") || record.target_date) return "goal";
   if (label.includes("person") || (record.role && record.name)) return "person";
   if (label.includes("project") || record.type === "project") return "project";
   if (label.includes("insight") || record.confidence) return "insight";
   if (label.includes("task") || record.task_name) return "task";
-  if (
-    label.includes("memory") ||
-    record.memory_category ||
-    record.content
-  ) {
+  if (label.includes("memory") || record.memory_category || record.content) {
     return "memory";
   }
   return "entity";
@@ -879,9 +956,10 @@ function pickFeatured(rails: WikiRail[]): WikiNode | null {
   return rails[0]?.items[0] ?? null;
 }
 
-function buildRailsFromItems(
-  grouped: Map<string, WikiNode[]>,
-): { rails: WikiRail[]; typeCounts: Record<string, number> } {
+function buildRailsFromItems(grouped: Map<string, WikiNode[]>): {
+  rails: WikiRail[];
+  typeCounts: Record<string, number>;
+} {
   const rails: WikiRail[] = [];
   const typeCounts: Record<string, number> = {};
 
@@ -1007,8 +1085,13 @@ async function fetchWikiHomeFromSearch(client: Papr): Promise<{
   }
 
   const result = buildRailsFromItems(grouped);
-  const totalItems = result.rails.reduce((sum, rail) => sum + rail.items.length, 0);
-  console.log(`[Wiki] Search loaded ${totalItems} items across ${result.rails.length} rails`);
+  const totalItems = result.rails.reduce(
+    (sum, rail) => sum + rail.items.length,
+    0,
+  );
+  console.log(
+    `[Wiki] Search loaded ${totalItems} items across ${result.rails.length} rails`,
+  );
   return result;
 }
 
@@ -1112,7 +1195,8 @@ export async function fetchWikiHome(options?: {
       rails: [],
       typeCounts: {},
       configured: false,
-      error: "Connect Papr in Settings → AI Models to browse your knowledge graph.",
+      error:
+        "Connect Papr in Settings → AI Models to browse your knowledge graph.",
     };
   }
 
@@ -1120,7 +1204,10 @@ export async function fetchWikiHome(options?: {
   const searchResult = await fetchWikiHomeFromSearch(client);
 
   const rails = mergeWikiRails(graphqlResult.rails, searchResult.rails);
-  const typeCounts = { ...searchResult.typeCounts, ...graphqlResult.typeCounts };
+  const typeCounts = {
+    ...searchResult.typeCounts,
+    ...graphqlResult.typeCounts,
+  };
   const searchFallback = searchResult.rails.length > 0;
   const featured = pickFeatured(rails);
 
@@ -1146,12 +1233,17 @@ export async function fetchWikiHome(options?: {
   return result;
 }
 
-async function _fetchWikiEntityBase(wikiType: string, id: string, label?: string): Promise<WikiEntityResult> {
+async function _fetchWikiEntityBase(
+  wikiType: string,
+  id: string,
+  label?: string,
+): Promise<WikiEntityResult> {
   // PRIMARY: Check entity .md files first
   const { nodes: entityNodes } = readEntityFilesSync();
   // Match by full id (type/slug) or just slug
   const entityNode = entityNodes.find(
-    (n) => n.id === id || n.id === `${wikiType}/${id}` || n.id.endsWith(`/${id}`)
+    (n) =>
+      n.id === id || n.id === `${wikiType}/${id}` || n.id.endsWith(`/${id}`),
   );
   if (entityNode) {
     const edges: WikiEdge[] = entityNode.relationships.map((r) => ({
@@ -1172,28 +1264,36 @@ async function _fetchWikiEntityBase(wikiType: string, id: string, label?: string
       if (connectedIds.has(other.id)) continue;
       // Check if other entity's relationships point to this entity
       const pointsHere = other.relationships.some(
-        (r) => r.target === entityNode.id || r.target.endsWith(`/${entitySlug}`)
+        (r) =>
+          r.target === entityNode.id || r.target.endsWith(`/${entitySlug}`),
       );
       // Check if other entity's body/description mentions this entity
-      const mentionsLabel = (other.markdownBody ?? "").toLowerCase().includes(entityLabel)
-        || (other.description ?? "").toLowerCase().includes(entityLabel);
+      const mentionsLabel =
+        (other.markdownBody ?? "").toLowerCase().includes(entityLabel) ||
+        (other.description ?? "").toLowerCase().includes(entityLabel);
       if (pointsHere || mentionsLabel) {
         connectedIds.add(other.id);
       }
     }
 
-    const related = entityNodes.filter((n) => connectedIds.has(n.id) && n.id !== entityNode.id);
+    const related = entityNodes.filter(
+      (n) => connectedIds.has(n.id) && n.id !== entityNode.id,
+    );
     const relGrouped = new Map<string, WikiNode[]>();
     for (const n of related) {
       const l = relGrouped.get(n.type) ?? [];
       l.push(n);
       relGrouped.set(n.type, l);
     }
-    const rails: WikiRail[] = [...relGrouped.entries()].map(([type, items]) => ({
-      title: railTitleForSingular(type),
-      items,
-    }));
-    console.log(`[Wiki] Entity (file): ${entityNode.id} → ${edges.length} edges, ${rails.length} rails (${related.length} connected)`);
+    const rails: WikiRail[] = [...relGrouped.entries()].map(
+      ([type, items]) => ({
+        title: railTitleForSingular(type),
+        items,
+      }),
+    );
+    console.log(
+      `[Wiki] Entity (file): ${entityNode.id} → ${edges.length} edges, ${rails.length} rails (${related.length} connected)`,
+    );
 
     return { node: entityNode, edges, rails };
   }
@@ -1201,7 +1301,12 @@ async function _fetchWikiEntityBase(wikiType: string, id: string, label?: string
   // FALLBACK: Neo4j / Qdrant
   const config = ENTITY_CONFIGS.find((c) => c.wikiType === wikiType);
   if (!config) {
-    return { node: null, edges: [], rails: [], error: `Unknown entity type: ${wikiType}` };
+    return {
+      node: null,
+      edges: [],
+      rails: [],
+      error: `Unknown entity type: ${wikiType}`,
+    };
   }
 
   let client: Papr;
@@ -1224,21 +1329,24 @@ async function _fetchWikiEntityBase(wikiType: string, id: string, label?: string
           `[Wiki] Skipping GraphQL entity load — invalid id (${wikiType}/${id})`,
         );
       } else {
-      const data = await runGraphQL(
-        client,
-        selection,
-        `${config.graphqlPlural}:${id}`,
-      );
-      if (data) {
-        const rows = data[config.graphqlPlural];
-        if (Array.isArray(rows) && rows.length > 0) {
-          const record = rows[0] as Record<string, unknown>;
-          const synced = await syncWikiGraphEntity(client, record, wikiType);
-          const node = normalizeNode(synced.record, wikiType);
-          const { edges, rails } = extractEdgesAndRails(synced.record, node.id);
-          return { node, edges, rails };
+        const data = await runGraphQL(
+          client,
+          selection,
+          `${config.graphqlPlural}:${id}`,
+        );
+        if (data) {
+          const rows = data[config.graphqlPlural];
+          if (Array.isArray(rows) && rows.length > 0) {
+            const record = rows[0] as Record<string, unknown>;
+            const synced = await syncWikiGraphEntity(client, record, wikiType);
+            const node = normalizeNode(synced.record, wikiType);
+            const { edges, rails } = extractEdgesAndRails(
+              synced.record,
+              node.id,
+            );
+            return { node, edges, rails };
+          }
         }
-      }
       }
     } catch (error) {
       console.warn(
@@ -1304,9 +1412,10 @@ export async function fetchWikiEntity(
   ]);
 
   // Merge graph-discovered entities into existing rails
-  const mergedRails = graphRails.length > 0
-    ? mergeWikiRails(result.rails, graphRails)
-    : result.rails;
+  const mergedRails =
+    graphRails.length > 0
+      ? mergeWikiRails(result.rails, graphRails)
+      : result.rails;
 
   return {
     ...result,
@@ -1328,14 +1437,16 @@ async function _fetchRelatedMemories(node: WikiNode): Promise<any[]> {
       enable_agentic_graph: false,
     });
     const { memories } = parseSearchPayload(response);
-    return memories.map(m => ({
-      id: asString(m.id),
-      content: asString(m.content),
-      category: asString(m.category),
-      source: asString(m.source),
-      createdAt: asString(m.created_at),
-      chatId: asString(m.chat_id),
-    })).filter(m => m.id && m.content);
+    return memories
+      .map((m) => ({
+        id: asString(m.id),
+        content: asString(m.content),
+        category: asString(m.category),
+        source: asString(m.source),
+        createdAt: asString(m.created_at),
+        chatId: asString(m.chat_id),
+      }))
+      .filter((m) => m.id && m.content);
   } catch (e) {
     console.warn("[Wiki] Failed to fetch related memories:", e);
     return [];
@@ -1355,25 +1466,37 @@ async function _fetchGraphConnectedEntities(
     // --- Graph queries: best-effort, entity files are the primary source ---
     // Some Person nodes in the graph have corrupted fields that cause errors,
     // so we use safe queries (id-only for nested relationships) and tolerate failures.
-    const graphType = entityType === "person" ? "people"
-      : entityType === "company" ? "companies"
-      : entityType === "project" ? "projects"
-      : entityType === "goal" ? "goals"
-      : null;
+    const graphType =
+      entityType === "person"
+        ? "people"
+        : entityType === "company"
+          ? "companies"
+          : entityType === "project"
+            ? "projects"
+            : entityType === "goal"
+              ? "goals"
+              : null;
 
     if (graphType && nameWhere) {
       // For companies: get connection count, then fetch person IDs individually
       if (entityType === "company") {
         // Safe query: only get totalCount (no nested name fields that could error)
         const countQuery = `${graphType}(where: ${nameWhere}, limit: 1) { id name employeesPersonConnection { totalCount edges { node { id } } } }`;
-        const data = await runGraphQL(client, countQuery, `connected-company-people`);
+        const data = await runGraphQL(
+          client,
+          countQuery,
+          `connected-company-people`,
+        );
         if (data) {
           const records = (data[graphType] as Record<string, unknown>[]) ?? [];
           if (records.length > 0) {
-            const conn = (records[0] as Record<string, unknown>).employeesPersonConnection as {
-              totalCount?: number;
-              edges?: Array<{ node: { id: string } }>;
-            } | undefined;
+            const conn = (records[0] as Record<string, unknown>)
+              .employeesPersonConnection as
+              | {
+                  totalCount?: number;
+                  edges?: Array<{ node: { id: string } }>;
+                }
+              | undefined;
             if (conn?.edges) {
               // Got person IDs — look up their names from entity files (reliable)
               const { nodes: entityNodes } = readEntityFilesSync();
@@ -1381,8 +1504,9 @@ async function _fetchGraphConnectedEntities(
               for (const edge of conn.edges) {
                 if (!edge.node?.id) continue;
                 // Try to find this person in entity files by graph ID or name
-                const entityMatch = entityNodes.find((n) =>
-                  n.type === "person" && (n.props.graph_id === edge.node.id)
+                const entityMatch = entityNodes.find(
+                  (n) =>
+                    n.type === "person" && n.props.graph_id === edge.node.id,
                 );
                 if (entityMatch) {
                   personNodes.push(entityMatch);
@@ -1390,14 +1514,24 @@ async function _fetchGraphConnectedEntities(
               }
               // Also try fetching names directly (may fail on corrupt nodes, that's OK)
               const nameQuery = `${graphType}(where: ${nameWhere}, limit: 1) { employeesPerson { id name } }`;
-              const nameData = await runGraphQL(client, nameQuery, `connected-company-people-names`);
+              const nameData = await runGraphQL(
+                client,
+                nameQuery,
+                `connected-company-people-names`,
+              );
               if (nameData) {
-                const recs = (nameData[graphType] as Record<string, unknown>[]) ?? [];
+                const recs =
+                  (nameData[graphType] as Record<string, unknown>[]) ?? [];
                 if (recs.length > 0) {
-                  const people = (recs[0] as Record<string, unknown>).employeesPerson as Record<string, unknown>[] | undefined;
+                  const people = (recs[0] as Record<string, unknown>)
+                    .employeesPerson as Record<string, unknown>[] | undefined;
                   if (people) {
                     for (const p of people) {
-                      if (p.id && p.name && !personNodes.some((n) => n.id === String(p.id))) {
+                      if (
+                        p.id &&
+                        p.name &&
+                        !personNodes.some((n) => n.id === String(p.id))
+                      ) {
                         personNodes.push(normalizeNode(p, "person"));
                       }
                     }
@@ -1423,7 +1557,10 @@ async function _fetchGraphConnectedEntities(
         if (data) {
           const records = (data[graphType] as Record<string, unknown>[]) ?? [];
           if (records.length > 0) {
-            const { rails: directRails } = extractEdgesAndRails(records[0], node.id);
+            const { rails: directRails } = extractEdgesAndRails(
+              records[0],
+              node.id,
+            );
             allRails.push(...directRails);
           }
         }
@@ -1432,7 +1569,7 @@ async function _fetchGraphConnectedEntities(
 
     // Deduplicate and filter out entities already shown
     const existingIds = new Set(
-      existingRails.flatMap((r) => r.items.map((i) => i.id))
+      existingRails.flatMap((r) => r.items.map((i) => i.id)),
     );
     const result = allRails
       .map((rail) => ({
@@ -1440,14 +1577,15 @@ async function _fetchGraphConnectedEntities(
         items: rail.items.filter((i) => !existingIds.has(i.id)),
       }))
       .filter((rail) => rail.items.length > 0);
-    console.log(`[Wiki] Graph connected entities: ${result.reduce((s, r) => s + r.items.length, 0)} items across ${result.length} rails`);
+    console.log(
+      `[Wiki] Graph connected entities: ${result.reduce((s, r) => s + r.items.length, 0)} items across ${result.length} rails`,
+    );
     return result;
   } catch (e) {
     console.warn("[Wiki] Graph connected entities lookup failed:", e);
     return [];
   }
 }
-
 
 export async function searchWiki(query: string): Promise<WikiSearchResult> {
   const trimmed = query.trim();
@@ -1624,6 +1762,131 @@ No decisions or insights captured yet.
   return { id, filePath, created: true };
 }
 
+export type WikiEntityMediaKind = "image" | "hero_image";
+
+export interface UpdateWikiEntityMediaInput {
+  type: string;
+  id: string;
+  kind: WikiEntityMediaKind;
+  dataUrl?: string | null;
+}
+
+function yamlMediaValue(
+  content: string,
+  key: WikiEntityMediaKind,
+  value: string | null,
+): string {
+  const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!frontmatter) throw new Error("Entity file has no YAML frontmatter");
+  const line = new RegExp(`^${key}:.*$`, "m");
+  let yaml = frontmatter[1];
+  if (value) {
+    yaml = line.test(yaml)
+      ? yaml.replace(line, `${key}: ${value}`)
+      : `${yaml}\n${key}: ${value}`;
+  } else {
+    yaml = yaml
+      .replace(line, "")
+      .replace(/\n{3,}/g, "\n\n")
+      .trimEnd();
+  }
+  return content.replace(frontmatter[0], `---\n${yaml}\n---`);
+}
+
+function parseImageDataUrl(dataUrl: string): { mime: string; bytes: Buffer } {
+  const match = dataUrl.match(
+    /^data:(image\/(?:png|jpeg|webp|gif|svg\+xml));base64,([A-Za-z0-9+/=\s]+)$/i,
+  );
+  if (!match) throw new Error("Use a PNG, JPEG, WebP, GIF, or SVG image");
+  const bytes = Buffer.from(match[2].replace(/\s/g, ""), "base64");
+  if (!bytes.length || bytes.length > MAX_MEDIA_UPLOAD_BYTES)
+    throw new Error("Image must be smaller than 12 MB");
+  return { mime: match[1].toLowerCase(), bytes };
+}
+
+/** Save/remove a company logo, person avatar, or company/person hero image. */
+export async function updateWikiEntityMedia(
+  input: UpdateWikiEntityMediaInput,
+): Promise<{ path: string | null }> {
+  const rawType = input.type.toLowerCase();
+  const type =
+    rawType === "companies"
+      ? "company"
+      : rawType === "people"
+        ? "person"
+        : rawType;
+  if (!EDITABLE_MEDIA_TYPES.has(type))
+    throw new Error("Media uploads are supported for companies and people");
+  if (input.kind !== "image" && input.kind !== "hero_image")
+    throw new Error("Invalid media kind");
+  const id = input.id.includes("/") ? input.id.split("/").pop()! : input.id;
+  if (!/^[a-z0-9][a-z0-9-]{0,79}$/i.test(id))
+    throw new Error("Invalid entity id");
+  const plural = type === "company" ? "companies" : "people";
+  const entityDir = path.join(getEntitiesDir(), plural);
+  const entityPath = path.join(entityDir, `${id}.md`);
+  if (!fs.existsSync(entityPath)) throw new Error("Entity file not found");
+  const assetsDir = path.join(getEntitiesDir(), "assets", plural);
+  fs.mkdirSync(assetsDir, { recursive: true });
+  const prefix = input.kind === "hero_image" ? `${id}-hero` : id;
+  for (const ext of [".svg", ".webp", ".png", ".jpg", ".jpeg"]) {
+    const old = path.join(assetsDir, `${prefix}${ext}`);
+    if (fs.existsSync(old)) fs.unlinkSync(old);
+  }
+  let relative: string | null = null;
+  if (input.dataUrl) {
+    const { mime, bytes } = parseImageDataUrl(input.dataUrl);
+    let output: Buffer;
+    let ext: string;
+    if (mime === "image/svg+xml" && input.kind === "image") {
+      const text = bytes.toString("utf8");
+      if (
+        !/<svg[\s>]/i.test(text) ||
+        /<script|on\w+\s*=|javascript:|(?:href|src)\s*=\s*['"]https?:/i.test(
+          text,
+        )
+      )
+        throw new Error("Unsafe SVG content");
+      output = bytes;
+      ext = ".svg";
+    } else {
+      const sharp = (await import("sharp")).default;
+      const width = input.kind === "hero_image" ? 1920 : 512;
+      const height = input.kind === "hero_image" ? 768 : 512;
+      output = await sharp(bytes, { animated: false })
+        .rotate()
+        .resize(width, height, {
+          fit: input.kind === "hero_image" ? "cover" : "inside",
+          withoutEnlargement: true,
+        })
+        .webp({ quality: input.kind === "hero_image" ? 82 : 88 })
+        .toBuffer();
+      ext = ".webp";
+    }
+    const outputLimit =
+      input.kind === "hero_image"
+        ? MAX_ENTITY_HERO_BYTES
+        : MAX_ENTITY_IMAGE_BYTES;
+    if (output.length > outputLimit)
+      throw new Error(
+        input.kind === "hero_image"
+          ? "Processed hero is too large"
+          : "Processed logo or photo is too large",
+      );
+    const target = path.join(assetsDir, `${prefix}${ext}`);
+    fs.writeFileSync(target, output);
+    relative = `../assets/${plural}/${prefix}${ext}`;
+  }
+  const content = fs.readFileSync(entityPath, "utf8");
+  fs.writeFileSync(
+    entityPath,
+    yamlMediaValue(content, input.kind, relative),
+    "utf8",
+  );
+  clearWikiHomeRemoteCache();
+  return { path: relative };
+}
+
 export async function addWikiType(
   typeName: string,
   icon: string,
@@ -1651,13 +1914,13 @@ export async function addWikiType(
     min_confidence: 0.5
 `;
       // Append under entity_types
-      const updated = config.replace(
-        /^(entity_types:)/m,
-        `$1${entry}`,
-      );
+      const updated = config.replace(/^(entity_types:)/m, `$1${entry}`);
       // If replace didn't work (no entity_types key), just append
       if (updated === config) {
-        fs.appendFileSync(configPath, `\n${typeName}:\n  icon: "${icon}"\n  description: "${description}"\n`);
+        fs.appendFileSync(
+          configPath,
+          `\n${typeName}:\n  icon: "${icon}"\n  description: "${description}"\n`,
+        );
       } else {
         fs.writeFileSync(configPath, updated, "utf-8");
       }

--- a/src/gateway/websocket/memory.ts
+++ b/src/gateway/websocket/memory.ts
@@ -19,9 +19,15 @@ import { promisify } from "util";
 
 const execAsync = promisify(exec);
 
-function workspaceDir(): string { return getPaprWorkspaceDir(); }
-function workspaceFile(): string { return path.join(getPaprWorkspaceDir(), "workspace.md"); }
-function workspaceMemoryDir(): string { return path.join(getPaprWorkspaceDir(), "memory"); }
+function workspaceDir(): string {
+  return getPaprWorkspaceDir();
+}
+function workspaceFile(): string {
+  return path.join(getPaprWorkspaceDir(), "workspace.md");
+}
+function workspaceMemoryDir(): string {
+  return path.join(getPaprWorkspaceDir(), "memory");
+}
 
 const WRITABLE_WORKSPACE_FILES = new Set([
   "MEMORY.md",
@@ -86,7 +92,7 @@ function assertPathUnderWorkspace(filePath: string): void {
 
 export async function setupMemoryHandlers(
   ws: WebSocket,
-  message: WSMessage
+  message: WSMessage,
 ): Promise<void> {
   try {
     if (message.type === "memory:get-workspace") {
@@ -119,6 +125,8 @@ export async function setupMemoryHandlers(
       await handleWikiCreateEntity(ws, message);
     } else if (message.type === "memory:wiki-add-type") {
       await handleWikiAddType(ws, message);
+    } else if (message.type === "memory:wiki-update-media") {
+      await handleWikiUpdateMedia(ws, message);
     } else {
       sendError(ws, message.id, `Unknown memory message type: ${message.type}`);
     }
@@ -132,7 +140,7 @@ export async function setupMemoryHandlers(
  */
 async function handleGetWorkspace(
   ws: WebSocket,
-  message: WSMessage
+  message: WSMessage,
 ): Promise<void> {
   try {
     // Ensure workspace directory exists
@@ -177,7 +185,7 @@ This file helps AI agents understand your current work context.
  */
 async function handleSaveWorkspace(
   ws: WebSocket,
-  message: WSMessage
+  message: WSMessage,
 ): Promise<void> {
   try {
     const { content } = message.payload as { content: string };
@@ -217,7 +225,7 @@ interface MemoryOpenFolderPayload {
  */
 async function handleOpenFolder(
   ws: WebSocket,
-  message: WSMessage
+  message: WSMessage,
 ): Promise<void> {
   try {
     const { folderPath, target } = message.payload as MemoryOpenFolderPayload;
@@ -267,7 +275,7 @@ async function handleOpenFolder(
  */
 async function handleChatStats(
   ws: WebSocket,
-  message: WSMessage
+  message: WSMessage,
 ): Promise<void> {
   try {
     // TODO: Query chats.db for statistics
@@ -302,9 +310,7 @@ async function handleChatStats(
 
         // Get last indexed (most recent message timestamp)
         const lastRow = db
-          .prepare(
-            "SELECT MAX(timestamp) as last_timestamp FROM messages"
-          )
+          .prepare("SELECT MAX(timestamp) as last_timestamp FROM messages")
           .get() as { last_timestamp: string | null };
         if (lastRow.last_timestamp) {
           stats.last_indexed_at = lastRow.last_timestamp;
@@ -331,7 +337,7 @@ async function handleChatStats(
  */
 async function handleListWorkspaceFiles(
   ws: WebSocket,
-  message: WSMessage
+  message: WSMessage,
 ): Promise<void> {
   try {
     // Ensure workspace directory exists
@@ -371,9 +377,8 @@ async function handleReadContextFile(
     }
 
     if (fileName === "IDENTITY.md" || fileName.startsWith("IDENTITY")) {
-      const { seedIdentityAboutFromProfile } = await import(
-        "../services/identityAboutSeed.js"
-      );
+      const { seedIdentityAboutFromProfile } =
+        await import("../services/identityAboutSeed.js");
       await seedIdentityAboutFromProfile();
     }
 
@@ -409,7 +414,8 @@ async function handleWriteContextFile(
   message: WSMessage,
 ): Promise<void> {
   try {
-    const payload = message.payload as { fileName?: string; content?: string } | undefined;
+    const payload = message.payload as
+      { fileName?: string; content?: string } | undefined;
     const fileName = payload?.fileName?.trim();
     const content = payload?.content;
 
@@ -464,21 +470,17 @@ async function handleGetContextPreview(
     const payload = message.payload as { forceRefresh?: boolean } | undefined;
     const forceRefresh = payload?.forceRefresh === true;
 
-    const { getWorkspaceService } = await import(
-      "../services/WorkspaceService.js"
-    );
-    const { getUserMemoryContextService } = await import(
-      "../services/UserMemoryContextService.js"
-    );
-    const { readMemoryPreviewCache, writeMemoryPreviewCache } = await import(
-      "../services/MemoryPreviewCache.js"
-    );
+    const { getWorkspaceService } =
+      await import("../services/WorkspaceService.js");
+    const { getUserMemoryContextService } =
+      await import("../services/UserMemoryContextService.js");
+    const { readMemoryPreviewCache, writeMemoryPreviewCache } =
+      await import("../services/MemoryPreviewCache.js");
 
     const workspaceService = getWorkspaceService();
     await workspaceService.initialize();
-    const { seedIdentityAboutFromProfile } = await import(
-      "../services/identityAboutSeed.js"
-    );
+    const { seedIdentityAboutFromProfile } =
+      await import("../services/identityAboutSeed.js");
     await seedIdentityAboutFromProfile();
     const ctx = await workspaceService.loadWorkspaceContext();
 
@@ -564,7 +566,9 @@ async function handleGetContextPreview(
       return;
     }
 
-    console.log("[Memory] context-preview force refresh (blocking remote fetch)");
+    console.log(
+      "[Memory] context-preview force refresh (blocking remote fetch)",
+    );
     const paprPreview = await memoryService.fetchMemoryPreviewForSettings({
       forceSyncTiers: true,
     });
@@ -641,9 +645,8 @@ async function handleUploadAttachment(
       return;
     }
 
-    const { uploadAttachmentToMemory } = await import(
-      "../services/AttachmentMemoryUpload.js"
-    );
+    const { uploadAttachmentToMemory } =
+      await import("../services/AttachmentMemoryUpload.js");
 
     console.log("[Memory] Uploading attachment to Papr Memory:", {
       filePath: payload.filePath,
@@ -680,9 +683,8 @@ async function handleWikiHome(
 ): Promise<void> {
   try {
     const payload = message.payload as { forceRefresh?: boolean } | undefined;
-    const { fetchWikiHome } = await import(
-      "../services/KnowledgeGraphWikiService.js"
-    );
+    const { fetchWikiHome } =
+      await import("../services/KnowledgeGraphWikiService.js");
     const data = await fetchWikiHome({
       forceRefresh: payload?.forceRefresh === true,
     });
@@ -698,21 +700,15 @@ async function handleWikiEntity(
 ): Promise<void> {
   try {
     const payload = message.payload as
-      | { type?: string; id?: string; label?: string }
-      | undefined;
+      { type?: string; id?: string; label?: string } | undefined;
     if (!payload?.type || !payload?.id) {
       sendError(ws, message.id, "Missing type or id");
       return;
     }
 
-    const { fetchWikiEntity } = await import(
-      "../services/KnowledgeGraphWikiService.js"
-    );
-    const data = await fetchWikiEntity(
-      payload.type,
-      payload.id,
-      payload.label,
-    );
+    const { fetchWikiEntity } =
+      await import("../services/KnowledgeGraphWikiService.js");
+    const data = await fetchWikiEntity(payload.type, payload.id, payload.label);
     sendResponse(ws, { id: message.id, success: true, data });
   } catch (error) {
     sendError(ws, message.id, error as Error);
@@ -725,9 +721,8 @@ async function handleWikiSearch(
 ): Promise<void> {
   try {
     const payload = message.payload as { query?: string } | undefined;
-    const { searchWiki } = await import(
-      "../services/KnowledgeGraphWikiService.js"
-    );
+    const { searchWiki } =
+      await import("../services/KnowledgeGraphWikiService.js");
     const data = await searchWiki(payload?.query ?? "");
     sendResponse(ws, { id: message.id, success: true, data });
   } catch (error) {
@@ -740,18 +735,19 @@ async function handleWikiCreateEntity(
   message: WSMessage,
 ): Promise<void> {
   try {
-    const payload = message.payload as {
-      type?: string;
-      name?: string;
-      description?: string;
-    } | undefined;
+    const payload = message.payload as
+      | {
+          type?: string;
+          name?: string;
+          description?: string;
+        }
+      | undefined;
     if (!payload?.type || !payload?.name) {
       sendError(ws, message.id, "Missing type or name");
       return;
     }
-    const { createWikiEntity } = await import(
-      "../services/KnowledgeGraphWikiService.js"
-    );
+    const { createWikiEntity } =
+      await import("../services/KnowledgeGraphWikiService.js");
     const data = await createWikiEntity(
       payload.type,
       payload.name,
@@ -763,23 +759,55 @@ async function handleWikiCreateEntity(
   }
 }
 
+async function handleWikiUpdateMedia(
+  ws: WebSocket,
+  message: WSMessage,
+): Promise<void> {
+  try {
+    const payload = message.payload as
+      | {
+          type?: string;
+          id?: string;
+          kind?: "image" | "hero_image";
+          dataUrl?: string | null;
+        }
+      | undefined;
+    if (!payload?.type || !payload.id || !payload.kind) {
+      sendError(ws, message.id, "Missing type, id, or media kind");
+      return;
+    }
+    const { updateWikiEntityMedia } =
+      await import("../services/KnowledgeGraphWikiService.js");
+    const data = await updateWikiEntityMedia({
+      type: payload.type,
+      id: payload.id,
+      kind: payload.kind,
+      dataUrl: payload.dataUrl,
+    });
+    sendResponse(ws, { id: message.id, success: true, data });
+  } catch (error) {
+    sendError(ws, message.id, error as Error);
+  }
+}
+
 async function handleWikiAddType(
   ws: WebSocket,
   message: WSMessage,
 ): Promise<void> {
   try {
-    const payload = message.payload as {
-      typeName?: string;
-      icon?: string;
-      description?: string;
-    } | undefined;
+    const payload = message.payload as
+      | {
+          typeName?: string;
+          icon?: string;
+          description?: string;
+        }
+      | undefined;
     if (!payload?.typeName) {
       sendError(ws, message.id, "Missing typeName");
       return;
     }
-    const { addWikiType } = await import(
-      "../services/KnowledgeGraphWikiService.js"
-    );
+    const { addWikiType } =
+      await import("../services/KnowledgeGraphWikiService.js");
     const data = await addWikiType(
       payload.typeName,
       payload.icon ?? "📌",
@@ -796,7 +824,7 @@ async function handleWikiAddType(
  */
 async function handleListSchemas(
   ws: WebSocket,
-  message: WSMessage
+  message: WSMessage,
 ): Promise<void> {
   try {
     const { getApiKey } = await import("../../gateway/utils/keyResolver.js");
@@ -812,22 +840,29 @@ async function handleListSchemas(
     }
 
     const Papr = (await import("@papr/memory")).default;
-    const client = new Papr({ xAPIKey: apiKey, maxRetries: 2, timeout: 30_000 });
+    const client = new Papr({
+      xAPIKey: apiKey,
+      maxRetries: 2,
+      timeout: 30_000,
+    });
 
     const payload = message.payload as { statusFilter?: string } | undefined;
     const response = await client.schemas.list({
-      status_filter: payload?.statusFilter as "draft" | "active" | "deprecated" | "archived" | undefined,
+      status_filter: payload?.statusFilter as
+        "draft" | "active" | "deprecated" | "archived" | undefined,
     });
 
-    const responseData = response as { data?: Array<{
-      id?: string;
-      name?: string;
-      description?: string;
-      status?: string;
-      version?: string;
-      node_types?: Array<{ name?: string }> | Record<string, unknown>;
-      relationship_types?: Array<{ name?: string }> | Record<string, unknown>;
-    }> };
+    const responseData = response as {
+      data?: Array<{
+        id?: string;
+        name?: string;
+        description?: string;
+        status?: string;
+        version?: string;
+        node_types?: Array<{ name?: string }> | Record<string, unknown>;
+        relationship_types?: Array<{ name?: string }> | Record<string, unknown>;
+      }>;
+    };
 
     const schemas = (responseData.data ?? []).map((schema) => {
       const nodeTypes = Array.isArray(schema.node_types)
@@ -860,7 +895,11 @@ async function handleListSchemas(
     sendResponse(ws, {
       id: message.id,
       success: true,
-      data: { schemas: [], error: error instanceof Error ? error.message : "Failed to list schemas" },
+      data: {
+        schemas: [],
+        error:
+          error instanceof Error ? error.message : "Failed to list schemas",
+      },
     });
   }
 }

--- a/src/resources/workspace-templates/WIKI_WRITER.md
+++ b/src/resources/workspace-templates/WIKI_WRITER.md
@@ -22,11 +22,14 @@ Entity files live in `$PAPR_HOME/workspace/entities/{type}/{slug}.md` where type
 ### Step 1: Identify what changed today
 
 **A. Read today's daily log for active entities and their data footprints:**
+
 ```bash
 # Find today's or most recent daily log
 ls -t $PAPR_HOME/workspace/memory/*.md | head -3
 ```
+
 Look for the "Active entities today" section. Each entity may include:
+
 - A brief activity summary
 - **Data sources** — which job databases and tables contain data about this entity (with row counts)
 - **Graph relationships** — linked people, companies, projects from the knowledge graph
@@ -35,6 +38,7 @@ Look for the "Active entities today" section. Each entity may include:
 **B. Discover schemas, then query the graph**
 
 1. **Schema read order** — WorkspaceContext first, then other active schemas:
+
 ```
 list_schemas({ statusFilter: "active" })
 introspect_memory_graph()
@@ -42,6 +46,7 @@ get_schema({ schemaId: "<WorkspaceContext schema id>" })
 ```
 
 2. **Query WorkspaceContext GraphQL roots** (use `limit`, not `first`; minimal fields on lists — corrupt graph nodes can error on bulk `role` reads; no `industry`/`status` fields):
+
 ```
 query_memory_graph({
   query: "{ people(limit: 20) { id name } }"
@@ -57,10 +62,12 @@ query_memory_graph({
 3. **Secondary schemas** — when `list_schemas` shows other active schemas relevant to today's entities, `get_schema` and query their GraphQL types.
 
 For a **specific entity by graph id** (preferred — safe to request `role`, relationships):
+
 ```
 query_memory_graph({ query: "{ people(where: { id: { eq: \"person_id\" } }) { id name role worksAtCompany { id name } participatedInProject { id name } } }" })
 query_memory_graph({ query: "{ companies(where: { id: { eq: \"company_id\" } }) { id name domain description employeesPerson { id name role } } }" })
 ```
+
 Do **not** use `name_CONTAINS` on companies — it fails. Do **not** nest `employeesPerson` on bulk `companies(limit: N)` list queries — it times out. Use `search_agent_memory` for name-based lookup instead.
 
 **C. Merge the two lists.** Entities from both the daily log AND graph updates are candidates. Typically 3-10 entities need attention per day. Prioritize entities with data footprints — they have the richest content to synthesize.
@@ -70,6 +77,7 @@ Do **not** use `name_CONTAINS` on companies — it fails. Do **not** nest `emplo
 For each entity that has a data footprint in the daily log, **follow the breadcrumbs** and query the discovered databases. This is where entity pages get their depth.
 
 **A. Read the data footprint** from the daily log. It will look like:
+
 ```
 - **CompanyName** (Company): Activity summary.
   - Data sources: job `abc123` "Job Name" — table1 (N rows), table2 (M rows)
@@ -78,6 +86,7 @@ For each entity that has a data footprint in the daily log, **follow the breadcr
 ```
 
 **B. Query the discovered databases.** For each job database listed in the data footprint:
+
 ```bash
 # First, understand the schema
 sqlite3 $PAPR_HOME/Jobs/<job_id>/data/data.db ".tables"
@@ -100,6 +109,7 @@ sqlite3 $PAPR_HOME/Jobs/<job_id>/data/data.db "SELECT question, response, speake
 ```
 
 **C. If no data footprint exists** for an entity, fall back to `search_agent_memory`:
+
 ```
 search_agent_memory({
   query: "Everything about EntityName — context, decisions, history, relationships",
@@ -108,6 +118,7 @@ search_agent_memory({
 ```
 
 **D. Always search Papr Memory too** — even when databases have rich data, memory captures chat conversations and context that databases don't:
+
 ```
 search_agent_memory({
   query: "EntityName recent activity discussions decisions",
@@ -120,9 +131,11 @@ search_agent_memory({
 For each entity that needs attention:
 
 **A. Check if a file already exists:**
+
 ```bash
 ls $PAPR_HOME/workspace/entities/{type}/{slug}.md 2>/dev/null
 ```
+
 If the file exists, read it and **merge new information** — don't overwrite existing content. Add to sections, update facts, append to the timeline.
 
 **B. Use this template for new entity files:**
@@ -132,8 +145,8 @@ render cards — without frontmatter a card falls back to a plain gradient tile.
 
 ```markdown
 ---
-id: {slug}
-name: {Entity Name}
+id: { slug }
+name: { Entity Name }
 description: One-line summary shown on the card.
 status: active
 image: ../assets/{type}/{slug}.png
@@ -153,26 +166,28 @@ how they relate to the user's work. Write in third person, encyclopedic tone.
 
 ## Key Facts
 
-| Field | Value |
-|-------|-------|
-| Type | Person / Company / Project |
-| Role | ... |
-| Since | first mention date |
-| Status | Active / Inactive |
+| Field  | Value                      |
+| ------ | -------------------------- |
+| Type   | Person / Company / Project |
+| Role   | ...                        |
+| Since  | first mention date         |
+| Status | Active / Inactive          |
 
 ## Details
 
 ### {Relevant Section}
+
 Deep content synthesized from databases, memory, and chat history.
 Include evidence, scores, quotes, and analysis — not just surface summaries.
 
 ### {Another Section}
+
 ...
 
 ## Related Entities
 
-| Entity | Type | Relationship | File |
-|--------|------|-------------|------|
+| Entity | Type           | Relationship                | File                               |
+| ------ | -------------- | --------------------------- | ---------------------------------- |
 | {Name} | Person/Company | role/connection description | [`{slug}.md`](../{type}/{slug}.md) |
 
 ## Timeline
@@ -187,6 +202,7 @@ Include evidence, scores, quotes, and analysis — not just surface summaries.
 ```
 
 **C. Query the graph for relationships** to populate the Related Entities section (prefer `id: { eq: "..." }` when you have a graph id):
+
 ```
 # For a company — find linked people (when you have company id):
 query_memory_graph({
@@ -203,9 +219,11 @@ query_memory_graph({
   query: "{ projects(where: { id: { eq: \"project_id\" } }) { id name description participantsPerson { id name role } } }"
 })
 ```
+
 If you only have a name (no graph id), use `search_agent_memory` — do not use broken `name_CONTAINS` filters on companies.
 
 **D. Cross-link related entity files.** Check which other entity files exist for related entities:
+
 ```bash
 # Find all entity files
 find $PAPR_HOME/workspace/entities -name "*.md" -type f | sort
@@ -214,12 +232,15 @@ find $PAPR_HOME/workspace/entities -name "*.md" -type f | sort
 ls $PAPR_HOME/workspace/entities/people/*.md 2>/dev/null
 ls $PAPR_HOME/workspace/entities/companies/*.md 2>/dev/null
 ```
+
 For each related entity that has a file, add a row to the Related Entities table with a relative markdown link: `[slug.md](../type/slug.md)`.
 
 Also scan for entity files that mention the current entity:
+
 ```bash
 grep -rl "EntityName" $PAPR_HOME/workspace/entities/ 2>/dev/null
 ```
+
 Update those files too — add a reciprocal link back to the current entity.
 
 **E. Fetch a logo/avatar and profile links (companies and people).**
@@ -233,6 +254,7 @@ for **every new company** — it takes one command.
 
 2. **Download the logo** into the shared assets folder. Use `-L`: the endpoint
    **301-redirects**, and without it you silently save an HTML stub instead of an image.
+
    ```bash
    mkdir -p $PAPR_HOME/workspace/entities/assets/companies
    curl -sL -o $PAPR_HOME/workspace/entities/assets/companies/{slug}.png \
@@ -246,13 +268,17 @@ for **every new company** — it takes one command.
    - Keep images under 256KB; larger files are skipped by the wiki reader.
 
 3. **Reference it in frontmatter** with a path relative to the entity file:
+
    ```yaml
    image: ../assets/companies/{slug}.png
+   hero_image: ../assets/companies/{slug}-hero.webp # optional wide cover
    website: https://acme.com
    linkedin: https://www.linkedin.com/company/acme/
    ```
-   The wiki service inlines this file as a data URI at read time, so relative paths
-   work — do **not** paste base64 into the markdown yourself.
+
+   The wiki service inlines these files as data URIs at read time, so relative paths
+   work — do **not** paste base64 into the markdown yourself. Preserve existing
+   `image:` and `hero_image:` values when enriching a page; user-uploaded media wins.
 
 4. **People:** set `linkedin:` when you have a verified profile URL. Only use a URL
    you've actually seen in a source — **never guess a slug from someone's name**, it
@@ -263,6 +289,7 @@ for **every new company** — it takes one command.
 ### Step 4: Quality checks
 
 Before finishing:
+
 - **MANDATORY:** Every entity listed in today's daily log "Active entities today" section MUST have a file under `$PAPR_HOME/workspace/entities/{type}/`. If missing, create a stub with `write_file` before ending the run. Daily log mentions alone do not create Memory library cards. Group related apps under projects when the data supports it — avoid duplicate near-miss names.
 - **Reconcile people from company pages:** When you create or update a **company** page that lists people in prose, a table, or an `employeesPerson` section, ensure **each named person** has a file in `entities/people/`. Create stubs for any missing person pages and add reciprocal links in both directions. This catches people who only appear in company tables (e.g. a CSM roster) but never in the daily log.
 - Every entity file should have an **Overview**, **Key Facts**, and **Related Entities** section at minimum
@@ -278,6 +305,7 @@ Before finishing:
 ### Step 5: Handle deletions
 
 If an entity was mentioned as deleted, deprecated, or irrelevant:
+
 ```bash
 # Don't delete the file — mark it as archived
 # Add to the top of the file:

--- a/tests/unit/backend/wikiEntityImage.test.ts
+++ b/tests/unit/backend/wikiEntityImage.test.ts
@@ -12,7 +12,8 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "papr-wiki-img-"));
 
 vi.mock("../../../src/core/utils/paprRoot", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../src/core/utils/paprRoot")>();
+  const actual =
+    await importOriginal<typeof import("../../../src/core/utils/paprRoot")>();
   return {
     ...actual,
     getPaprWorkspaceDir: () => path.join(tmpHome, "workspace"),
@@ -41,9 +42,8 @@ beforeAll(async () => {
   fs.writeFileSync(path.join(assetsDir, "notes.txt"), "not an image");
   fs.writeFileSync(path.join(tmpHome, "outside-secret.png"), PNG_1PX);
 
-  ({ resolveEntityImage } = await import(
-    "../../../src/gateway/services/KnowledgeGraphWikiService"
-  ));
+  ({ resolveEntityImage } =
+    await import("../../../src/gateway/services/KnowledgeGraphWikiService"));
 });
 
 afterAll(() => {
@@ -52,7 +52,10 @@ afterAll(() => {
 
 describe("resolveEntityImage", () => {
   it("inlines a relative asset path as a base64 data URI", () => {
-    const result = resolveEntityImage("../assets/companies/acme.png", companiesDir);
+    const result = resolveEntityImage(
+      "../assets/companies/acme.png",
+      companiesDir,
+    );
     expect(result).toBeTruthy();
     expect(result).toMatch(/^data:image\/png;base64,/);
     // Round-trips to the original bytes.
@@ -61,7 +64,10 @@ describe("resolveEntityImage", () => {
   });
 
   it("maps .jpg to image/jpeg", () => {
-    const result = resolveEntityImage("../assets/companies/acme-photo.jpg", companiesDir);
+    const result = resolveEntityImage(
+      "../assets/companies/acme-photo.jpg",
+      companiesDir,
+    );
     expect(result).toMatch(/^data:image\/jpeg;base64,/);
   });
 
@@ -77,15 +83,113 @@ describe("resolveEntityImage", () => {
 
   it("refuses paths that escape the entities directory", () => {
     // ../../outside-secret.png from companies/ lands in the workspace root.
-    expect(resolveEntityImage("../../outside-secret.png", companiesDir)).toBeNull();
+    expect(
+      resolveEntityImage("../../outside-secret.png", companiesDir),
+    ).toBeNull();
     expect(resolveEntityImage("/etc/passwd", companiesDir)).toBeNull();
   });
 
   it("returns null for missing files, non-images, and empty values", () => {
-    expect(resolveEntityImage("../assets/companies/nope.png", companiesDir)).toBeNull();
-    expect(resolveEntityImage("../assets/companies/notes.txt", companiesDir)).toBeNull();
+    expect(
+      resolveEntityImage("../assets/companies/nope.png", companiesDir),
+    ).toBeNull();
+    expect(
+      resolveEntityImage("../assets/companies/notes.txt", companiesDir),
+    ).toBeNull();
     expect(resolveEntityImage("", companiesDir)).toBeNull();
     expect(resolveEntityImage(undefined, companiesDir)).toBeNull();
     expect(resolveEntityImage(42, companiesDir)).toBeNull();
+  });
+});
+
+describe("updateWikiEntityMedia", () => {
+  let updateWikiEntityMedia: typeof import("../../../src/gateway/services/KnowledgeGraphWikiService").updateWikiEntityMedia;
+  const companyFile = path.join(companiesDir, "acme.md");
+  const personDir = path.join(entitiesDir, "people");
+
+  beforeAll(async () => {
+    fs.mkdirSync(personDir, { recursive: true });
+    fs.writeFileSync(companyFile, "---\nid: acme\nname: Acme\n---\n# Acme\n");
+    fs.writeFileSync(
+      path.join(personDir, "ada.md"),
+      "---\nid: ada\nname: Ada\n---\n# Ada\n",
+    );
+    ({ updateWikiEntityMedia } =
+      await import("../../../src/gateway/services/KnowledgeGraphWikiService"));
+  });
+
+  it("stores a safe SVG logo and updates frontmatter", async () => {
+    const svg = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h10v10z"/></svg>',
+    );
+    const dataUrl = `data:image/svg+xml;base64,${svg.toString("base64")}`;
+    const result = await updateWikiEntityMedia({
+      type: "company",
+      id: "company/acme",
+      kind: "image",
+      dataUrl,
+    });
+    expect(result.path).toBe("../assets/companies/acme.svg");
+    expect(fs.readFileSync(companyFile, "utf8")).toContain(
+      "image: ../assets/companies/acme.svg",
+    );
+  });
+
+  it("normalizes a hero to bounded WebP and can remove it", async () => {
+    const dataUrl = `data:image/png;base64,${PNG_1PX.toString("base64")}`;
+    const added = await updateWikiEntityMedia({
+      type: "company",
+      id: "acme",
+      kind: "hero_image",
+      dataUrl,
+    });
+    expect(added.path).toBe("../assets/companies/acme-hero.webp");
+    const heroPath = path.join(assetsDir, "acme-hero.webp");
+    expect(fs.existsSync(heroPath)).toBe(true);
+    expect(fs.statSync(heroPath).size).toBeLessThanOrEqual(1024 * 1024);
+    expect(fs.readFileSync(companyFile, "utf8")).toContain(
+      "hero_image: ../assets/companies/acme-hero.webp",
+    );
+    await updateWikiEntityMedia({
+      type: "company",
+      id: "acme",
+      kind: "hero_image",
+      dataUrl: null,
+    });
+    expect(fs.existsSync(heroPath)).toBe(false);
+    expect(fs.readFileSync(companyFile, "utf8")).not.toContain("hero_image:");
+  });
+
+  it("accepts plural type aliases", async () => {
+    await expect(
+      updateWikiEntityMedia({
+        type: "people",
+        id: "ada",
+        kind: "hero_image",
+        dataUrl: null,
+      }),
+    ).resolves.toEqual({ path: null });
+  });
+
+  it("rejects unsafe SVG and unsupported entity types", async () => {
+    const unsafe = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+    );
+    await expect(
+      updateWikiEntityMedia({
+        type: "company",
+        id: "acme",
+        kind: "image",
+        dataUrl: `data:image/svg+xml;base64,${unsafe.toString("base64")}`,
+      }),
+    ).rejects.toThrow("Unsafe SVG");
+    await expect(
+      updateWikiEntityMedia({
+        type: "project",
+        id: "demo",
+        kind: "image",
+        dataUrl: null,
+      }),
+    ).rejects.toThrow("companies and people");
   });
 });

--- a/ui/components/Memory/WikiLibrary.css
+++ b/ui/components/Memory/WikiLibrary.css
@@ -6,16 +6,16 @@
   --bg-panel: #ffffff;
   --bg-sunk: #eceef1;
   --bg-inset: #e4e7ec;
-  --line: rgba(0,0,0,0.10);
-  --line-soft: rgba(0,0,0,0.06);
+  --line: rgba(0, 0, 0, 0.1);
+  --line-soft: rgba(0, 0, 0, 0.06);
   --text: #1d1d1f;
-  --text-mute: rgba(29,29,31,0.62);
-  --text-dim: rgba(29,29,31,0.42);
-  --accent: #0080FF;
-  --accent-soft: rgba(0,128,255,0.12);
-  --shadow: 0 1px 2px rgba(0,0,0,0.05), 0 8px 32px rgba(0,0,0,0.10);
-  --shadow-sm: 0 1px 3px rgba(0,0,0,0.08);
-  --g-project: linear-gradient(135deg, #0080FF, #0040CC);
+  --text-mute: rgba(29, 29, 31, 0.62);
+  --text-dim: rgba(29, 29, 31, 0.42);
+  --accent: #0080ff;
+  --accent-soft: rgba(0, 128, 255, 0.12);
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.05), 0 8px 32px rgba(0, 0, 0, 0.1);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --g-project: linear-gradient(135deg, #0080ff, #0040cc);
   --g-goal: linear-gradient(135deg, #f59e0b, #d97706);
   --g-person: linear-gradient(135deg, #10b981, #059669);
   --g-memory: linear-gradient(135deg, #6366f1, #4f46e5);
@@ -229,11 +229,31 @@
   position: absolute;
   inset: 0;
   background-image:
-    radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.12) 0, transparent 2px),
-    radial-gradient(circle at 70% 60%, rgba(255, 255, 255, 0.1) 0, transparent 2px),
-    radial-gradient(circle at 40% 80%, rgba(255, 255, 255, 0.08) 0, transparent 2px),
-    radial-gradient(circle at 85% 25%, rgba(255, 255, 255, 0.1) 0, transparent 2px);
-  background-size: 220px 220px, 180px 180px, 260px 260px, 200px 200px;
+    radial-gradient(
+      circle at 20% 30%,
+      rgba(255, 255, 255, 0.12) 0,
+      transparent 2px
+    ),
+    radial-gradient(
+      circle at 70% 60%,
+      rgba(255, 255, 255, 0.1) 0,
+      transparent 2px
+    ),
+    radial-gradient(
+      circle at 40% 80%,
+      rgba(255, 255, 255, 0.08) 0,
+      transparent 2px
+    ),
+    radial-gradient(
+      circle at 85% 25%,
+      rgba(255, 255, 255, 0.1) 0,
+      transparent 2px
+    );
+  background-size:
+    220px 220px,
+    180px 180px,
+    260px 260px,
+    200px 200px;
   pointer-events: none;
 }
 
@@ -242,7 +262,11 @@
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(ellipse 80% 60% at 30% 40%, rgba(255, 255, 255, 0.15), transparent 60%),
+    radial-gradient(
+      ellipse 80% 60% at 30% 40%,
+      rgba(255, 255, 255, 0.15),
+      transparent 60%
+    ),
     linear-gradient(180deg, transparent 0%, transparent 40%, var(--bg) 100%),
     linear-gradient(90deg, rgba(0, 0, 0, 0.45) 0%, transparent 60%);
 }
@@ -416,7 +440,9 @@
   background: var(--bg-panel);
   border: 1px solid var(--line);
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .wiki-card:hover {
@@ -606,7 +632,9 @@
   color: #fff;
   text-decoration: none;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
 }
 
 .wiki-entity__pill--link:hover {
@@ -776,8 +804,12 @@
 }
 
 @keyframes wiki-connect-spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .wiki-setup-panel--sign-in {
@@ -868,7 +900,12 @@
   height: 18px;
   border-radius: 8px;
   margin-bottom: 12px;
-  background: linear-gradient(90deg, var(--bg-inset) 25%, var(--bg-sunk) 50%, var(--bg-inset) 75%);
+  background: linear-gradient(
+    90deg,
+    var(--bg-inset) 25%,
+    var(--bg-sunk) 50%,
+    var(--bg-inset) 75%
+  );
   background-size: 200% 100%;
   animation: wiki-shimmer 1.2s infinite;
 }
@@ -878,8 +915,12 @@
 }
 
 @keyframes wiki-shimmer {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 .wiki-empty-state h2,
@@ -936,7 +977,7 @@
   --g-learnings: linear-gradient(135deg, #14b8a6, #0f766e);
   --g-collections: linear-gradient(135deg, #8b5cf6, #6d28d9);
   --g-people: linear-gradient(135deg, #10b981, #059669);
-  --g-projects: linear-gradient(135deg, #0080FF, #0040CC);
+  --g-projects: linear-gradient(135deg, #0080ff, #0040cc);
 }
 
 /* Rail section header — more distinct on dark bg */
@@ -947,7 +988,12 @@
 
 /* Hero bg — branded blue cover; white hero text stays legible in light + dark */
 .wiki-hero__bg {
-  background: linear-gradient(135deg, #0a4da8 0%, #0080FF 55%, #2ba6ff 100%) !important;
+  background: linear-gradient(
+    135deg,
+    #0a4da8 0%,
+    #0080ff 55%,
+    #2ba6ff 100%
+  ) !important;
 }
 
 /* Palette (⌘K) — glass style */
@@ -964,7 +1010,7 @@
 
 .wiki-palette__result:hover,
 .wiki-palette__result--sel {
-  background: rgba(0,128,255,0.15) !important;
+  background: rgba(0, 128, 255, 0.15) !important;
 }
 
 /* View switch buttons on dark bg */
@@ -992,18 +1038,29 @@
 
 /* ── Entity Stats Bar ─────────────────── */
 .wiki-entity__stats {
-  display: flex; gap: 24px; padding: 12px 32px;
+  display: flex;
+  gap: 24px;
+  padding: 12px 32px;
   border-bottom: 1px solid var(--line);
-  font-size: 13px; color: var(--text-mute);
+  font-size: 13px;
+  color: var(--text-mute);
 }
 .wiki-entity__stats span::before {
-  content: ""; display: inline-block; width: 6px; height: 6px;
-  border-radius: 50%; background: var(--accent); margin-right: 6px; vertical-align: middle;
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-right: 6px;
+  vertical-align: middle;
 }
 
 /* ── Content Layout: main + sidebar ───── */
 .wiki-entity__content {
-  display: grid; grid-template-columns: 1fr 360px; gap: 32px;
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  gap: 32px;
   padding: 24px 32px;
 }
 /* Context files (MEMORY.md, IDENTITY.md, …) — single full-width column, no sidebar rail */
@@ -1029,95 +1086,214 @@
   box-sizing: border-box;
 }
 @media (max-width: 900px) {
-  .wiki-entity__content { grid-template-columns: 1fr; }
+  .wiki-entity__content {
+    grid-template-columns: 1fr;
+  }
 }
-.wiki-entity__main { min-width: 0; }
-.wiki-entity__sidebar { min-width: 0; }
-.wiki-entity__overview { font-size: 15px; line-height: 1.7; color: var(--text); }
+.wiki-entity__main {
+  min-width: 0;
+}
+.wiki-entity__sidebar {
+  min-width: 0;
+}
+.wiki-entity__overview {
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--text);
+}
 
 /* ── Sections ────────────────────────── */
 .wiki-section {
-  margin-bottom: 8px; border: 1px solid var(--line); border-radius: 10px;
-  background: var(--bg-panel); overflow: hidden;
+  margin-bottom: 8px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bg-panel);
+  overflow: hidden;
 }
 .wiki-section__header {
-  display: flex; align-items: center; gap: 8px; width: 100%;
-  padding: 12px 16px; border: none; background: transparent;
-  color: var(--text); font-size: 14px; font-weight: 600; cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 16px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
   transition: background 0.15s;
 }
-.wiki-section__header:hover { background: var(--bg-inset); }
-.wiki-section__icon { font-size: 16px; }
-.wiki-section__title { flex: 1; text-align: left; }
-.wiki-section__count { font-size: 12px; color: var(--text-dim); font-weight: 400; }
-.wiki-section__chevron { font-size: 12px; color: var(--text-mute); }
-.wiki-section__body { padding: 0 16px 14px; }
-.wiki-section__text { font-size: 14px; line-height: 1.6; color: var(--text-mute); margin: 4px 0; }
+.wiki-section__header:hover {
+  background: var(--bg-inset);
+}
+.wiki-section__icon {
+  font-size: 16px;
+}
+.wiki-section__title {
+  flex: 1;
+  text-align: left;
+}
+.wiki-section__count {
+  font-size: 12px;
+  color: var(--text-dim);
+  font-weight: 400;
+}
+.wiki-section__chevron {
+  font-size: 12px;
+  color: var(--text-mute);
+}
+.wiki-section__body {
+  padding: 0 16px 14px;
+}
+.wiki-section__text {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-mute);
+  margin: 4px 0;
+}
 .wiki-section__dated {
-  display: flex; align-items: baseline; gap: 10px;
-  padding: 6px 0; border-bottom: 1px solid var(--line-soft);
-  font-size: 13px; color: var(--text-mute);
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--line-soft);
+  font-size: 13px;
+  color: var(--text-mute);
 }
 .wiki-section__date {
-  font-size: 12px; font-family: 'SF Mono', monospace;
-  color: var(--accent); white-space: nowrap; min-width: 90px;
+  font-size: 12px;
+  font-family: "SF Mono", monospace;
+  color: var(--accent);
+  white-space: nowrap;
+  min-width: 90px;
 }
 .wiki-section__check {
-  display: flex; align-items: center; gap: 8px;
-  padding: 4px 0; font-size: 13px; color: var(--text-mute);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 13px;
+  color: var(--text-mute);
 }
-.wiki-section__check.done { color: var(--text-dim); text-decoration: line-through; }
+.wiki-section__check.done {
+  color: var(--text-dim);
+  text-decoration: line-through;
+}
 
 /* ── Relationships Panel ─────────────── */
 .wiki-relationships {
-  background: var(--bg-panel); border: 1px solid var(--line); border-radius: 10px;
-  padding: 16px; margin-bottom: 16px;
+  background: var(--bg-panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 16px;
+  margin-bottom: 16px;
 }
 .wiki-relationships__title {
-  font-size: 14px; font-weight: 600; color: var(--text); margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0 0 12px;
 }
-.wiki-rel-group { margin-bottom: 12px; }
+.wiki-rel-group {
+  margin-bottom: 12px;
+}
 .wiki-rel-group__type {
-  font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
-  color: var(--accent); font-weight: 600; margin-bottom: 6px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  font-weight: 600;
+  margin-bottom: 6px;
 }
 .wiki-rel-item {
-  display: flex; align-items: flex-start; gap: 8px;
-  padding: 8px; border-radius: 6px; transition: background 0.15s;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 6px;
+  transition: background 0.15s;
 }
-.wiki-rel-item:hover { background: var(--bg-inset); }
-.wiki-rel-item__glyph { font-size: 14px; margin-top: 2px; }
-.wiki-rel-item__info { flex: 1; min-width: 0; }
-.wiki-rel-item__name { font-size: 13px; font-weight: 500; color: var(--text); display: block; }
-.wiki-rel-item__context { font-size: 12px; color: var(--text-dim); display: block; margin-top: 2px; }
-.wiki-rel-item__since { font-size: 11px; color: var(--text-dim); white-space: nowrap; }
+.wiki-rel-item:hover {
+  background: var(--bg-inset);
+}
+.wiki-rel-item__glyph {
+  font-size: 14px;
+  margin-top: 2px;
+}
+.wiki-rel-item__info {
+  flex: 1;
+  min-width: 0;
+}
+.wiki-rel-item__name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  display: block;
+}
+.wiki-rel-item__context {
+  font-size: 12px;
+  color: var(--text-dim);
+  display: block;
+  margin-top: 2px;
+}
+.wiki-rel-item__since {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
 
 /* ── Evidence Trail ──────────────────── */
 .wiki-evidence {
-  background: var(--bg-panel); border: 1px solid var(--line); border-radius: 10px;
+  background: var(--bg-panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
   padding: 16px;
 }
 .wiki-evidence__title {
-  font-size: 14px; font-weight: 600; color: var(--text); margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0 0 12px;
 }
 .wiki-evidence__item {
-  padding: 10px 0; border-bottom: 1px solid var(--line-soft);
-  display: grid; grid-template-columns: 90px 1fr; gap: 4px 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line-soft);
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  gap: 4px 12px;
 }
-.wiki-evidence__item:last-child { border-bottom: none; }
+.wiki-evidence__item:last-child {
+  border-bottom: none;
+}
 .wiki-evidence__date {
-  font-size: 12px; font-family: 'SF Mono', monospace; color: var(--accent);
+  font-size: 12px;
+  font-family: "SF Mono", monospace;
+  color: var(--accent);
   grid-row: 1 / 3;
 }
-.wiki-evidence__source { font-size: 11px; color: var(--text-dim); text-transform: uppercase; }
-.wiki-evidence__summary { font-size: 13px; color: var(--text-mute); margin: 0; grid-column: 2; }
+.wiki-evidence__source {
+  font-size: 11px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+.wiki-evidence__summary {
+  font-size: 13px;
+  color: var(--text-mute);
+  margin: 0;
+  grid-column: 2;
+}
 
 /* ── Related section ─────────────────── */
 .wiki-entity__related {
-  padding: 24px 32px; border-top: 1px solid var(--line);
+  padding: 24px 32px;
+  border-top: 1px solid var(--line);
 }
 .wiki-entity__related h3 {
-  font-size: 16px; font-weight: 600; color: var(--text); margin: 0 0 16px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0 0 16px;
 }
 
 /* Connected entities — prominent card grid above memories */
@@ -1127,29 +1303,45 @@
   background: var(--bg-sunk);
 }
 .wiki-entity__connected h3 {
-  font-size: 16px; font-weight: 600; color: var(--text); margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0 0 4px;
 }
 .wiki-entity__connected-count {
-  font-size: 12px; color: var(--text-dim); margin: 0 0 16px;
+  font-size: 12px;
+  color: var(--text-dim);
+  margin: 0 0 16px;
 }
 .wiki-entity__connected-grid {
-  display: flex; flex-direction: row; flex-wrap: wrap; gap: 12px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 .wiki-entity__connected-grid .wiki-rail {
   flex: 0 0 auto;
 }
 .wiki-entity__connected-grid .wiki-rail h2 {
-  font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em;
-  color: var(--text-dim); margin: 0 0 8px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+  margin: 0 0 8px;
 }
 .wiki-entity__connected-grid .wiki-rail__track {
-  display: flex; flex-wrap: wrap; gap: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 .wiki-entity__connected-grid .wiki-card {
-  flex: 0 0 auto; min-width: 160px; max-width: 220px;
+  flex: 0 0 auto;
+  min-width: 160px;
+  max-width: 220px;
 }
 .wiki-entity__connected-grid .wiki-card.poster {
-  cursor: pointer; transition: transform 0.1s ease;
+  cursor: pointer;
+  transition: transform 0.1s ease;
 }
 .wiki-entity__connected-grid .wiki-card.poster:hover {
   transform: translateY(-2px);
@@ -1157,15 +1349,31 @@
 
 /* ── Add FAB ───────────────────────────────── */
 .wiki-add-float {
-  position: fixed; bottom: 28px; right: 80px; z-index: 100;
-  width: 44px; height: 44px; border-radius: 50%;
-  background: var(--accent, #0080FF); color: #fff; border: none;
-  font-size: 24px; line-height: 1; cursor: pointer;
-  box-shadow: 0 4px 16px rgba(0,128,255,.35);
-  display: flex; align-items: center; justify-content: center;
-  transition: transform .15s, box-shadow .15s;
+  position: fixed;
+  bottom: 28px;
+  right: 80px;
+  z-index: 100;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--accent, #0080ff);
+  color: #fff;
+  border: none;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 4px 16px rgba(0, 128, 255, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s;
 }
-.wiki-add-float:hover { transform: scale(1.1); box-shadow: 0 6px 24px rgba(0,128,255,.5); }
+.wiki-add-float:hover {
+  transform: scale(1.1);
+  box-shadow: 0 6px 24px rgba(0, 128, 255, 0.5);
+}
 
 .wiki-palette-backdrop {
   position: fixed;
@@ -1178,61 +1386,112 @@
 }
 /* ── Create Dialog ──────────────────────────── */
 .wiki-create-dialog {
-  background: var(--bg-panel, #13161d); border: 1px solid rgba(255,255,255,.1);
-  border-radius: 16px; padding: 0; width: 420px; max-width: 90vw;
-  box-shadow: 0 24px 80px rgba(0,0,0,.6); overflow: hidden;
+  background: var(--bg-panel, #13161d);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 0;
+  width: 420px;
+  max-width: 90vw;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
 }
 .wiki-create-dialog__tabs {
-  display: flex; border-bottom: 1px solid rgba(255,255,255,.08);
+  display: flex;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 .wiki-create-dialog__tab {
-  flex: 1; padding: 12px 16px; background: none; border: none;
-  color: rgba(255,255,255,.5); font-size: 14px; font-weight: 500;
-  cursor: pointer; transition: all .15s;
+  flex: 1;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
 }
 .wiki-create-dialog__tab.active {
-  color: var(--accent, #0080FF); border-bottom: 2px solid var(--accent, #0080FF);
+  color: var(--accent, #0080ff);
+  border-bottom: 2px solid var(--accent, #0080ff);
 }
 .wiki-create-dialog__form {
-  padding: 20px; display: flex; flex-direction: column; gap: 14px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
 }
 .wiki-create-dialog__form label {
-  display: flex; flex-direction: column; gap: 6px;
-  font-size: 13px; color: rgba(255,255,255,.6); font-weight: 500;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.6);
+  font-weight: 500;
 }
 .wiki-create-dialog__form input,
 .wiki-create-dialog__form textarea,
 .wiki-create-dialog__form select {
-  background: rgba(255,255,255,.06); border: 1px solid rgba(255,255,255,.12);
-  border-radius: 8px; padding: 10px 12px; color: var(--text, #f0f0ee);
-  font-size: 14px; outline: none; transition: border-color .15s;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  padding: 10px 12px;
+  color: var(--text, #f0f0ee);
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.15s;
 }
 .wiki-create-dialog__form input:focus,
 .wiki-create-dialog__form textarea:focus,
 .wiki-create-dialog__form select:focus {
-  border-color: var(--accent, #0080FF);
+  border-color: var(--accent, #0080ff);
 }
 .wiki-create-dialog__actions {
-  display: flex; gap: 8px; justify-content: flex-end; padding: 16px 20px;
-  border-top: 1px solid rgba(255,255,255,.06);
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  padding: 16px 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 .wiki-btn--primary {
-  background: var(--accent, #0080FF); color: #fff; border: none;
-  border-radius: 8px; padding: 8px 20px; font-size: 13px; font-weight: 600;
-  cursor: pointer; transition: opacity .15s;
+  background: var(--accent, #0080ff);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 20px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
 }
-.wiki-btn--primary:disabled { opacity: .4; cursor: default; }
-.wiki-btn--primary:hover:not(:disabled) { opacity: .9; }
+.wiki-btn--primary:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.wiki-btn--primary:hover:not(:disabled) {
+  opacity: 0.9;
+}
 
 /* ── Rail + button ──────────────────────────── */
 .wiki-rail__add {
-  background: rgba(255,255,255,.06); border: 1px solid rgba(255,255,255,.1);
-  border-radius: 50%; width: 28px; height: 28px; color: rgba(255,255,255,.5);
-  font-size: 18px; line-height: 1; cursor: pointer; display: flex;
-  align-items: center; justify-content: center; transition: all .15s;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
   margin-left: auto;
 }
-.wiki-rail__add:hover { background: var(--accent, #0080FF); color: #fff; }
+.wiki-rail__add:hover {
+  background: var(--accent, #0080ff);
+  color: #fff;
+}
 
 /* ── Related Memories ─────────────────── */
 .wiki-related-memories {
@@ -1252,13 +1511,21 @@
   margin-bottom: 8px;
 }
 .wiki-related-memory__date {
-  font-size: 12px; font-family: 'SF Mono', monospace; color: var(--accent);
+  font-size: 12px;
+  font-family: "SF Mono", monospace;
+  color: var(--accent);
 }
 .wiki-related-memory__category {
-  font-size: 11px; color: var(--text-dim); text-transform: uppercase;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-transform: uppercase;
 }
 .wiki-related-memory__content {
-  font-size: 14px; color: var(--text-mute); margin: 0; line-height: 1.5; white-space: pre-wrap;
+  font-size: 14px;
+  color: var(--text-mute);
+  margin: 0;
+  line-height: 1.5;
+  white-space: pre-wrap;
 }
 
 /* Markdown body in entity page */
@@ -1418,7 +1685,9 @@
   background: var(--card-bg, rgba(255, 255, 255, 0.5));
   border: 1px solid var(--border-color, rgba(0, 0, 0, 0.06));
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
 }
 .wiki-context-card:hover {
   background: var(--card-bg-hover, rgba(255, 255, 255, 0.75));
@@ -1478,7 +1747,11 @@
 }
 
 .wiki-entity__hero-bg--context {
-  background: linear-gradient(135deg, #6366f1, color-mix(in srgb, #6366f1 55%, #111));
+  background: linear-gradient(
+    135deg,
+    #6366f1,
+    color-mix(in srgb, #6366f1 55%, #111)
+  );
 }
 
 .wiki-card--context {
@@ -1504,8 +1777,12 @@
 
 .wiki-card__gradient--context {
   background:
-    radial-gradient(circle at 78% 18%, rgba(255, 255, 255, 0.22), transparent 42%),
-    linear-gradient(135deg, #0080FF, #0a2a8c 55%, #06165a);
+    radial-gradient(
+      circle at 78% 18%,
+      rgba(255, 255, 255, 0.22),
+      transparent 42%
+    ),
+    linear-gradient(135deg, #0080ff, #0a2a8c 55%, #06165a);
 }
 
 .wiki-card--context .wiki-card__glyph {
@@ -1627,4 +1904,146 @@
 .wiki-card__art-icon--context {
   width: 42px;
   height: 42px;
+}
+
+/* Entity media: cover hero + independent logo/avatar. */
+.wiki-card__logo {
+  position: absolute;
+  left: 12px;
+  bottom: 10px;
+  width: 54px;
+  height: 36px;
+  padding: 7px;
+  border-radius: 9px;
+  background: rgba(8, 12, 20, 0.76);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  backdrop-filter: blur(12px);
+}
+.wiki-card__logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+.wiki-entity__hero-img {
+  filter: brightness(0.72);
+}
+.wiki-entity__identity {
+  position: absolute;
+  left: 40px;
+  top: 84px;
+  z-index: 2;
+  width: 150px;
+  height: 76px;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(8, 12, 20, 0.74);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(18px);
+}
+.wiki-entity__identity img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+.wiki-entity__identity--person {
+  width: 112px;
+  height: 112px;
+  padding: 0;
+  border-radius: 50%;
+  overflow: hidden;
+}
+.wiki-entity__identity--person img {
+  object-fit: cover;
+}
+.wiki-entity__identity ~ .wiki-entity__hero-inner {
+  padding-left: 220px;
+}
+.wiki-entity__identity--person ~ .wiki-entity__hero-inner {
+  padding-left: 184px;
+}
+.wiki-entity__media-actions {
+  position: absolute;
+  z-index: 4;
+  right: 20px;
+  top: 16px;
+  display: flex;
+  gap: 7px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.wiki-media-btn {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(0, 0, 0, 0.42);
+  color: #fff;
+  font: 500 11px/1.2 inherit;
+  cursor: pointer;
+  backdrop-filter: blur(12px);
+}
+.wiki-media-btn:hover {
+  background: rgba(0, 0, 0, 0.58);
+}
+.wiki-media-btn input {
+  display: none;
+}
+.wiki-media-btn:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+.wiki-entity__media-error {
+  position: absolute;
+  z-index: 4;
+  right: 20px;
+  top: 58px;
+  max-width: 360px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  background: rgba(145, 28, 28, 0.88);
+  color: #fff;
+  font-size: 11px;
+}
+@media (max-width: 720px) {
+  .wiki-entity__media-actions {
+    top: 58px;
+    left: 20px;
+    right: 20px;
+    justify-content: flex-start;
+  }
+  .wiki-entity__identity {
+    left: 24px;
+    top: 118px;
+  }
+  .wiki-entity__identity ~ .wiki-entity__hero-inner,
+  .wiki-entity__identity--person ~ .wiki-entity__hero-inner {
+    padding: 210px 24px 28px;
+  }
+  .wiki-entity__hero-inner {
+    padding: 150px 24px 28px;
+  }
+}
+.wiki-card--person-hero {
+  position: relative;
+  padding-top: 72px;
+  overflow: hidden;
+}
+.wiki-card__person-hero {
+  position: absolute;
+  inset: 0 0 auto;
+  width: 100%;
+  height: 92px;
+  object-fit: cover;
+  filter: brightness(0.72);
+}
+.wiki-card--person-hero .wiki-card__avatar {
+  position: relative;
+  z-index: 1;
+  border: 3px solid var(--bg-panel);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.18);
 }

--- a/ui/components/Memory/WikiLibrary.tsx
+++ b/ui/components/Memory/WikiLibrary.tsx
@@ -6,8 +6,20 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Markdown } from "../common/Markdown";
 import { gateway } from "../../src/lib/gateway";
 import { isTransientGatewayError, sleep } from "../../utils/gatewayRetry";
-import type { WikiEntityData, WikiHomeData, WikiNode, WikiRail, WikiRelationship, WikiEvidence, WikiRelatedMemory } from "../../types/wiki";
-import { collectWikiNodes, normalizeWikiNode, wikiTypeMeta } from "../../types/wiki";
+import type {
+  WikiEntityData,
+  WikiHomeData,
+  WikiNode,
+  WikiRail,
+  WikiRelationship,
+  WikiEvidence,
+  WikiRelatedMemory,
+} from "../../types/wiki";
+import {
+  collectWikiNodes,
+  normalizeWikiNode,
+  wikiTypeMeta,
+} from "../../types/wiki";
 import {
   countSetupBlockingPlaceholderFiles,
   isBrandFileUnset,
@@ -30,7 +42,10 @@ interface WorkspaceFilePreview {
 const FOCUS_CACHE_KEY = "memory-view-focus";
 
 function fileLabel(name: string): string {
-  return name.replace(/\.(md|txt|yaml|yml|json)$/i, "").replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  return name
+    .replace(/\.(md|txt|yaml|yml|json)$/i, "")
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 interface WikiLibraryProps {
@@ -55,7 +70,7 @@ const IC = `fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap=
 /**
  * Returns an SVG icon for context .md files based on filename keywords.
  * Matches against common file naming patterns to provide appropriate visual representation.
- * 
+ *
  * @param name - The filename to match against (e.g., "IDENTITY.md", "ICP.md", "Playbook.md")
  * @returns SVG markup string with appropriate icon:
  *   - identity/brand → person icon
@@ -77,7 +92,7 @@ function fileGlyphSvg(name: string): string {
 /**
  * Returns an SVG icon for entity types when no cover image is available.
  * Only returns icons for specific entity types that have custom glyphs.
- * 
+ *
  * @param type - The entity type (e.g., "goal", "insight")
  * @returns SVG markup string for supported types, or null if the type should use the default glyph
  *   - goal → target/bullseye icon
@@ -94,7 +109,12 @@ function typeGlyphSvg(type: string): string | null {
 
 /** Types whose image is a brand mark (letterboxed) rather than cover art. */
 function isLogoType(type: string): boolean {
-  return type === "company" || type === "companies" || type === "app" || type === "apps";
+  return (
+    type === "company" ||
+    type === "companies" ||
+    type === "app" ||
+    type === "apps"
+  );
 }
 
 /** Entity props that hold URLs and should render as clickable pills, not raw text. */
@@ -104,85 +124,144 @@ const LINK_PROP_LABELS: Record<string, string> = {
   linkedin: "LinkedIn",
 };
 
-function PosterCard({ node, onClick }: { node: WikiNode; onClick: () => void }) {
+function PosterCard({
+  node,
+  onClick,
+}: {
+  node: WikiNode;
+  onClick: () => void;
+}) {
   const meta = wikiTypeMeta(node.type);
   const props = node.props ?? {};
   const status = props.status ? String(props.status) : null;
   const image = props.image ? String(props.image) : null;
-  const glyphSvg = image ? null : typeGlyphSvg(node.type);
+  const hero = props.hero_image ? String(props.hero_image) : null;
+  const art = hero || image;
+  const glyphSvg = art ? null : typeGlyphSvg(node.type);
   return (
     <article className="wiki-card poster" onClick={onClick}>
       <div className="wiki-card__art">
-        {image ? (
-          // Company marks are logos, not photography — contain them on a neutral
-          // backdrop instead of cropping to fill like a cover image.
+        {art ? (
           <img
-            className={`wiki-card__art-img${isLogoType(node.type) ? " wiki-card__art-img--logo" : ""}`}
-            src={image}
+            className={`wiki-card__art-img${!hero && isLogoType(node.type) ? " wiki-card__art-img--logo" : ""}`}
+            src={art}
             alt={node.label}
             loading="lazy"
           />
         ) : (
-          <div className="wiki-card__gradient"
-            style={{ background: `linear-gradient(135deg, ${meta.color}, color-mix(in srgb, ${meta.color} 70%, #000))` }} />
+          <div
+            className="wiki-card__gradient"
+            style={{
+              background: `linear-gradient(135deg, ${meta.color}, color-mix(in srgb, ${meta.color} 70%, #000))`,
+            }}
+          />
         )}
         <span className="wiki-card__type-chip">{meta.label}</span>
-        {status ? <span className="wiki-card__status"><span className="wiki-card__status-dot" />{status}</span> : null}
+        {status ? (
+          <span className="wiki-card__status">
+            <span className="wiki-card__status-dot" />
+            {status}
+          </span>
+        ) : null}
+        {hero && image ? (
+          <span className="wiki-card__logo">
+            <img src={image} alt="" />
+          </span>
+        ) : null}
         {glyphSvg ? (
-          <span 
-            className="wiki-card__art-icon" 
+          <span
+            className="wiki-card__art-icon"
             dangerouslySetInnerHTML={{ __html: glyphSvg }}
             aria-label={`${node.type} icon`}
             role="img"
           />
-        ) : image ? null : (
+        ) : art ? null : (
           <span className="wiki-card__glyph">{meta.glyph}</span>
         )}
       </div>
       <div className="wiki-card__body">
         <h4 className="wiki-card__title">{node.label}</h4>
-        {node.description ? <p className="wiki-card__preview">{bodyPreview(node.description)}</p> : null}
+        {node.description ? (
+          <p className="wiki-card__preview">{bodyPreview(node.description)}</p>
+        ) : null}
       </div>
     </article>
   );
 }
 
-function PersonCard({ node, onClick }: { node: WikiNode; onClick: () => void }) {
+function PersonCard({
+  node,
+  onClick,
+}: {
+  node: WikiNode;
+  onClick: () => void;
+}) {
   const label = node.label ?? node.id;
-  const initials = label.split(/\s+/).map((s) => s[0]).filter(Boolean).slice(0, 2).join("").toUpperCase();
+  const initials = label
+    .split(/\s+/)
+    .map((s) => s[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
   const props = node.props ?? {};
   const image = props.image ? String(props.image) : null;
   return (
     <article className="wiki-card person" onClick={onClick}>
       <div className="wiki-card__avatar">
-        {image ? <img className="wiki-card__avatar-img" src={image} alt={label} /> : (initials || "?")}
+        {image ? (
+          <img className="wiki-card__avatar-img" src={image} alt={label} />
+        ) : (
+          initials || "?"
+        )}
       </div>
       <div className="wiki-card__name">{label}</div>
-      {props.role ? <div className="wiki-card__role">{String(props.role)}</div> : null}
+      {props.role ? (
+        <div className="wiki-card__role">{String(props.role)}</div>
+      ) : null}
     </article>
   );
 }
 
-function EntityCard({ node, onClick }: { node: WikiNode; onClick: () => void }) {
-  if (node.type === "person") return <PersonCard node={node} onClick={onClick} />;
+function EntityCard({
+  node,
+  onClick,
+}: {
+  node: WikiNode;
+  onClick: () => void;
+}) {
+  if (node.type === "person")
+    return <PersonCard node={node} onClick={onClick} />;
   return <PosterCard node={node} onClick={onClick} />;
 }
 
 /* ── Rail ────────────────────────────────────────── */
 
-
-function ContextFileCard({ file, onOpen }: { file: WorkspaceFilePreview; onOpen: (file: WorkspaceFilePreview) => void }) {
+function ContextFileCard({
+  file,
+  onOpen,
+}: {
+  file: WorkspaceFilePreview;
+  onOpen: (file: WorkspaceFilePreview) => void;
+}) {
   const isOptionalBrand = isOptionalContextFile(file.name);
   const needsSetup =
     !isOptionalBrand && isWorkspaceFilePlaceholder(file.content);
   const brandUnset = isOptionalBrand && isBrandFileUnset(file.content);
-  const chipLabel = needsSetup ? "Setup needed" : brandUnset ? "Optional" : "Context";
+  const chipLabel = needsSetup
+    ? "Setup needed"
+    : brandUnset
+      ? "Optional"
+      : "Context";
   return (
-    <article className={`wiki-card poster wiki-card--context${needsSetup ? " wiki-card--context-setup" : brandUnset ? " wiki-card--context-optional" : ""}`} onClick={() => onOpen(file)}>
+    <article
+      className={`wiki-card poster wiki-card--context${needsSetup ? " wiki-card--context-setup" : brandUnset ? " wiki-card--context-optional" : ""}`}
+      onClick={() => onOpen(file)}
+    >
       <div className="wiki-card__art wiki-card__art--context">
         <div className="wiki-card__gradient wiki-card__gradient--context" />
         <span className="wiki-card__type-chip">{chipLabel}</span>
-        <span 
+        <span
           className="wiki-card__art-icon wiki-card__art-icon--context"
           dangerouslySetInnerHTML={{ __html: fileGlyphSvg(file.name) }}
           aria-label={`${fileLabel(file.name)} icon`}
@@ -207,18 +286,40 @@ function ContextFileCard({ file, onOpen }: { file: WorkspaceFilePreview; onOpen:
   );
 }
 
-function WikiRailSection({ rail, onPick, onAdd }: { rail: WikiRail; onPick: (n: WikiNode) => void; onAdd?: (railTitle: string) => void }) {
+function WikiRailSection({
+  rail,
+  onPick,
+  onAdd,
+}: {
+  rail: WikiRail;
+  onPick: (n: WikiNode) => void;
+  onAdd?: (railTitle: string) => void;
+}) {
   if (rail.items.length === 0) return null;
   return (
     <section className="wiki-rail">
       <div className="wiki-rail__head">
         <h2>{rail.title}</h2>
-        {rail.reason ? <span className="wiki-rail__reason">{rail.reason}</span> : null}
-        {onAdd ? <button type="button" className="wiki-rail__add" onClick={() => onAdd(rail.title)}>+</button> : null}
+        {rail.reason ? (
+          <span className="wiki-rail__reason">{rail.reason}</span>
+        ) : null}
+        {onAdd ? (
+          <button
+            type="button"
+            className="wiki-rail__add"
+            onClick={() => onAdd(rail.title)}
+          >
+            +
+          </button>
+        ) : null}
       </div>
       <div className="wiki-rail__track">
         {rail.items.map((item) => (
-          <EntityCard key={`${item.type}-${item.id}`} node={item} onClick={() => onPick(item)} />
+          <EntityCard
+            key={`${item.type}-${item.id}`}
+            node={item}
+            onClick={() => onPick(item)}
+          />
         ))}
       </div>
     </section>
@@ -227,26 +328,50 @@ function WikiRailSection({ rail, onPick, onAdd }: { rail: WikiRail; onPick: (n: 
 
 /* ── Search Palette ────────────────────────────────── */
 
-function SearchPalette({ open, onClose, onPick }: { open: boolean; onClose: () => void; onPick: (n: WikiNode) => void }) {
+function SearchPalette({
+  open,
+  onClose,
+  onPick,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onPick: (n: WikiNode) => void;
+}) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<WikiNode[]>([]);
   const [loading, setLoading] = useState(false);
   const [selected, setSelected] = useState(0);
 
-  useEffect(() => { if (!open) return; setQuery(""); setResults([]); setSelected(0); }, [open]);
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    setResults([]);
+    setSelected(0);
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
     const trimmed = query.trim();
-    if (!trimmed) { setResults([]); return; }
+    if (!trimmed) {
+      setResults([]);
+      return;
+    }
     const timer = window.setTimeout(async () => {
       setLoading(true);
       try {
-        const response = await gateway.send("memory:wiki-search", { query: trimmed });
-        setResults((response.data as { results?: WikiNode[] } | undefined)?.results ?? []);
+        const response = await gateway.send("memory:wiki-search", {
+          query: trimmed,
+        });
+        setResults(
+          (response.data as { results?: WikiNode[] } | undefined)?.results ??
+            [],
+        );
         setSelected(0);
-      } catch { setResults([]); }
-      finally { setLoading(false); }
+      } catch {
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
     }, 300);
     return () => window.clearTimeout(timer);
   }, [open, query]);
@@ -255,9 +380,16 @@ function SearchPalette({ open, onClose, onPick }: { open: boolean; onClose: () =
     if (!open) return;
     const onKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") onClose();
-      else if (event.key === "ArrowDown") { event.preventDefault(); setSelected((s) => Math.min(s + 1, Math.max(results.length - 1, 0))); }
-      else if (event.key === "ArrowUp") { event.preventDefault(); setSelected((s) => Math.max(s - 1, 0)); }
-      else if (event.key === "Enter" && results[selected]) { onPick(results[selected]); onClose(); }
+      else if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setSelected((s) => Math.min(s + 1, Math.max(results.length - 1, 0)));
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setSelected((s) => Math.max(s - 1, 0));
+      } else if (event.key === "Enter" && results[selected]) {
+        onPick(results[selected]);
+        onClose();
+      }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -266,19 +398,45 @@ function SearchPalette({ open, onClose, onPick }: { open: boolean; onClose: () =
   if (!open) return null;
   return (
     <div className="wiki-palette-scrim" onClick={onClose} role="presentation">
-      <div className="wiki-palette" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
-        <input className="wiki-palette__input" placeholder="Search your knowledge graph…" value={query}
-          onChange={(e) => setQuery(e.target.value)} autoFocus />
+      <div
+        className="wiki-palette"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        <input
+          className="wiki-palette__input"
+          placeholder="Search your knowledge graph…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          autoFocus
+        />
         <div className="wiki-palette__results">
-          {loading ? <div className="wiki-palette__empty">Searching…</div> : null}
-          {!loading && query.trim() && results.length === 0 ? <div className="wiki-palette__empty">No matches found.</div> : null}
+          {loading ? (
+            <div className="wiki-palette__empty">Searching…</div>
+          ) : null}
+          {!loading && query.trim() && results.length === 0 ? (
+            <div className="wiki-palette__empty">No matches found.</div>
+          ) : null}
           {results.map((node, index) => {
             const meta = wikiTypeMeta(node.type);
             return (
-              <button key={`${node.type}-${node.id}`} type="button"
+              <button
+                key={`${node.type}-${node.id}`}
+                type="button"
                 className={`wiki-palette__result${index === selected ? " wiki-palette__result--sel" : ""}`}
-                onMouseEnter={() => setSelected(index)} onClick={() => { onPick(node); onClose(); }}>
-                <span className="wiki-palette__glyph" style={{ color: meta.color }}>{meta.glyph}</span>
+                onMouseEnter={() => setSelected(index)}
+                onClick={() => {
+                  onPick(node);
+                  onClose();
+                }}
+              >
+                <span
+                  className="wiki-palette__glyph"
+                  style={{ color: meta.color }}
+                >
+                  {meta.glyph}
+                </span>
                 <span className="wiki-palette__label">{node.label}</span>
                 <span className="wiki-palette__meta">{meta.label}</span>
               </button>
@@ -292,11 +450,18 @@ function SearchPalette({ open, onClose, onPick }: { open: boolean; onClose: () =
 
 /* ── Wiki Section Renderer ────────────────────────────── */
 
-
 /* ── Create Entity / Add Type Dialog ──────────────── */
 
-function CreateDialog({ open, onClose, onCreated, existingTypes }: {
-  open: boolean; onClose: () => void; onCreated: () => void; existingTypes: string[];
+function CreateDialog({
+  open,
+  onClose,
+  onCreated,
+  existingTypes,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+  existingTypes: string[];
 }) {
   const [mode, setMode] = useState<"entity" | "type">("entity");
   const [typeName, setTypeName] = useState("");
@@ -329,7 +494,11 @@ function CreateDialog({ open, onClose, onCreated, existingTypes }: {
       }
       onCreated();
       onClose();
-      setTypeName(""); setName(""); setDescription(""); setIcon("📌"); setSelectedType("");
+      setTypeName("");
+      setName("");
+      setDescription("");
+      setIcon("📌");
+      setSelectedType("");
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : "Failed to save");
     } finally {
@@ -339,57 +508,127 @@ function CreateDialog({ open, onClose, onCreated, existingTypes }: {
 
   return (
     <div className="wiki-palette-backdrop" onClick={onClose}>
-      <div className="wiki-create-dialog" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
+      <div
+        className="wiki-create-dialog"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
         <div className="wiki-create-dialog__tabs">
-          <button type="button" className={`wiki-create-dialog__tab ${mode === "entity" ? "active" : ""}`}
-            onClick={() => setMode("entity")}>+ Entity</button>
-          <button type="button" className={`wiki-create-dialog__tab ${mode === "type" ? "active" : ""}`}
-            onClick={() => setMode("type")}>+ Type</button>
+          <button
+            type="button"
+            className={`wiki-create-dialog__tab ${mode === "entity" ? "active" : ""}`}
+            onClick={() => setMode("entity")}
+          >
+            + Entity
+          </button>
+          <button
+            type="button"
+            className={`wiki-create-dialog__tab ${mode === "type" ? "active" : ""}`}
+            onClick={() => setMode("type")}
+          >
+            + Type
+          </button>
         </div>
 
         {mode === "entity" ? (
           <div className="wiki-create-dialog__form">
-            <label>Type
-              <select value={selectedType} onChange={(e) => setSelectedType(e.target.value)}>
+            <label>
+              Type
+              <select
+                value={selectedType}
+                onChange={(e) => setSelectedType(e.target.value)}
+              >
                 <option value="">Select type...</option>
                 {existingTypes.map((t) => (
-                  <option key={t} value={t}>{t}</option>
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
                 ))}
               </select>
             </label>
-            <label>Name
-              <input type="text" value={name} onChange={(e) => setName(e.target.value)}
-                placeholder="e.g. Newton Howard" autoFocus />
+            <label>
+              Name
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Newton Howard"
+                autoFocus
+              />
             </label>
-            <label>Description (optional)
-              <textarea value={description} onChange={(e) => setDescription(e.target.value)}
-                placeholder="Brief description..." rows={3} />
+            <label>
+              Description (optional)
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Brief description..."
+                rows={3}
+              />
             </label>
           </div>
         ) : (
           <div className="wiki-create-dialog__form">
-            <label>Type name
-              <input type="text" value={typeName} onChange={(e) => setTypeName(e.target.value)}
-                placeholder="e.g. investors, research_papers" autoFocus />
+            <label>
+              Type name
+              <input
+                type="text"
+                value={typeName}
+                onChange={(e) => setTypeName(e.target.value)}
+                placeholder="e.g. investors, research_papers"
+                autoFocus
+              />
             </label>
-            <label>Icon
-              <input type="text" value={icon} onChange={(e) => setIcon(e.target.value)}
-                placeholder="📌" style={{ width: 60 }} />
+            <label>
+              Icon
+              <input
+                type="text"
+                value={icon}
+                onChange={(e) => setIcon(e.target.value)}
+                placeholder="📌"
+                style={{ width: 60 }}
+              />
             </label>
-            <label>Description
-              <input type="text" value={description} onChange={(e) => setDescription(e.target.value)}
-                placeholder="What this type represents..." />
+            <label>
+              Description
+              <input
+                type="text"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What this type represents..."
+              />
             </label>
           </div>
         )}
 
-        {saveError ? <p className="wiki-create-dialog__error">{saveError}</p> : null}
+        {saveError ? (
+          <p className="wiki-create-dialog__error">{saveError}</p>
+        ) : null}
 
         <div className="wiki-create-dialog__actions">
-          <button type="button" className="wiki-btn wiki-btn--secondary" onClick={onClose}>Cancel</button>
-          <button type="button" className="wiki-btn wiki-btn--primary" onClick={handleSubmit}
-            disabled={saving || (mode === "entity" ? !name.trim() || !selectedType : !typeName.trim())}>
-            {saving ? "Creating..." : mode === "entity" ? "Create Entity" : "Add Type"}
+          <button
+            type="button"
+            className="wiki-btn wiki-btn--secondary"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="wiki-btn wiki-btn--primary"
+            onClick={handleSubmit}
+            disabled={
+              saving ||
+              (mode === "entity"
+                ? !name.trim() || !selectedType
+                : !typeName.trim())
+            }
+          >
+            {saving
+              ? "Creating..."
+              : mode === "entity"
+                ? "Create Entity"
+                : "Add Type"}
           </button>
         </div>
       </div>
@@ -397,28 +636,53 @@ function CreateDialog({ open, onClose, onCreated, existingTypes }: {
   );
 }
 
-const SECTION_ORDER = ["Context & Background", "Key Details", "Key Interactions", "Decisions & Insights", "Open Items", "Changelog"];
+const SECTION_ORDER = [
+  "Context & Background",
+  "Key Details",
+  "Key Interactions",
+  "Decisions & Insights",
+  "Open Items",
+  "Changelog",
+];
 const SECTION_ICONS: Record<string, string> = {
-  "Context & Background": "◉", "Key Details": "◈", "Key Interactions": "▸",
-  "Decisions & Insights": "◆", "Open Items": "☐", "Changelog": "▪",
+  "Context & Background": "◉",
+  "Key Details": "◈",
+  "Key Interactions": "▸",
+  "Decisions & Insights": "◆",
+  "Open Items": "☐",
+  Changelog: "▪",
 };
 
 function displaySectionsFor(node: WikiNode): Record<string, string> {
   const sections = { ...(node.sections ?? {}) };
-  if (!sections["Context & Background"] && node.description) sections["Context & Background"] = node.description;
+  if (!sections["Context & Background"] && node.description)
+    sections["Context & Background"] = node.description;
   if (!sections["Key Details"]) {
     const facts = Object.entries(node.props ?? {})
-      .filter(([k, v]) => v != null && String(v).trim() !== "" && !["description", "description_short"].includes(k))
+      .filter(
+        ([k, v]) =>
+          v != null &&
+          String(v).trim() !== "" &&
+          !["description", "description_short"].includes(k),
+      )
       .slice(0, 12)
       .map(([k, v]) => `- ${k.replace(/_/g, " ")}: ${String(v)}`);
-    sections["Key Details"] = facts.length ? facts.join("\n") : `- Type: ${node.type}\n- ID: ${node.id}`;
+    sections["Key Details"] = facts.length
+      ? facts.join("\n")
+      : `- Type: ${node.type}\n- ID: ${node.id}`;
   }
   if (!sections["Key Interactions"] && node.evidence?.length) {
-    sections["Key Interactions"] = node.evidence.map((e) => `- ${e.date || "Undated"} — ${e.summary || e.source}`).join("\n");
+    sections["Key Interactions"] = node.evidence
+      .map((e) => `- ${e.date || "Undated"} — ${e.summary || e.source}`)
+      .join("\n");
   }
-  if (!sections["Decisions & Insights"]) sections["Decisions & Insights"] = "- No durable decisions or insights have been captured yet.";
-  if (!sections["Open Items"]) sections["Open Items"] = "No open items captured yet.";
-  if (!sections["Changelog"]) sections["Changelog"] = "- No changelog entries captured yet.";
+  if (!sections["Decisions & Insights"])
+    sections["Decisions & Insights"] =
+      "- No durable decisions or insights have been captured yet.";
+  if (!sections["Open Items"])
+    sections["Open Items"] = "No open items captured yet.";
+  if (!sections["Changelog"])
+    sections["Changelog"] = "- No changelog entries captured yet.";
   return sections;
 }
 
@@ -429,8 +693,11 @@ function WikiSection({ title, content }: { title: string; content: string }) {
 
   return (
     <div className="wiki-section">
-      <button type="button" className={`wiki-section__header ${expanded ? "expanded" : ""}`}
-        onClick={() => setExpanded(!expanded)}>
+      <button
+        type="button"
+        className={`wiki-section__header ${expanded ? "expanded" : ""}`}
+        onClick={() => setExpanded(!expanded)}
+      >
         <span className="wiki-section__icon">{icon}</span>
         <span className="wiki-section__title">{title}</span>
         <span className="wiki-section__count">{lines.length} items</span>
@@ -442,13 +709,18 @@ function WikiSection({ title, content }: { title: string; content: string }) {
             const bullet = line.match(/^[-*]\s*\[([x ])\]\s*(.+)/i);
             if (bullet) {
               return (
-                <div key={i} className={`wiki-section__check ${bullet[1] !== " " ? "done" : ""}`}>
+                <div
+                  key={i}
+                  className={`wiki-section__check ${bullet[1] !== " " ? "done" : ""}`}
+                >
                   <span>{bullet[1] !== " " ? "■" : "☐"}</span>
                   <span>{bullet[2]}</span>
                 </div>
               );
             }
-            const dated = line.match(/^[-*]\s*\*?\*?(\d{4}-\d{2}-\d{2})\*?\*?[:\s]+(.+)/);
+            const dated = line.match(
+              /^[-*]\s*\*?\*?(\d{4}-\d{2}-\d{2})\*?\*?[:\s]+(.+)/,
+            );
             if (dated) {
               return (
                 <div key={i} className="wiki-section__dated">
@@ -457,7 +729,11 @@ function WikiSection({ title, content }: { title: string; content: string }) {
                 </div>
               );
             }
-            return <p key={i} className="wiki-section__text">{line.replace(/^[-*]\s*/, "")}</p>;
+            return (
+              <p key={i} className="wiki-section__text">
+                {line.replace(/^[-*]\s*/, "")}
+              </p>
+            );
           })}
         </div>
       ) : null}
@@ -467,7 +743,11 @@ function WikiSection({ title, content }: { title: string; content: string }) {
 
 /* ── Relationships Panel ────────────────────────────── */
 
-function RelationshipsPanel({ relationships, onPick, allNodes }: {
+function RelationshipsPanel({
+  relationships,
+  onPick,
+  allNodes,
+}: {
   relationships: WikiRelationship[];
   onPick: (n: WikiNode) => void;
   allNodes: WikiNode[];
@@ -482,26 +762,42 @@ function RelationshipsPanel({ relationships, onPick, allNodes }: {
 
   return (
     <div className="wiki-relationships">
-      <h3 className="wiki-relationships__title">Relationships ({relationships.length})</h3>
+      <h3 className="wiki-relationships__title">
+        Relationships ({relationships.length})
+      </h3>
       {[...grouped.entries()].map(([type, rels]) => (
         <div key={type} className="wiki-rel-group">
           <div className="wiki-rel-group__type">{type}</div>
           {rels.map((r, i) => {
             const targetId = r.target;
             const targetNode = allNodes.find((n) => n.id === targetId);
-            const targetMeta = targetNode ? wikiTypeMeta(targetNode.type) : null;
+            const targetMeta = targetNode
+              ? wikiTypeMeta(targetNode.type)
+              : null;
             return (
-              <div key={i} className="wiki-rel-item"
+              <div
+                key={i}
+                className="wiki-rel-item"
                 onClick={() => targetNode && onPick(targetNode)}
-                style={{ cursor: targetNode ? "pointer" : "default" }}>
-                <span className="wiki-rel-item__glyph" style={{ color: targetMeta?.color ?? "#666" }}>
+                style={{ cursor: targetNode ? "pointer" : "default" }}
+              >
+                <span
+                  className="wiki-rel-item__glyph"
+                  style={{ color: targetMeta?.color ?? "#666" }}
+                >
                   {targetMeta?.glyph ?? "◇"}
                 </span>
                 <div className="wiki-rel-item__info">
-                  <span className="wiki-rel-item__name">{targetNode?.label ?? targetId}</span>
-                  {r.context ? <span className="wiki-rel-item__context">{r.context}</span> : null}
+                  <span className="wiki-rel-item__name">
+                    {targetNode?.label ?? targetId}
+                  </span>
+                  {r.context ? (
+                    <span className="wiki-rel-item__context">{r.context}</span>
+                  ) : null}
                 </div>
-                {r.since ? <span className="wiki-rel-item__since">{r.since}</span> : null}
+                {r.since ? (
+                  <span className="wiki-rel-item__since">{r.since}</span>
+                ) : null}
               </div>
             );
           })}
@@ -517,11 +813,16 @@ function EvidenceTrail({ evidence }: { evidence: WikiEvidence[] }) {
   if (!evidence?.length) return null;
   return (
     <div className="wiki-evidence">
-      <h3 className="wiki-evidence__title">Evidence Trail ({evidence.length})</h3>
+      <h3 className="wiki-evidence__title">
+        Evidence Trail ({evidence.length})
+      </h3>
       {evidence.map((e, i) => (
         <div key={i} className="wiki-evidence__item">
           <span className="wiki-evidence__date">{e.date}</span>
-          <span className="wiki-evidence__source">{e.source}{e.chat ? ` · ${e.chat}` : ""}</span>
+          <span className="wiki-evidence__source">
+            {e.source}
+            {e.chat ? ` · ${e.chat}` : ""}
+          </span>
           <p className="wiki-evidence__summary">{e.summary}</p>
         </div>
       ))}
@@ -571,8 +872,63 @@ function ContextFilePage({
     <div className="wiki-library">
       <div className="wiki-entity wiki-entity--context-file">
         <div className="wiki-entity__hero wiki-entity__hero--context">
-          <button type="button" className="wiki-entity__back" onClick={onBack}>← Library</button>
+          <button type="button" className="wiki-entity__back" onClick={onBack}>
+            ← Library
+          </button>
           <div className="wiki-entity__hero-bg wiki-entity__hero-bg--context" />
+          {props.image ? (
+            <div
+              className={`wiki-entity__identity${node.type === "person" ? " wiki-entity__identity--person" : ""}`}
+            >
+              <img
+                src={String(props.image)}
+                alt={`${node.label} ${node.type === "company" ? "logo" : "photo"}`}
+              />
+            </div>
+          ) : null}
+          {canEditMedia ? (
+            <div className="wiki-entity__media-actions">
+              <label className="wiki-media-btn">
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
+                  disabled={mediaBusy}
+                  onChange={(e) => {
+                    const f = e.target.files?.[0];
+                    if (f) void updateMedia("image", f);
+                    e.currentTarget.value = "";
+                  }}
+                />
+                {props.image ? "Replace logo / photo" : "Add logo / photo"}
+              </label>
+              <label className="wiki-media-btn">
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp,image/gif"
+                  disabled={mediaBusy}
+                  onChange={(e) => {
+                    const f = e.target.files?.[0];
+                    if (f) void updateMedia("hero_image", f);
+                    e.currentTarget.value = "";
+                  }}
+                />
+                {props.hero_image ? "Replace hero" : "Add hero"}
+              </label>
+              {props.hero_image ? (
+                <button
+                  type="button"
+                  className="wiki-media-btn"
+                  disabled={mediaBusy}
+                  onClick={() => void updateMedia("hero_image")}
+                >
+                  Remove hero
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+          {mediaError ? (
+            <div className="wiki-entity__media-error">{mediaError}</div>
+          ) : null}
           <div className="wiki-entity__hero-inner">
             <div className="wiki-entity__eyebrow">
               <span>Context</span>
@@ -581,10 +937,18 @@ function ContextFilePage({
             </div>
             <h1>{fileLabel(file.name)}</h1>
             <div className="wiki-entity__meta-row">
-              <span className="wiki-entity__pill">{Math.max(1, Math.round(file.size / 1024))} KB</span>
-              {file.truncated ? <span className="wiki-entity__pill">Preview truncated</span> : null}
+              <span className="wiki-entity__pill">
+                {Math.max(1, Math.round(file.size / 1024))} KB
+              </span>
+              {file.truncated ? (
+                <span className="wiki-entity__pill">Preview truncated</span>
+              ) : null}
               {!loading && !editing ? (
-                <button type="button" className="wiki-btn wiki-btn--secondary" onClick={() => setEditing(true)}>
+                <button
+                  type="button"
+                  className="wiki-btn wiki-btn--secondary"
+                  onClick={() => setEditing(true)}
+                >
                   Edit
                 </button>
               ) : null}
@@ -592,51 +956,77 @@ function ContextFilePage({
           </div>
         </div>
 
-        {error ? <div className="wiki-entity__error" role="alert">{error}</div> : null}
+        {error ? (
+          <div className="wiki-entity__error" role="alert">
+            {error}
+          </div>
+        ) : null}
 
         <div className="wiki-entity__content wiki-entity__content--context-file">
           <div className="wiki-entity__main">
-          {loading ? (
-            <div className="wiki-loading"><div className="wiki-loading__shimmer wiki-loading__shimmer--wide" /></div>
-          ) : editing ? (
-            <>
-              <p className="wiki-context-editor__hint">
-                Edit markdown directly. Changes are saved to your workspace and used by Papr on future sessions.
-              </p>
-              {saveError ? <p className="wiki-context-editor__error" role="alert">{saveError}</p> : null}
-              <div className="wiki-context-editor__actions">
-                <button type="button" className="wiki-btn wiki-btn--primary" onClick={() => { void handleSave(); }} disabled={saving}>
-                  {saving ? "Saving…" : "Save"}
-                </button>
+            {loading ? (
+              <div className="wiki-loading">
+                <div className="wiki-loading__shimmer wiki-loading__shimmer--wide" />
+              </div>
+            ) : editing ? (
+              <>
+                <p className="wiki-context-editor__hint">
+                  Edit markdown directly. Changes are saved to your workspace
+                  and used by Papr on future sessions.
+                </p>
+                {saveError ? (
+                  <p className="wiki-context-editor__error" role="alert">
+                    {saveError}
+                  </p>
+                ) : null}
+                <div className="wiki-context-editor__actions">
+                  <button
+                    type="button"
+                    className="wiki-btn wiki-btn--primary"
+                    onClick={() => {
+                      void handleSave();
+                    }}
+                    disabled={saving}
+                  >
+                    {saving ? "Saving…" : "Save"}
+                  </button>
+                  <button
+                    type="button"
+                    className="wiki-btn wiki-btn--secondary"
+                    onClick={() => {
+                      setDraft(file.content);
+                      setEditing(false);
+                      setSaveError(undefined);
+                    }}
+                    disabled={saving}
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <textarea
+                  className="wiki-context-editor"
+                  value={draft}
+                  onChange={(event) => setDraft(event.target.value)}
+                  spellCheck={false}
+                  aria-label={`Edit ${fileLabel(file.name)}`}
+                />
+              </>
+            ) : file.content.trim() ? (
+              <div className="wiki-entity__markdown">
+                <Markdown>{file.content}</Markdown>
+              </div>
+            ) : (
+              <div className="wiki-empty-state">
+                <p>This file is empty.</p>
                 <button
                   type="button"
-                  className="wiki-btn wiki-btn--secondary"
-                  onClick={() => { setDraft(file.content); setEditing(false); setSaveError(undefined); }}
-                  disabled={saving}
+                  className="wiki-btn wiki-btn--primary"
+                  onClick={() => setEditing(true)}
                 >
-                  Cancel
+                  Add content
                 </button>
               </div>
-              <textarea
-                className="wiki-context-editor"
-                value={draft}
-                onChange={(event) => setDraft(event.target.value)}
-                spellCheck={false}
-                aria-label={`Edit ${fileLabel(file.name)}`}
-              />
-            </>
-          ) : file.content.trim() ? (
-            <div className="wiki-entity__markdown">
-              <Markdown>{file.content}</Markdown>
-            </div>
-          ) : (
-            <div className="wiki-empty-state">
-              <p>This file is empty.</p>
-              <button type="button" className="wiki-btn wiki-btn--primary" onClick={() => setEditing(true)}>
-                Add content
-              </button>
-            </div>
-          )}
+            )}
           </div>
         </div>
       </div>
@@ -646,11 +1036,26 @@ function ContextFilePage({
 
 /* ── Home ────────────────────────────────────────── */
 
-function WikiHome({ data, loading, loadError, onRetry, onPick, onSearch, onAdd, onOpenContextFile, contextFiles, onboardingPending }: {
-  data: WikiHomeData | null; loading: boolean; loadError?: string | null;
+function WikiHome({
+  data,
+  loading,
+  loadError,
+  onRetry,
+  onPick,
+  onSearch,
+  onAdd,
+  onOpenContextFile,
+  contextFiles,
+  onboardingPending,
+}: {
+  data: WikiHomeData | null;
+  loading: boolean;
+  loadError?: string | null;
   onRetry?: () => void;
   onPick: (n: WikiNode) => void;
-  onSearch: () => void; onAdd?: () => void; onOpenContextFile: (file: WorkspaceFilePreview) => void;
+  onSearch: () => void;
+  onAdd?: () => void;
+  onOpenContextFile: (file: WorkspaceFilePreview) => void;
   contextFiles: WorkspaceFilePreview[];
   onboardingPending: boolean;
 }) {
@@ -659,7 +1064,10 @@ function WikiHome({ data, loading, loadError, onRetry, onPick, onSearch, onAdd, 
   const placeholderFileCount = countSetupBlockingPlaceholderFiles(contextFiles);
   const identityFile = contextFiles.find((file) => file.name === "IDENTITY.md");
   const wikiHasContent = (data?.rails.length ?? 0) > 0 || !!featured;
-  const setupPending = isEffectiveOnboardingPending(onboardingPending, contextFiles);
+  const setupPending = isEffectiveOnboardingPending(
+    onboardingPending,
+    contextFiles,
+  );
   const showSetupPanel = shouldShowMemorySetupPanel({
     onboardingPending,
     contextFiles,
@@ -670,9 +1078,16 @@ function WikiHome({ data, loading, loadError, onRetry, onPick, onSearch, onAdd, 
   if (loading && !data) {
     return (
       <div className="wiki-library wiki-library--setup-only">
-        <section className="wiki-setup-panel wiki-setup-panel--connecting" aria-busy="true">
-          <div className="wiki-setup-panel__icon" aria-hidden>↻</div>
-          <h2 className="wiki-setup-panel__title">Loading your knowledge graph…</h2>
+        <section
+          className="wiki-setup-panel wiki-setup-panel--connecting"
+          aria-busy="true"
+        >
+          <div className="wiki-setup-panel__icon" aria-hidden>
+            ↻
+          </div>
+          <h2 className="wiki-setup-panel__title">
+            Loading your knowledge graph…
+          </h2>
           <p className="wiki-setup-panel__body">
             Fetching goals, projects, people, and memories from Papr.
           </p>
@@ -690,13 +1105,20 @@ function WikiHome({ data, loading, loadError, onRetry, onPick, onSearch, onAdd, 
     return (
       <div className="wiki-library wiki-library--setup-only">
         <section className="wiki-setup-panel wiki-setup-panel--connecting">
-          <div className="wiki-setup-panel__icon" aria-hidden>↻</div>
+          <div className="wiki-setup-panel__icon" aria-hidden>
+            ↻
+          </div>
           <h2 className="wiki-setup-panel__title">Connecting to Papr…</h2>
           <p className="wiki-setup-panel__body">
-            Your knowledge graph is still loading. This usually resolves in a few seconds once the gateway connects.
+            Your knowledge graph is still loading. This usually resolves in a
+            few seconds once the gateway connects.
           </p>
           <div className="wiki-setup-panel__actions">
-            <button type="button" className="wiki-btn wiki-btn--primary" onClick={onRetry}>
+            <button
+              type="button"
+              className="wiki-btn wiki-btn--primary"
+              onClick={onRetry}
+            >
               Try again
             </button>
           </div>
@@ -710,17 +1132,25 @@ function WikiHome({ data, loading, loadError, onRetry, onPick, onSearch, onAdd, 
     return (
       <div className="wiki-library wiki-library--setup-only">
         <MemorySetupPanel variant="sign-in" />
-        {data?.error ? <p className="wiki-setup-panel__error">{data.error}</p> : null}
+        {data?.error ? (
+          <p className="wiki-setup-panel__error">{data.error}</p>
+        ) : null}
       </div>
     );
   }
 
   return (
-    <div className={`wiki-library${featured && meta ? " wiki-library--has-hero" : ""}`}>
+    <div
+      className={`wiki-library${featured && meta ? " wiki-library--has-hero" : ""}`}
+    >
       {featured && meta ? (
         <div className="wiki-hero">
-          <div className="wiki-hero__bg"
-            style={{ background: `var(--g-${featured.type}, linear-gradient(135deg, ${meta.color}, color-mix(in srgb, ${meta.color} 60%, #111))` }} />
+          <div
+            className="wiki-hero__bg"
+            style={{
+              background: `var(--g-${featured.type}, linear-gradient(135deg, ${meta.color}, color-mix(in srgb, ${meta.color} 60%, #111))`,
+            }}
+          />
           <div className="wiki-hero__pattern" />
           <div className="wiki-hero__inner">
             <div className="wiki-hero__eyebrow">
@@ -728,9 +1158,19 @@ function WikiHome({ data, loading, loadError, onRetry, onPick, onSearch, onAdd, 
               <span>{meta.label}</span>
             </div>
             <h1>{featured.label}</h1>
-            {featured.description ? <p className="wiki-hero__tag">{bodyPreview(featured.description, 200)}</p> : null}
+            {featured.description ? (
+              <p className="wiki-hero__tag">
+                {bodyPreview(featured.description, 200)}
+              </p>
+            ) : null}
             <div className="wiki-hero__actions">
-              <button type="button" className="wiki-btn wiki-btn--primary" onClick={() => onPick(featured)}>Open →</button>
+              <button
+                type="button"
+                className="wiki-btn wiki-btn--primary"
+                onClick={() => onPick(featured)}
+              >
+                Open →
+              </button>
             </div>
           </div>
         </div>
@@ -742,9 +1182,7 @@ function WikiHome({ data, loading, loadError, onRetry, onPick, onSearch, onAdd, 
           onboardingPending={setupPending}
           placeholderFileCount={placeholderFileCount}
           onEditIdentity={
-            identityFile
-              ? () => onOpenContextFile(identityFile)
-              : undefined
+            identityFile ? () => onOpenContextFile(identityFile) : undefined
           }
         />
       ) : null}
@@ -769,7 +1207,11 @@ function WikiHome({ data, loading, loadError, onRetry, onPick, onSearch, onAdd, 
           </div>
           <div className="wiki-rail__track">
             {contextFiles.map((file) => (
-              <ContextFileCard key={file.name} file={file} onOpen={onOpenContextFile} />
+              <ContextFileCard
+                key={file.name}
+                file={file}
+                onOpen={onOpenContextFile}
+              />
             ))}
           </div>
         </section>
@@ -781,24 +1223,27 @@ function WikiHome({ data, loading, loadError, onRetry, onPick, onSearch, onAdd, 
 
       {wikiEmpty ? (
         showSetupPanel ? null : (
-          <MemorySetupPanel variant="wiki-empty" onboardingPending={setupPending} />
+          <MemorySetupPanel
+            variant="wiki-empty"
+            onboardingPending={setupPending}
+          />
         )
       ) : data.error ? (
         <div className="wiki-nudge">
           <p>{data.error}</p>
         </div>
       ) : (
-        <div className="wiki-rails">{data.rails.map((rail) => (
-          <WikiRailSection key={rail.title} rail={rail} onPick={onPick} />
-        ))}</div>
+        <div className="wiki-rails">
+          {data.rails.map((rail) => (
+            <WikiRailSection key={rail.title} rail={rail} onPick={onPick} />
+          ))}
+        </div>
       )}
-
     </div>
   );
 }
 
 /* ── Entity Detail Page ────────────────────────────── */
-
 
 function RelatedMemoriesPanel({ memories }: { memories: WikiRelatedMemory[] }) {
   if (!memories || memories.length === 0) return null;
@@ -809,8 +1254,12 @@ function RelatedMemoriesPanel({ memories }: { memories: WikiRelatedMemory[] }) {
         {memories.map((m) => (
           <div key={m.id} className="wiki-related-memory">
             <div className="wiki-related-memory__header">
-              <span className="wiki-related-memory__date">{m.createdAt ? new Date(m.createdAt).toLocaleDateString() : ''}</span>
-              <span className="wiki-related-memory__category">{m.category || 'memory'}</span>
+              <span className="wiki-related-memory__date">
+                {m.createdAt ? new Date(m.createdAt).toLocaleDateString() : ""}
+              </span>
+              <span className="wiki-related-memory__category">
+                {m.category || "memory"}
+              </span>
             </div>
             <p className="wiki-related-memory__content">{m.content}</p>
           </div>
@@ -820,21 +1269,93 @@ function RelatedMemoriesPanel({ memories }: { memories: WikiRelatedMemory[] }) {
   );
 }
 
-function WikiEntityPage({ node, rails, relatedMemories, allNodes, loading, error, onBack, onPick }: {
-  node: WikiNode | null; rails: WikiRail[]; relatedMemories: WikiRelatedMemory[]; allNodes: WikiNode[];
-  loading: boolean; error?: string; onBack: () => void; onPick: (n: WikiNode) => void;
+function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("Could not read image"));
+    reader.readAsDataURL(file);
+  });
+}
+
+function WikiEntityPage({
+  node,
+  rails,
+  relatedMemories,
+  allNodes,
+  loading,
+  error,
+  onBack,
+  onPick,
+  onMediaUpdated,
+}: {
+  node: WikiNode | null;
+  rails: WikiRail[];
+  relatedMemories: WikiRelatedMemory[];
+  allNodes: WikiNode[];
+  loading: boolean;
+  error?: string;
+  onBack: () => void;
+  onPick: (n: WikiNode) => void;
+  onMediaUpdated: (n: WikiNode) => void;
 }) {
   const meta = node ? wikiTypeMeta(node.type) : null;
 
-  if (loading && !node) return <div className="wiki-loading"><div className="wiki-loading__shimmer" /></div>;
+  if (loading && !node)
+    return (
+      <div className="wiki-loading">
+        <div className="wiki-loading__shimmer" />
+      </div>
+    );
   if (!node || !meta) {
-    return (<div className="wiki-empty-state"><p>{error ?? "Entity not found."}</p>
-      <button type="button" className="wiki-btn wiki-btn--secondary" onClick={onBack}>← Back to library</button></div>);
+    return (
+      <div className="wiki-empty-state">
+        <p>{error ?? "Entity not found."}</p>
+        <button
+          type="button"
+          className="wiki-btn wiki-btn--secondary"
+          onClick={onBack}
+        >
+          ← Back to library
+        </button>
+      </div>
+    );
   }
 
   const relationships = node.relationships ?? [];
   const evidence = node.evidence ?? [];
   const props = node.props ?? {};
+  const canEditMedia = node.type === "company" || node.type === "person";
+  const [mediaBusy, setMediaBusy] = useState(false);
+  const [mediaError, setMediaError] = useState<string | null>(null);
+  const updateMedia = async (kind: "image" | "hero_image", file?: File) => {
+    setMediaBusy(true);
+    setMediaError(null);
+    try {
+      const dataUrl = file ? await fileToDataUrl(file) : null;
+      const response = await gateway.send(
+        "memory:wiki-update-media",
+        { type: node.type, id: node.id, kind, dataUrl },
+        { timeoutMs: 45_000 },
+      );
+      if (!response.success)
+        throw new Error(response.error ?? "Could not update image");
+      const fresh = await gateway.send(
+        "memory:wiki-entity",
+        { type: node.type, id: node.id, label: node.label },
+        { timeoutMs: 30_000 },
+      );
+      const updated = (fresh.data as WikiEntityData | undefined)?.node;
+      if (updated) onMediaUpdated(normalizeWikiNode(updated));
+    } catch (err) {
+      setMediaError(
+        err instanceof Error ? err.message : "Could not update image",
+      );
+    } finally {
+      setMediaBusy(false);
+    }
+  };
 
   return (
     <div className="wiki-library">
@@ -846,22 +1367,86 @@ function WikiEntityPage({ node, rails, relatedMemories, allNodes, loading, error
         ) : null}
         {/* Hero */}
         <div className="wiki-entity__hero">
-          <button type="button" className="wiki-entity__back" onClick={onBack}>← Library</button>
-          {props.image ? (
-            <img className="wiki-entity__hero-img" src={String(props.image)} alt={node.label} />
+          <button type="button" className="wiki-entity__back" onClick={onBack}>
+            ← Library
+          </button>
+          {props.hero_image ? (
+            <img
+              className="wiki-entity__hero-img"
+              src={String(props.hero_image)}
+              alt=""
+            />
           ) : (
-            <div className="wiki-entity__hero-bg"
-              style={{ background: `linear-gradient(135deg, ${meta.color}, color-mix(in srgb, ${meta.color} 55%, #111))` }} />
+            <div
+              className="wiki-entity__hero-bg"
+              style={{
+                background: `linear-gradient(135deg, ${meta.color}, color-mix(in srgb, ${meta.color} 55%, #111))`,
+              }}
+            />
           )}
+          {props.image ? (
+            <div
+              className={`wiki-entity__identity${node.type === "person" ? " wiki-entity__identity--person" : ""}`}
+            >
+              <img
+                src={String(props.image)}
+                alt={`${node.label} ${node.type === "company" ? "logo" : "photo"}`}
+              />
+            </div>
+          ) : null}
+          {canEditMedia ? (
+            <div className="wiki-entity__media-actions">
+              <label className="wiki-media-btn">
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
+                  disabled={mediaBusy}
+                  onChange={(e) => {
+                    const f = e.target.files?.[0];
+                    if (f) void updateMedia("image", f);
+                    e.currentTarget.value = "";
+                  }}
+                />
+                {props.image ? "Replace logo / photo" : "Add logo / photo"}
+              </label>
+              <label className="wiki-media-btn">
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp,image/gif"
+                  disabled={mediaBusy}
+                  onChange={(e) => {
+                    const f = e.target.files?.[0];
+                    if (f) void updateMedia("hero_image", f);
+                    e.currentTarget.value = "";
+                  }}
+                />
+                {props.hero_image ? "Replace hero" : "Add hero"}
+              </label>
+              {props.hero_image ? (
+                <button
+                  type="button"
+                  className="wiki-media-btn"
+                  disabled={mediaBusy}
+                  onClick={() => void updateMedia("hero_image")}
+                >
+                  Remove hero
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+          {mediaError ? (
+            <div className="wiki-entity__media-error">{mediaError}</div>
+          ) : null}
           <div className="wiki-entity__hero-inner">
             <div className="wiki-entity__eyebrow">
-              <span>{meta.label}</span><span>·</span>
+              <span>{meta.label}</span>
+              <span>·</span>
               <span className="wiki-entity__id">{node.id}</span>
             </div>
             <h1>{node.label}</h1>
             <div className="wiki-entity__meta-row">
               {Object.entries(props)
-                .filter(([key]) => key !== "image")
+                .filter(([key]) => key !== "image" && key !== "hero_image")
                 .map(([key, value]) => {
                   const text = String(value);
                   // website / linkedin are URLs — render them clickable instead of
@@ -875,12 +1460,15 @@ function WikiEntityPage({ node, rails, relatedMemories, allNodes, loading, error
                         target="_blank"
                         rel="noreferrer noopener"
                       >
-                        {key === "linkedin" ? "in" : "↗"} {LINK_PROP_LABELS[key] ?? key}
+                        {key === "linkedin" ? "in" : "↗"}{" "}
+                        {LINK_PROP_LABELS[key] ?? key}
                       </a>
                     );
                   }
                   return (
-                    <span key={key} className="wiki-entity__pill">{key}: {text}</span>
+                    <span key={key} className="wiki-entity__pill">
+                      {key}: {text}
+                    </span>
                   );
                 })}
             </div>
@@ -902,13 +1490,19 @@ function WikiEntityPage({ node, rails, relatedMemories, allNodes, loading, error
                 <Markdown>{String(node.markdownBody)}</Markdown>
               </div>
             ) : node.description ? (
-              <div className="wiki-entity__overview"><p>{node.description}</p></div>
+              <div className="wiki-entity__overview">
+                <p>{node.description}</p>
+              </div>
             ) : null}
           </div>
 
           {/* Sidebar */}
           <div className="wiki-entity__sidebar">
-            <RelationshipsPanel relationships={relationships} onPick={onPick} allNodes={allNodes} />
+            <RelationshipsPanel
+              relationships={relationships}
+              onPick={onPick}
+              allNodes={allNodes}
+            />
             <EvidenceTrail evidence={evidence} />
           </div>
         </div>
@@ -918,11 +1512,16 @@ function WikiEntityPage({ node, rails, relatedMemories, allNodes, loading, error
           <div className="wiki-entity__connected">
             <h3>Connected Entities</h3>
             <p className="wiki-entity__connected-count">
-              {rails.reduce((s, r) => s + r.items.length, 0)} entities across {rails.length} {rails.length === 1 ? "group" : "groups"}
-              {rails.some((r) => r.reason?.includes("knowledge graph")) ? " · from knowledge graph + entity files" : ""}
+              {rails.reduce((s, r) => s + r.items.length, 0)} entities across{" "}
+              {rails.length} {rails.length === 1 ? "group" : "groups"}
+              {rails.some((r) => r.reason?.includes("knowledge graph"))
+                ? " · from knowledge graph + entity files"
+                : ""}
             </p>
             <div className="wiki-entity__connected-grid">
-              {rails.map((rail) => <WikiRailSection key={rail.title} rail={rail} onPick={onPick} />)}
+              {rails.map((rail) => (
+                <WikiRailSection key={rail.title} rail={rail} onPick={onPick} />
+              ))}
             </div>
           </div>
         ) : loading ? (
@@ -941,16 +1540,25 @@ function WikiEntityPage({ node, rails, relatedMemories, allNodes, loading, error
 
 /* ── Shell ────────────────────────────────────────── */
 
-export function WikiLibrary({ refreshToken = 0, paletteOpen: paletteOpenProp, onPaletteOpenChange, onFocusChange }: WikiLibraryProps) {
+export function WikiLibrary({
+  refreshToken = 0,
+  paletteOpen: paletteOpenProp,
+  onPaletteOpenChange,
+  onFocusChange,
+}: WikiLibraryProps) {
   const [home, setHome] = useState<WikiHomeData | null>(null);
   const [homeLoading, setHomeLoading] = useState(true);
   const [homeLoadError, setHomeLoadError] = useState<string | null>(null);
   const [focus, setFocus] = useState<WikiNode | null>(null);
-  const [contextFocus, setContextFocus] = useState<WorkspaceFilePreview | null>(null);
+  const [contextFocus, setContextFocus] = useState<WorkspaceFilePreview | null>(
+    null,
+  );
   const [contextLoading, setContextLoading] = useState(false);
   const [contextError, setContextError] = useState<string | undefined>();
   const [entityRails, setEntityRails] = useState<WikiRail[]>([]);
-  const [entityRelatedMemories, setEntityRelatedMemories] = useState<WikiRelatedMemory[]>([]);
+  const [entityRelatedMemories, setEntityRelatedMemories] = useState<
+    WikiRelatedMemory[]
+  >([]);
   const [entityLoading, setEntityLoading] = useState(false);
   const [entityError, setEntityError] = useState<string | undefined>();
   const [paletteOpenLocal, setPaletteOpenLocal] = useState(false);
@@ -959,7 +1567,8 @@ export function WikiLibrary({ refreshToken = 0, paletteOpen: paletteOpenProp, on
   const [createOpen, setCreateOpen] = useState(false);
   const [contextFiles, setContextFiles] = useState<WorkspaceFilePreview[]>([]);
   const [onboardingPending, setOnboardingPending] = useState(false);
-  const existingTypes = home?.rails?.map((r) => r.title.toLowerCase().replace(/\s+/g, "_")) ?? [];
+  const existingTypes =
+    home?.rails?.map((r) => r.title.toLowerCase().replace(/\s+/g, "_")) ?? [];
   const allNodes = useMemo(() => {
     const merged = collectWikiNodes(home);
     const seen = new Set(merged.map((n) => `${n.type}:${n.id}`));
@@ -978,46 +1587,54 @@ export function WikiLibrary({ refreshToken = 0, paletteOpen: paletteOpenProp, on
     return merged;
   }, [home, focus, entityRails]);
 
-  const loadHome = useCallback(async (options?: { silent?: boolean; forceRefresh?: boolean }) => {
-    if (!options?.silent) {
-      setHomeLoading(true);
-    }
-    setHomeLoadError(null);
+  const loadHome = useCallback(
+    async (options?: { silent?: boolean; forceRefresh?: boolean }) => {
+      if (!options?.silent) {
+        setHomeLoading(true);
+      }
+      setHomeLoadError(null);
 
-    try {
-      const maxAttempts = 4;
-      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-        try {
-          await gateway.waitForConnection(20_000);
-          const response = await gateway.send(
-            "memory:wiki-home",
-            { forceRefresh: options?.forceRefresh === true },
-            { timeoutMs: 30_000 },
-          );
-          if (response.success && response.data) {
-            setHome(response.data as WikiHomeData);
-            setHomeLoadError(null);
+      try {
+        const maxAttempts = 4;
+        for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+          try {
+            await gateway.waitForConnection(20_000);
+            const response = await gateway.send(
+              "memory:wiki-home",
+              { forceRefresh: options?.forceRefresh === true },
+              { timeoutMs: 30_000 },
+            );
+            if (response.success && response.data) {
+              setHome(response.data as WikiHomeData);
+              setHomeLoadError(null);
+              return;
+            }
+            throw new Error(
+              response.error ?? "Could not load your knowledge graph.",
+            );
+          } catch (error) {
+            const canRetry =
+              attempt < maxAttempts && isTransientGatewayError(error);
+            if (canRetry) {
+              await sleep(Math.min(1000 * attempt, 4000));
+              continue;
+            }
+            setHomeLoadError(
+              error instanceof Error
+                ? error.message
+                : "Could not load your knowledge graph.",
+            );
             return;
           }
-          throw new Error(response.error ?? "Could not load your knowledge graph.");
-        } catch (error) {
-          const canRetry = attempt < maxAttempts && isTransientGatewayError(error);
-          if (canRetry) {
-            await sleep(Math.min(1000 * attempt, 4000));
-            continue;
-          }
-          setHomeLoadError(
-            error instanceof Error ? error.message : "Could not load your knowledge graph.",
-          );
-          return;
+        }
+      } finally {
+        if (!options?.silent) {
+          setHomeLoading(false);
         }
       }
-    } finally {
-      if (!options?.silent) {
-        setHomeLoading(false);
-      }
-    }
-  }, []);
+    },
+    [],
+  );
 
   /** Load context files for inline display */
   const loadContext = useCallback(async () => {
@@ -1025,7 +1642,11 @@ export function WikiLibrary({ refreshToken = 0, paletteOpen: paletteOpenProp, on
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       try {
         await gateway.waitForConnection(20_000);
-        const response = await gateway.send("memory:get-context-preview", { forceRefresh: false }, { timeoutMs: 15_000 });
+        const response = await gateway.send(
+          "memory:get-context-preview",
+          { forceRefresh: false },
+          { timeoutMs: 15_000 },
+        );
         if (response.success && response.data) {
           const data = response.data as {
             workspaceFiles?: WorkspaceFilePreview[];
@@ -1058,108 +1679,148 @@ export function WikiLibrary({ refreshToken = 0, paletteOpen: paletteOpenProp, on
 
   const clearFocus = useCallback(() => {
     setFocus(null);
-    try { sessionStorage.removeItem(FOCUS_CACHE_KEY); } catch { /* noop */ }
+    try {
+      sessionStorage.removeItem(FOCUS_CACHE_KEY);
+    } catch {
+      /* noop */
+    }
     onFocusChange?.(null, null);
   }, [onFocusChange]);
 
-  const openContextFile = useCallback(async (file: WorkspaceFilePreview) => {
-    setFocus(null);
-    setContextFocus({ ...file });
-    setContextLoading(true);
-    setContextError(undefined);
-    onFocusChange?.(fileLabel(file.name), clearContextFocus);
-    window.scrollTo?.(0, 0);
+  const openContextFile = useCallback(
+    async (file: WorkspaceFilePreview) => {
+      setFocus(null);
+      setContextFocus({ ...file });
+      setContextLoading(true);
+      setContextError(undefined);
+      onFocusChange?.(fileLabel(file.name), clearContextFocus);
+      window.scrollTo?.(0, 0);
 
-    try {
-      const response = await gateway.send(
-        "memory:read-context-file",
-        { fileName: file.name },
-        { timeoutMs: 15_000 },
-      );
-      if (!response.success) {
-        setContextError(response.error ?? "Failed to load file");
-        return;
+      try {
+        const response = await gateway.send(
+          "memory:read-context-file",
+          { fileName: file.name },
+          { timeoutMs: 15_000 },
+        );
+        if (!response.success) {
+          setContextError(response.error ?? "Failed to load file");
+          return;
+        }
+        const data = response.data as WorkspaceFilePreview | undefined;
+        if (data?.content != null) {
+          setContextFocus({
+            name: file.name,
+            content: data.content,
+            size: data.size ?? data.content.length,
+            truncated: data.truncated ?? false,
+            rawLength: data.rawLength ?? data.content.length,
+          });
+        }
+      } catch (err) {
+        setContextError(
+          err instanceof Error ? err.message : "Failed to load file",
+        );
+      } finally {
+        setContextLoading(false);
       }
-      const data = response.data as WorkspaceFilePreview | undefined;
-      if (data?.content != null) {
+    },
+    [onFocusChange, clearContextFocus],
+  );
+
+  const saveContextFile = useCallback(
+    async (content: string): Promise<string | undefined> => {
+      if (!contextFocus) return "No file selected";
+      try {
+        const response = await gateway.send(
+          "memory:write-context-file",
+          { fileName: contextFocus.name, content },
+          { timeoutMs: 15_000 },
+        );
+        if (!response.success) {
+          return response.error ?? "Failed to save file";
+        }
+        const data = response.data as WorkspaceFilePreview | undefined;
         setContextFocus({
-          name: file.name,
-          content: data.content,
-          size: data.size ?? data.content.length,
-          truncated: data.truncated ?? false,
-          rawLength: data.rawLength ?? data.content.length,
+          name: contextFocus.name,
+          content: data?.content ?? content,
+          size: data?.size ?? content.length,
+          truncated: false,
+          rawLength: data?.rawLength ?? content.length,
         });
+        void loadContext();
+        return undefined;
+      } catch (err) {
+        return err instanceof Error ? err.message : "Failed to save file";
       }
-    } catch (err) {
-      setContextError(err instanceof Error ? err.message : "Failed to load file");
-    } finally {
-      setContextLoading(false);
-    }
-  }, [onFocusChange, clearContextFocus]);
+    },
+    [contextFocus, loadContext],
+  );
 
-  const saveContextFile = useCallback(async (content: string): Promise<string | undefined> => {
-    if (!contextFocus) return "No file selected";
-    try {
-      const response = await gateway.send(
-        "memory:write-context-file",
-        { fileName: contextFocus.name, content },
-        { timeoutMs: 15_000 },
-      );
-      if (!response.success) {
-        return response.error ?? "Failed to save file";
+  const loadEntity = useCallback(
+    async (nodeInput: WikiNode) => {
+      const node = normalizeWikiNode(nodeInput);
+      setContextFocus(null);
+      setContextError(undefined);
+      // Optimistic: show entity page immediately with what we already have
+      setFocus(node);
+      setEntityRails([]);
+      setEntityRelatedMemories([]);
+      setEntityLoading(true);
+      setEntityError(undefined);
+      // Cache to sessionStorage
+      try {
+        sessionStorage.setItem(
+          FOCUS_CACHE_KEY,
+          JSON.stringify({ type: node.type, id: node.id, label: node.label }),
+        );
+      } catch {
+        /* noop */
       }
-      const data = response.data as WorkspaceFilePreview | undefined;
-      setContextFocus({
-        name: contextFocus.name,
-        content: data?.content ?? content,
-        size: data?.size ?? content.length,
-        truncated: false,
-        rawLength: data?.rawLength ?? content.length,
-      });
-      void loadContext();
-      return undefined;
-    } catch (err) {
-      return err instanceof Error ? err.message : "Failed to save file";
-    }
-  }, [contextFocus, loadContext]);
-
-  const loadEntity = useCallback(async (nodeInput: WikiNode) => {
-    const node = normalizeWikiNode(nodeInput);
-    setContextFocus(null);
-    setContextError(undefined);
-    // Optimistic: show entity page immediately with what we already have
-    setFocus(node);
-    setEntityRails([]);
-    setEntityRelatedMemories([]);
-    setEntityLoading(true);
-    setEntityError(undefined);
-    // Cache to sessionStorage
-    try { sessionStorage.setItem(FOCUS_CACHE_KEY, JSON.stringify({ type: node.type, id: node.id, label: node.label })); } catch { /* noop */ }
-    // Report to parent for breadcrumbs
-    onFocusChange?.(node.label, clearFocus);
-    try {
-      const response = await gateway.send("memory:wiki-entity",
-        { type: node.type, id: node.id, label: node.label }, { timeoutMs: 30_000 });
-      if (!response.success) {
-        setEntityError(response.error ?? "Failed to load entity");
-        return;
+      // Report to parent for breadcrumbs
+      onFocusChange?.(node.label, clearFocus);
+      try {
+        const response = await gateway.send(
+          "memory:wiki-entity",
+          { type: node.type, id: node.id, label: node.label },
+          { timeoutMs: 30_000 },
+        );
+        if (!response.success) {
+          setEntityError(response.error ?? "Failed to load entity");
+          return;
+        }
+        const data = response.data as WikiEntityData | undefined;
+        if (data?.node) {
+          const enriched = normalizeWikiNode(data.node);
+          setFocus(enriched);
+          setEntityRails(data.rails ?? []);
+          setEntityRelatedMemories(data.relatedMemories ?? []);
+          // Update cache with enriched node
+          try {
+            sessionStorage.setItem(
+              FOCUS_CACHE_KEY,
+              JSON.stringify({
+                type: enriched.type,
+                id: enriched.id,
+                label: enriched.label,
+              }),
+            );
+          } catch {
+            /* noop */
+          }
+          onFocusChange?.(enriched.label, clearFocus);
+        } else {
+          setEntityError(data?.error ?? "Entity not found");
+        }
+      } catch (err) {
+        setEntityError(
+          err instanceof Error ? err.message : "Failed to load entity",
+        );
+      } finally {
+        setEntityLoading(false);
       }
-      const data = response.data as WikiEntityData | undefined;
-      if (data?.node) {
-        const enriched = normalizeWikiNode(data.node);
-        setFocus(enriched);
-        setEntityRails(data.rails ?? []);
-        setEntityRelatedMemories(data.relatedMemories ?? []);
-        // Update cache with enriched node
-        try { sessionStorage.setItem(FOCUS_CACHE_KEY, JSON.stringify({ type: enriched.type, id: enriched.id, label: enriched.label })); } catch { /* noop */ }
-        onFocusChange?.(enriched.label, clearFocus);
-      } else {
-        setEntityError(data?.error ?? "Entity not found");
-      }
-    } catch (err) {
-      setEntityError(err instanceof Error ? err.message : "Failed to load entity");
-    } finally { setEntityLoading(false); }
-  }, [onFocusChange, clearFocus]);
+    },
+    [onFocusChange, clearFocus],
+  );
 
   // Initial load + restore cached focus
   useEffect(() => {
@@ -1174,7 +1835,9 @@ export function WikiLibrary({ refreshToken = 0, paletteOpen: paletteOpenProp, on
           void loadEntity(normalizeWikiNode(parsed as WikiNode));
         }
       }
-    } catch { /* noop */ }
+    } catch {
+      /* noop */
+    }
   }, []);
 
   useEffect(() => {
@@ -1187,8 +1850,15 @@ export function WikiLibrary({ refreshToken = 0, paletteOpen: paletteOpenProp, on
     return unsubscribe;
   }, [homeLoadError, loadHome, loadContext]);
 
-  useEffect(() => { if (refreshToken > 0 && focus) void loadEntity(focus); }, [refreshToken]);
-  useEffect(() => { if (refreshToken > 0 && !focus) { void loadHome(); void loadContext(); } }, [refreshToken]);
+  useEffect(() => {
+    if (refreshToken > 0 && focus) void loadEntity(focus);
+  }, [refreshToken]);
+  useEffect(() => {
+    if (refreshToken > 0 && !focus) {
+      void loadHome();
+      void loadContext();
+    }
+  }, [refreshToken]);
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
@@ -1200,17 +1870,28 @@ export function WikiLibrary({ refreshToken = 0, paletteOpen: paletteOpenProp, on
     return () => window.removeEventListener("keydown", onKey);
   }, [focus, contextFocus, clearFocus, clearContextFocus]);
 
-  const handlePick = useCallback((node: WikiNode) => {
-    void loadEntity(node);
-    window.scrollTo?.(0, 0);
-  }, [loadEntity]);
+  const handlePick = useCallback(
+    (node: WikiNode) => {
+      void loadEntity(node);
+      window.scrollTo?.(0, 0);
+    },
+    [loadEntity],
+  );
 
   return (
     <div className="wiki-shell">
       <div className="wiki-shell__content">
         {focus ? (
-          <WikiEntityPage node={focus} rails={entityRails} relatedMemories={entityRelatedMemories} allNodes={allNodes}
-            loading={entityLoading} error={entityError} onBack={clearFocus} onPick={handlePick} />
+          <WikiEntityPage
+            node={focus}
+            rails={entityRails}
+            relatedMemories={entityRelatedMemories}
+            allNodes={allNodes}
+            loading={entityLoading}
+            error={entityError}
+            onBack={clearFocus}
+            onPick={handlePick}
+          />
         ) : contextFocus ? (
           <ContextFilePage
             file={contextFocus}
@@ -1220,18 +1901,33 @@ export function WikiLibrary({ refreshToken = 0, paletteOpen: paletteOpenProp, on
             onSave={saveContextFile}
           />
         ) : (
-          <WikiHome data={home} loading={homeLoading} loadError={homeLoadError}
+          <WikiHome
+            data={home}
+            loading={homeLoading}
+            loadError={homeLoadError}
             onRetry={reloadLibrary}
             onPick={handlePick}
-            onSearch={() => setPaletteOpen(true)} onAdd={() => setCreateOpen(true)}
-            onOpenContextFile={(file) => { void openContextFile(file); }}
+            onSearch={() => setPaletteOpen(true)}
+            onAdd={() => setCreateOpen(true)}
+            onOpenContextFile={(file) => {
+              void openContextFile(file);
+            }}
             contextFiles={contextFiles}
-            onboardingPending={onboardingPending} />
+            onboardingPending={onboardingPending}
+          />
         )}
       </div>
-      <SearchPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} onPick={handlePick} />
-      <CreateDialog open={createOpen} onClose={() => setCreateOpen(false)}
-        onCreated={() => loadHome()} existingTypes={existingTypes} />
+      <SearchPalette
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        onPick={handlePick}
+      />
+      <CreateDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={() => loadHome()}
+        existingTypes={existingTypes}
+      />
     </div>
   );
 }

--- a/ui/components/Memory/WikiLibrary.tsx
+++ b/ui/components/Memory/WikiLibrary.tsx
@@ -1298,9 +1298,11 @@ function WikiEntityPage({
   error?: string;
   onBack: () => void;
   onPick: (n: WikiNode) => void;
-  onMediaUpdated: (n: WikiNode) => void;
+  onMediaUpdated?: (n: WikiNode) => void;
 }) {
   const meta = node ? wikiTypeMeta(node.type) : null;
+  const [mediaBusy, setMediaBusy] = useState(false);
+  const [mediaError, setMediaError] = useState<string | null>(null);
 
   if (loading && !node)
     return (
@@ -1327,8 +1329,6 @@ function WikiEntityPage({
   const evidence = node.evidence ?? [];
   const props = node.props ?? {};
   const canEditMedia = node.type === "company" || node.type === "person";
-  const [mediaBusy, setMediaBusy] = useState(false);
-  const [mediaError, setMediaError] = useState<string | null>(null);
   const updateMedia = async (kind: "image" | "hero_image", file?: File) => {
     setMediaBusy(true);
     setMediaError(null);
@@ -1347,7 +1347,7 @@ function WikiEntityPage({
         { timeoutMs: 30_000 },
       );
       const updated = (fresh.data as WikiEntityData | undefined)?.node;
-      if (updated) onMediaUpdated(normalizeWikiNode(updated));
+      if (updated) onMediaUpdated?.(normalizeWikiNode(updated));
     } catch (err) {
       setMediaError(
         err instanceof Error ? err.message : "Could not update image",
@@ -1891,6 +1891,10 @@ export function WikiLibrary({
             error={entityError}
             onBack={clearFocus}
             onPick={handlePick}
+            onMediaUpdated={(updated) => {
+              setFocus(updated);
+              void loadHome({ silent: true, forceRefresh: true });
+            }}
           />
         ) : contextFocus ? (
           <ContextFilePage


### PR DESCRIPTION
## Summary
- add separate `hero_image` support for company and person wiki entities while preserving `image` as the backwards-compatible logo/avatar field
- add in-page upload, replace, and remove controls for logos/photos and hero images
- normalize raster uploads with Sharp, preserve validated SVG logos, enforce size/path/MIME safety, and persist media beside entity markdown
- render hero imagery on cards and entity pages with the logo/avatar layered independently
- update Wiki Writer guidance to preserve user-uploaded media

## Why
Company logos were being stretched into cover art and there was no way to give company/person pages a richer visual identity. This separates brand/profile identity from wide hero imagery and lets users manage both directly in Memory Wiki.

## Testing
- `npm run build:gateway`
- `npm run build:ui`
- `npx vitest run tests/unit/backend/wikiEntityImage.test.ts ui/__tests__/wiki-normalize.test.ts --reporter=dot`
- verified a local Boeing entity resolves an SVG logo and normalized WebP hero together

## Notes
Boeing's user-provided assets were applied to the active workspace for local verification; workspace data is not included in this platform PR.
