### PR TITLE
fix(papr): stop Parse connection storm and harden the workspace cache

### DIFF
--- a/src/electron/ipc/paprBilling.ts
+++ b/src/electron/ipc/paprBilling.ts
@@ -339,6 +339,57 @@ async function resolveWorkspaceRole(
   return self?.user.role ?? "member";
 }
 
+/**
+ * Short-lived cache for the read-only plan summary.
+ *
+ * Every profile load asks for this, and building it costs two Parse queries plus
+ * two dashboard.papr.ai calls (Stripe subscription + usage metrics). Plans do not
+ * change second to second, so a brief cache removes almost all of that traffic
+ * without the UI ever looking stale. Billing mutations invalidate it explicitly.
+ */
+const PLAN_SUMMARY_TTL_MS = 60_000;
+
+let planSummaryCache:
+  | { key: string; expiresAt: number; summary: PaprPlanSummary }
+  | null = null;
+let planSummaryInFlight: { key: string; promise: Promise<PaprPlanSummary> } | null =
+  null;
+
+function invalidatePlanSummaryCache(): void {
+  planSummaryCache = null;
+}
+
+/** Plan summary for read paths: cached, and concurrent callers share one build. */
+async function getPlanSummaryCached(
+  services: BillingServices,
+): Promise<PaprPlanSummary> {
+  const profile = requireLoggedInProfile(services.settingsStorage);
+  const key = `${profile.workspaceId}:${profile.organizationId}`;
+
+  if (planSummaryCache?.key === key && planSummaryCache.expiresAt > Date.now()) {
+    return planSummaryCache.summary;
+  }
+  if (planSummaryInFlight?.key === key) {
+    return planSummaryInFlight.promise;
+  }
+
+  const promise = buildPlanSummary(services)
+    .then((summary) => {
+      planSummaryCache = {
+        key,
+        expiresAt: Date.now() + PLAN_SUMMARY_TTL_MS,
+        summary,
+      };
+      return summary;
+    })
+    .finally(() => {
+      planSummaryInFlight = null;
+    });
+
+  planSummaryInFlight = { key, promise };
+  return promise;
+}
+
 async function buildPlanSummary(services: BillingServices): Promise<PaprPlanSummary> {
   const profile = requireLoggedInProfile(services.settingsStorage);
 
@@ -548,7 +599,7 @@ export function registerPaprBillingHandlers(deps: {
 
   ipcMain.handle("papr:get-plan-summary", async () => {
     try {
-      const summary = await buildPlanSummary(services);
+      const summary = await getPlanSummaryCached(services);
       persistPlanSummaryToProfile(deps.settingsStorage, summary);
       return { success: true, summary };
     } catch (error) {
@@ -653,6 +704,7 @@ export function registerPaprBillingHandlers(deps: {
         },
       });
 
+      invalidatePlanSummaryCache();
       return { success: true, enabled };
     } catch (error) {
       return {

--- a/src/electron/ipc/paprLogin.ts
+++ b/src/electron/ipc/paprLogin.ts
@@ -27,10 +27,11 @@ import {
   stopPaprAuthCallbackServer,
 } from "./paprAuthCallbackServer.js";
 import {
-  cacheNamespacesForOrg,
-  getCachedNamespaces,
-  readPaprWorkspaceCache,
-  writePaprWorkspaceCache,
+  clearPaprWorkspaceCache,
+  readCachedNamespaces,
+  readCachedWorkspaces,
+  writeCachedNamespaces,
+  writeCachedWorkspaces,
   type CachedWorkspace,
 } from "./paprWorkspaceCache.js";
 import {
@@ -38,6 +39,7 @@ import {
   sendWorkspaceInvite,
 } from "./paprWorkspaceTeam.js";
 import { registerPaprBillingHandlers } from "./paprBilling.js";
+import { coalesce, parseFetch } from "./parseTransport.js";
 import * as crypto from "crypto";
 import path from "node:path";
 import { getPaprDataDir } from "../../core/utils/paprRoot.js";
@@ -673,68 +675,46 @@ type ParseGraphQLJson = {
   [key: string]: ParseGraphQLJson | ParseGraphQLJson[] | string | number | boolean | null | undefined;
 };
 
-function isTransientParseError(error: unknown): boolean {
-  const msg = error instanceof Error ? error.message : String(error);
-  const cause = error instanceof Error && "cause" in error ? String(error.cause) : "";
-  const combined = `${msg} ${cause}`;
-  return (
-    combined.includes("Invalid server state") ||
-    combined.includes("ECONNRESET") ||
-    combined.includes("fetch failed") ||
-    combined.includes("ETIMEDOUT") ||
-    combined.includes("503") ||
-    combined.includes("502") ||
-    /Parse GraphQL error: 5\d\d/.test(combined)
-  );
-}
-
 // ─── Parse GraphQL Client ──────────────────────────────────────
 
+/**
+ * Run a Parse GraphQL operation.
+ *
+ * Connection pooling, timeouts, jittered retry and circuit breaking all live in
+ * `parseTransport`, shared with the profile-sync client so both compete for the
+ * same bounded set of sockets rather than each opening its own.
+ */
 async function parseGraphQL(
   sessionToken: string,
   query: string,
   variables: Record<string, unknown>,
+  options: { maxAttempts?: number } = {},
 ): Promise<ParseGraphQLJson> {
-  let lastError: unknown;
-  const maxAttempts = 4;
+  const response = await parseFetch(PARSE_GRAPHQL_URL, {
+    method: "POST",
+    maxAttempts: options.maxAttempts,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Parse-Application-Id": PARSE_APP_ID,
+      "X-Parse-Session-Token": sessionToken,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const response = await fetch(PARSE_GRAPHQL_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Parse-Application-Id": PARSE_APP_ID,
-          "X-Parse-Session-Token": sessionToken,
-        },
-        body: JSON.stringify({ query, variables }),
-      });
-
-      if (!response.ok) {
-        const text = await response.text();
-        throw new Error(`Parse GraphQL error: ${response.status} ${text}`);
-      }
-
-      const result = (await response.json()) as { data?: Record<string, unknown>; errors?: unknown[] };
-      if (result.errors) {
-        throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
-      }
-
-      return (result.data ?? {}) as ParseGraphQLJson;
-    } catch (error) {
-      lastError = error;
-      if (!isTransientParseError(error) || attempt === maxAttempts) {
-        throw error;
-      }
-      const delayMs = 300 * 2 ** (attempt - 1);
-      console.warn(
-        `[PaprLogin] Transient Parse error (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs}ms...`,
-      );
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-    }
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Parse GraphQL error: ${response.status} ${text}`);
   }
 
-  throw lastError;
+  const result = (await response.json()) as {
+    data?: Record<string, unknown>;
+    errors?: unknown[];
+  };
+  if (result.errors) {
+    throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
+  }
+
+  return (result.data ?? {}) as ParseGraphQLJson;
 }
 
 // ─── GraphQL Mutations (matching papr-dev-platform) ────────────
@@ -1245,13 +1225,24 @@ async function fetchUserWorkspaces(
     };
   };
 
+  const edges = data.workspace_followers?.edges ?? [];
   const workspaces: UserWorkspaceOption[] = [];
-  for (const edge of data.workspace_followers?.edges ?? []) {
+  const skipped: string[] = [];
+
+  for (const edge of edges) {
     const node = edge.node;
 
     const workspace = node?.workspace;
     const organization = workspace?.organization;
     if (!node?.objectId || !workspace?.objectId || !organization?.objectId || !organization.name) {
+      // A membership row that fails these checks disappears from the switcher
+      // with no trace, which makes "my workspace is missing" impossible to
+      // diagnose from logs. Record why it was dropped.
+      skipped.push(
+        `${workspace?.workspace_name ?? workspace?.objectId ?? "unknown"} ` +
+          `(follower=${node?.objectId ?? "none"}, org=${organization?.objectId ?? "none"}, ` +
+          `orgName=${JSON.stringify(organization?.name ?? null)})`,
+      );
       continue;
     }
 
@@ -1291,6 +1282,17 @@ async function fetchUserWorkspaces(
 
   workspaces.sort((a, b) =>
     workspaceDisplayName(a).localeCompare(workspaceDisplayName(b)),
+  );
+
+  if (skipped.length > 0) {
+    console.warn(
+      `[PaprLogin] Dropped ${skipped.length} of ${edges.length} workspace membership ` +
+        `rows (incomplete organization data): ${skipped.join("; ")}`,
+    );
+  }
+  console.log(
+    `[PaprLogin] Parse returned ${edges.length} workspace membership rows, ` +
+      `kept ${workspaces.length}: ${workspaces.map(workspaceDisplayName).join(", ") || "none"}`,
   );
 
   return workspaces;
@@ -1379,16 +1381,20 @@ async function fetchUserWorkspacesWithRefresh(
   customKeysStorage: CustomKeysStorage,
   settingsStorage: SettingsStorage,
 ): Promise<UserWorkspaceOption[]> {
-  const graphql: GraphQLExecutor = (query, variables) =>
-    parseGraphQLWithRefresh(
-      profile.sessionToken!,
-      query,
-      variables,
-      customKeysStorage,
-      settingsStorage,
-    );
+  // This is a three-query fan-out (workspaces, owned orgs, developer org) and
+  // several callers can want it at once; they share one pass.
+  return coalesce(`parse:workspaces:${profile.userId}`, () => {
+    const graphql: GraphQLExecutor = (query, variables) =>
+      parseGraphQLWithRefresh(
+        profile.sessionToken!,
+        query,
+        variables,
+        customKeysStorage,
+        settingsStorage,
+      );
 
-  return fetchUserWorkspaces(profile.userId!, graphql);
+    return fetchUserWorkspaces(profile.userId!, graphql);
+  });
 }
 
 type PaprProfile = NonNullable<ReturnType<SettingsStorage["getPaprProfile"]>>;
@@ -2069,6 +2075,14 @@ interface OrgNamespaceListItem {
   environmentType?: string;
 }
 
+/**
+ * The user the workspace cache belongs to. Reads and writes are scoped by this,
+ * so a cache written before a logout is never served to the next account.
+ */
+function cacheUserId(settingsStorage: SettingsStorage): string {
+  return settingsStorage.getPaprProfile()?.userId ?? "";
+}
+
 async function fetchOrgNamespaces(
   sessionToken: string,
   organizationId: string,
@@ -2115,12 +2129,25 @@ async function fetchOrgNamespaces(
 
   // Compare against what was cached BEFORE overwriting, so a background refresh
   // that discovers new/removed namespaces can wake the renderer up.
-  const previousCacheEntries = getCachedNamespaces(organizationId) ?? [];
+  const userId = cacheUserId(settingsStorage);
+  const previousCacheEntries = readCachedNamespaces(userId, organizationId)?.data ?? [];
   const changed =
     namespaceListSignature(previousCacheEntries) !==
     namespaceListSignature(nextCacheEntries);
 
-  cacheNamespacesForOrg(organizationId, nextCacheEntries);
+  // An empty result on top of a populated cache is almost always a partial
+  // failure upstream, not a real deletion. Overwriting here made the cache
+  // flip empty/populated on every pass, and each flip notified the renderer,
+  // which forced another refresh — load grew while Parse was degraded.
+  if (nextCacheEntries.length === 0 && previousCacheEntries.length > 0) {
+    console.warn(
+      `[PaprLogin] Namespace fetch for org ${organizationId} returned nothing; ` +
+        `keeping ${previousCacheEntries.length} cached entries`,
+    );
+    return previousCacheEntries.map((entry) => ({ ...entry }));
+  }
+
+  writeCachedNamespaces(userId, organizationId, nextCacheEntries);
 
   if (changed) {
     console.log(
@@ -2140,11 +2167,42 @@ async function fetchOrgNamespaces(
  * Without this, a background refresh rewrites the cache but the UI keeps showing
  * the stale list until a manual reload, so one bad cache write sticks forever.
  */
-function notifyWorkspaceCacheUpdated(): void {
+/**
+ * Minimum gap between cache-updated notifications.
+ *
+ * The renderer responds to this event with a full profile reload (profile +
+ * plan + workspace list), and that reload itself triggers the background
+ * refreshes that can emit this event. Throttling caps the cycle: even if the
+ * cache keeps changing, the renderer is woken at most once per window.
+ */
+const WORKSPACE_CACHE_NOTIFY_INTERVAL_MS = 15_000;
+
+let lastWorkspaceCacheNotifyAt = 0;
+let pendingWorkspaceCacheNotify: NodeJS.Timeout | null = null;
+
+function sendWorkspaceCacheUpdated(): void {
+  lastWorkspaceCacheNotifyAt = Date.now();
   const win = BrowserWindow.getAllWindows()[0];
   if (win && !win.isDestroyed()) {
     win.webContents.send("papr:workspace-cache-updated");
   }
+}
+
+function notifyWorkspaceCacheUpdated(): void {
+  if (pendingWorkspaceCacheNotify) return;
+
+  const elapsed = Date.now() - lastWorkspaceCacheNotifyAt;
+  if (elapsed >= WORKSPACE_CACHE_NOTIFY_INTERVAL_MS) {
+    sendWorkspaceCacheUpdated();
+    return;
+  }
+
+  // Trailing edge: coalesce the burst into one notification.
+  pendingWorkspaceCacheNotify = setTimeout(() => {
+    pendingWorkspaceCacheNotify = null;
+    sendWorkspaceCacheUpdated();
+  }, WORKSPACE_CACHE_NOTIFY_INTERVAL_MS - elapsed);
+  pendingWorkspaceCacheNotify.unref?.();
 }
 
 /** Stable signature for namespace cache change detection (order-insensitive). */
@@ -2216,6 +2274,16 @@ interface WorkspaceNamespaceGroup {
  * cache-updated event) would multiply that fan-out by the number of callers.
  */
 const backgroundNamespaceRefreshes = new Set<string>();
+
+/**
+ * Guard for the cache-first workspace refresh.
+ *
+ * `papr:list-organizations` answers from disk cache and refreshes behind it.
+ * Every profile reload calls it, so without this guard a burst of reloads each
+ * started its own Parse fan-out (workspaces + owned orgs + developer org +
+ * namespaces) against an origin that was already struggling.
+ */
+let backgroundWorkspaceRefreshRunning = false;
 
 function refreshOrgNamespacesInBackground(
   sessionToken: string,
@@ -3533,6 +3601,10 @@ export function initializePaprLoginIPC(
       await clearPersistedPkceState();
 
       settingsStorage.clearPaprProfile();
+      // The workspace cache is keyed by user, so a stale one would be ignored
+      // anyway — but leaving another account's workspace names on disk after a
+      // logout is not something to rely on scoping alone to hide.
+      clearPaprWorkspaceCache();
       await clearPaprUserIdFromGatewaySettings();
       try {
         const { clearMemoryPreviewCache } = await import(
@@ -3644,20 +3716,27 @@ export function initializePaprLoginIPC(
         }
 
         const forceRefresh = options?.forceRefresh === true;
-        const cached = forceRefresh ? null : getCachedNamespaces(organizationId);
+        const cached = forceRefresh
+          ? null
+          : readCachedNamespaces(cacheUserId(settingsStorage), organizationId);
         if (cached) {
-          void fetchOrgNamespaces(
-            profile.sessionToken,
-            organizationId,
-            customKeysStorage,
-            settingsStorage,
-          ).catch((error) => {
-            console.warn("[PaprLogin] Background namespace refresh failed:", error);
-          });
+          // Only chase a refresh once the entry is past its freshness window.
+          // Refreshing on every cache hit is what turned a routine settings
+          // render into a burst of Parse traffic.
+          if (cached.isStale) {
+            void fetchOrgNamespaces(
+              profile.sessionToken,
+              organizationId,
+              customKeysStorage,
+              settingsStorage,
+            ).catch((error) => {
+              console.warn("[PaprLogin] Background namespace refresh failed:", error);
+            });
+          }
 
           return {
             success: true,
-            namespaces: cached,
+            namespaces: cached.data,
             activeNamespaceId: profile.activeNamespaceId,
             parseOrganizationId: organizationId,
             fromCache: true,
@@ -3706,14 +3785,13 @@ export function initializePaprLoginIPC(
         const sessionToken = profile.sessionToken;
         const forceRefresh = options?.forceRefresh === true;
 
-        let workspaces: CachedWorkspace[] = readPaprWorkspaceCache()?.workspaces ?? [];
-        if (forceRefresh || workspaces.length === 0) {
+        const refreshWorkspaceCache = async (): Promise<CachedWorkspace[]> => {
           const fetched = await fetchUserWorkspacesWithRefresh(
             profile,
             customKeysStorage,
             settingsStorage,
           );
-          workspaces = fetched.map(
+          const rows = fetched.map(
             (workspace): CachedWorkspace => ({
               id: workspace.workspaceId,
               name: workspaceDisplayName(workspace),
@@ -3724,7 +3802,27 @@ export function initializePaprLoginIPC(
               defaultNamespaceId: workspace.defaultNamespaceId,
             }),
           );
-          writePaprWorkspaceCache({ workspaces });
+          writeCachedWorkspaces(profile.userId, rows);
+          return rows;
+        };
+
+        const cachedWorkspaces = forceRefresh
+          ? null
+          : readCachedWorkspaces(profile.userId);
+        let workspaces: CachedWorkspace[];
+
+        if (!cachedWorkspaces) {
+          workspaces = await refreshWorkspaceCache();
+        } else {
+          workspaces = cachedWorkspaces.data;
+          // Stale but usable: answer from cache so the picker stays instant, and
+          // repair the cache behind it. Serving a non-empty list forever without
+          // ever re-checking is how a wrong workspace list became permanent.
+          if (cachedWorkspaces.isStale) {
+            void refreshWorkspaceCache().catch((error) => {
+              console.warn("[PaprLogin] Background workspace refresh failed:", error);
+            });
+          }
         }
 
         const workspaceFilter = options?.workspaceId?.trim();
@@ -3802,15 +3900,19 @@ export function initializePaprLoginIPC(
                 organizationName,
               };
 
-              const cached = forceRefresh ? null : getCachedNamespaces(organizationId);
+              const cached = forceRefresh
+                ? null
+                : readCachedNamespaces(profile.userId, organizationId);
               if (cached) {
-                refreshOrgNamespacesInBackground(
-                  sessionToken,
-                  organizationId,
-                  customKeysStorage,
-                  settingsStorage,
-                );
-                return { ...base, namespaces: cached };
+                if (cached.isStale) {
+                  refreshOrgNamespacesInBackground(
+                    sessionToken,
+                    organizationId,
+                    customKeysStorage,
+                    settingsStorage,
+                  );
+                }
+                return { ...base, namespaces: cached.data };
               }
 
               try {
@@ -3872,8 +3974,8 @@ export function initializePaprLoginIPC(
         return { success: false, error: "Not logged in" };
       }
 
-      const diskCache = readPaprWorkspaceCache();
-      const cachedWorkspaces = diskCache?.workspaces ?? [];
+      const diskCache = readCachedWorkspaces(profile.userId);
+      const cachedWorkspaces = diskCache?.data ?? [];
 
       const buildResponse = (
         workspaces: UserWorkspaceOption[],
@@ -3902,64 +4004,88 @@ export function initializePaprLoginIPC(
       };
 
       if (cachedWorkspaces.length > 0) {
-        void fetchUserWorkspacesWithRefresh(profile, customKeysStorage, settingsStorage)
-          .then(async (workspaces) => {
-            const workspacesChanged =
-              workspaceListSignature(
-                cachedWorkspaces.map((workspace) => ({
-                  workspaceId: workspace.id,
-                  organizationId: workspace.organizationId,
-                  workspaceName: workspace.workspaceName ?? workspace.name,
-                })),
-              ) !== workspaceListSignature(workspaces);
-
-            writePaprWorkspaceCache({
-              workspaces: workspaces.map(
-                (workspace): CachedWorkspace => ({
-                  id: workspace.workspaceId,
-                  name: workspaceDisplayName(workspace),
-                  role: workspace.role,
-                  organizationId: workspace.organizationId,
-                  organizationName: workspace.organizationName,
-                  workspaceName: workspace.workspaceName,
-                  defaultNamespaceId: workspace.defaultNamespaceId,
-                }),
-              ),
-            });
-
-            if (workspacesChanged) {
-              console.log(
-                `[PaprLogin] Workspace cache changed ` +
-                  `(${cachedWorkspaces.length} -> ${workspaces.length}); notifying renderer`,
-              );
-              notifyWorkspaceCacheUpdated();
-            }
-
-            const active = await syncActiveWorkspaceOrganization(
-              profile,
-              workspaces,
-              settingsStorage,
-              customKeysStorage,
-            );
-            if (active?.organizationId && profile.sessionToken) {
-              try {
-                const namespaces = await fetchOrgNamespaces(
-                  profile.sessionToken,
-                  active.organizationId,
-                  customKeysStorage,
-                  settingsStorage,
+        // Refresh only once the cache is past its freshness window. This handler
+        // is called on every profile load, and refreshing unconditionally is
+        // what let a routine render fan out into repeated Parse round trips.
+        if (diskCache?.isStale && !backgroundWorkspaceRefreshRunning) {
+          backgroundWorkspaceRefreshRunning = true;
+          void fetchUserWorkspacesWithRefresh(profile, customKeysStorage, settingsStorage)
+            .then(async (workspaces) => {
+              // Same reasoning as the namespace cache: an empty list on top of a
+              // populated one means the fetch degraded, not that the user lost
+              // every workspace. Writing it would blank the switcher.
+              if (workspaces.length === 0) {
+                console.warn(
+                  `[PaprLogin] Workspace refresh returned nothing; keeping ` +
+                    `${cachedWorkspaces.length} cached workspaces`,
                 );
-                console.log(
-                  `[PaprLogin] Prefetched ${namespaces.length} namespaces for org ${active.organizationId}`,
-                );
-              } catch (error) {
-                console.warn("[PaprLogin] Background namespace prefetch failed:", error);
+                return;
               }
-            }
-          })
-          .catch((error) => {
-            console.warn("[PaprLogin] Background workspace refresh failed:", error);
-          });
+
+              const workspacesChanged =
+                workspaceListSignature(
+                  cachedWorkspaces.map((workspace) => ({
+                    workspaceId: workspace.id,
+                    organizationId: workspace.organizationId,
+                    workspaceName: workspace.workspaceName ?? workspace.name,
+                  })),
+                ) !== workspaceListSignature(workspaces);
+
+              writeCachedWorkspaces(
+                profile.userId,
+                workspaces.map(
+                  (workspace): CachedWorkspace => ({
+                    id: workspace.workspaceId,
+                    name: workspaceDisplayName(workspace),
+                    role: workspace.role,
+                    organizationId: workspace.organizationId,
+                    organizationName: workspace.organizationName,
+                    workspaceName: workspace.workspaceName,
+                    defaultNamespaceId: workspace.defaultNamespaceId,
+                  }),
+                ),
+              );
+
+              if (workspacesChanged) {
+                console.log(
+                  `[PaprLogin] Workspace cache changed ` +
+                    `(${cachedWorkspaces.length} -> ${workspaces.length}); notifying renderer`,
+                );
+                notifyWorkspaceCacheUpdated();
+              }
+
+              const active = await syncActiveWorkspaceOrganization(
+                profile,
+                workspaces,
+                settingsStorage,
+                customKeysStorage,
+              );
+              if (active?.organizationId && profile.sessionToken) {
+                try {
+                  const namespaces = await fetchOrgNamespaces(
+                    profile.sessionToken,
+                    active.organizationId,
+                    customKeysStorage,
+                    settingsStorage,
+                  );
+                  console.log(
+                    `[PaprLogin] Prefetched ${namespaces.length} namespaces for org ${active.organizationId}`,
+                  );
+                } catch (error) {
+                  console.warn(
+                    "[PaprLogin] Background namespace prefetch failed:",
+                    error,
+                  );
+                }
+              }
+            })
+            .catch((error) => {
+              console.warn("[PaprLogin] Background workspace refresh failed:", error);
+            })
+            .finally(() => {
+              backgroundWorkspaceRefreshRunning = false;
+            });
+        }
 
         const workspacesFromCache: UserWorkspaceOption[] = cachedWorkspaces.map(
           (workspace) => ({
@@ -3990,8 +4116,9 @@ export function initializePaprLoginIPC(
         settingsStorage,
       );
 
-      writePaprWorkspaceCache({
-        workspaces: workspaces.map(
+      writeCachedWorkspaces(
+        profile.userId,
+        workspaces.map(
           (workspace): CachedWorkspace => ({
             id: workspace.workspaceId,
             name: workspaceDisplayName(workspace),
@@ -4002,7 +4129,7 @@ export function initializePaprLoginIPC(
             defaultNamespaceId: workspace.defaultNamespaceId,
           }),
         ),
-      });
+      );
 
       const selected = workspaces.find((workspace) => workspace.isSelected);
       const activeWorkspaceId =

--- a/src/electron/ipc/paprProfileSync.ts
+++ b/src/electron/ipc/paprProfileSync.ts
@@ -3,6 +3,8 @@
  * Mirrors papr-dev-platform SettingsModal + parse-file-upload flow.
  */
 
+import { coalesce, parseFetch } from "./parseTransport.js";
+
 const PARSE_GRAPHQL_URL =
   process.env.PARSE_GRAPHQL_URL || "https://server.papr.ai/graphql";
 const PARSE_SERVER_URL =
@@ -132,17 +134,17 @@ const UPDATE_USER_DETAILS = `
   }
 `;
 
-const PARSE_GRAPHQL_TIMEOUT_MS = 90_000;
 const PARSE_FILE_UPLOAD_TIMEOUT_MS = 60_000;
 
 async function parseGraphQL(
   sessionToken: string,
   query: string,
   variables: Record<string, unknown>,
+  options: { maxAttempts?: number } = {},
 ): Promise<Record<string, unknown>> {
-  const response = await fetch(PARSE_GRAPHQL_URL, {
+  const response = await parseFetch(PARSE_GRAPHQL_URL, {
     method: "POST",
-    signal: AbortSignal.timeout(PARSE_GRAPHQL_TIMEOUT_MS),
+    maxAttempts: options.maxAttempts,
     headers: {
       "Content-Type": "application/json",
       "X-Parse-Application-Id": PARSE_APP_ID,
@@ -198,6 +200,15 @@ export async function fetchParseUserProfile(
   sessionToken: string,
   userId: string,
 ): Promise<ParseUserProfileDetails> {
+  // Several renderer triggers (app mount, sidebar, Settings profile tab) refresh
+  // the profile at once; they should share one round trip.
+  return coalesce(`parse:user:${userId}`, () => fetchParseUserProfileUncached(sessionToken, userId));
+}
+
+async function fetchParseUserProfileUncached(
+  sessionToken: string,
+  userId: string,
+): Promise<ParseUserProfileDetails> {
   const data = await parseGraphQL(sessionToken, GET_USER_DETAILS, { userId });
   const user = data.user as
     | {
@@ -233,11 +244,12 @@ export async function uploadProfileImageToParse(
     "_",
   );
 
-  const response = await fetch(
+  const response = await parseFetch(
     `${PARSE_SERVER_URL}/files/${encodeURIComponent(sanitizedFileName)}`,
     {
       method: "POST",
-      signal: AbortSignal.timeout(PARSE_FILE_UPLOAD_TIMEOUT_MS),
+      timeoutMs: PARSE_FILE_UPLOAD_TIMEOUT_MS,
+      maxAttempts: 1,
       headers: {
         "X-Parse-Application-Id": PARSE_APP_ID,
         "X-Parse-Session-Token": sessionToken,
@@ -269,9 +281,13 @@ export async function updateParseUserProfile(
     profileImage?: ParseProfileImageFilePointer;
   },
 ): Promise<{ profileImageUrl?: string }> {
-  const data = await parseGraphQL(sessionToken, UPDATE_USER_DETAILS, {
-    input: buildUpdateUserProfileGraphQLInput(userId, fields),
-  });
+  const data = await parseGraphQL(
+    sessionToken,
+    UPDATE_USER_DETAILS,
+    { input: buildUpdateUserProfileGraphQLInput(userId, fields) },
+    // Mutation — do not replay it on a transport error.
+    { maxAttempts: 1 },
+  );
   const user = (data.updateUser as { user?: { profileimage?: { url?: string } } })
     ?.user;
 

--- a/src/electron/ipc/paprWorkspaceCache.ts
+++ b/src/electron/ipc/paprWorkspaceCache.ts
@@ -1,5 +1,25 @@
 /**
  * Disk cache for Papr workspaces + namespaces (instant Settings load).
+ *
+ * The rules below are the ones a previous version of this cache broke, each of
+ * which stranded a user in a single workspace with no way out but deleting the
+ * file by hand:
+ *
+ *   1. Store what the server returned, verbatim. Dedupe and display naming are
+ *      applied on read, so a bug in either is a display bug we fix with a
+ *      deploy rather than permanent data loss on disk.
+ *   2. Scope to a user. The path is global, so an unlabelled cache serves the
+ *      previous account's workspaces after a logout and login.
+ *   3. Stamp each section with its fetch time and expose the age, so callers
+ *      can refresh stale data instead of treating any non-empty list as
+ *      authoritative forever.
+ *   4. Never let an upstream failure shrink the cache to nothing.
+ *   5. Write atomically. A half-written file parses as corrupt, and a corrupt
+ *      file reads as "no cache", silently discarding everything.
+ *
+ * Writes are synchronous and only the main process touches this file, so a
+ * read-modify-write cannot interleave and no lock is needed. The atomic rename
+ * is for crashes mid-write, not for concurrency.
  */
 
 import fs from "node:fs";
@@ -22,12 +42,28 @@ export interface CachedWorkspace {
   defaultNamespaceId?: string;
 }
 
-export interface PaprWorkspaceCacheFile {
-  version: 2;
-  updatedAt: string;
-  workspaces: CachedWorkspace[];
-  namespacesByOrgId: Record<string, CachedNamespace[]>;
+interface CachedNamespaceEntry {
+  fetchedAt: string;
+  namespaces: CachedNamespace[];
 }
+
+export interface PaprWorkspaceCacheFile {
+  version: 3;
+  /** Owner of this cache. A mismatch is a miss, never a fallback. */
+  userId: string;
+  workspacesFetchedAt: string;
+  /** Rows exactly as fetched. Deduped on read, never on write. */
+  workspaces: CachedWorkspace[];
+  namespacesByOrgId: Record<string, CachedNamespaceEntry>;
+}
+
+export const WORKSPACE_CACHE_VERSION = 3;
+
+/** Below this age, serve without triggering a refresh. */
+export const CACHE_FRESH_MS = 5 * 60_000;
+
+/** Above this age, treat as a miss — too old to show even briefly. */
+export const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60_000;
 
 const CACHE_FILENAME = "papr-workspace-cache.json";
 
@@ -36,91 +72,312 @@ function getCachePath(): string {
   return path.join(getPaprBaseDir(), "data", CACHE_FILENAME);
 }
 
-export function readPaprWorkspaceCache(): PaprWorkspaceCacheFile | null {
+function ageOf(fetchedAt: string | undefined): number {
+  const timestamp = fetchedAt ? Date.parse(fetchedAt) : Number.NaN;
+  return Number.isFinite(timestamp)
+    ? Math.max(0, Date.now() - timestamp)
+    : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * The stored file for this user, or null when there is nothing usable: no file,
+ * corrupt JSON, an older schema, or a cache belonging to a different account.
+ */
+function readForUser(userId: string): PaprWorkspaceCacheFile | null {
+  if (!userId) return null;
+
+  let parsed: PaprWorkspaceCacheFile;
   try {
-    const raw = fs.readFileSync(getCachePath(), "utf8");
-    const parsed = JSON.parse(raw) as PaprWorkspaceCacheFile;
-    if (parsed.version !== 2 || !Array.isArray(parsed.workspaces)) {
-      return null;
-    }
-    // Dedupe on read too, so caches written by older builds are cleaned up
-    // without requiring the user to log out and back in.
-    return { ...parsed, workspaces: dedupeCachedWorkspaces(parsed.workspaces) };
+    parsed = JSON.parse(
+      fs.readFileSync(getCachePath(), "utf8"),
+    ) as PaprWorkspaceCacheFile;
   } catch {
     return null;
   }
+
+  // Pre-v3 files carry no userId, so they cannot be attributed to an account.
+  // Discarding them costs one refetch and closes the cross-account leak.
+  if (parsed?.version !== WORKSPACE_CACHE_VERSION) return null;
+  if (!Array.isArray(parsed.workspaces)) return null;
+  if (!parsed.userId || parsed.userId !== userId) return null;
+
+  return {
+    ...parsed,
+    namespacesByOrgId: parsed.namespacesByOrgId ?? {},
+  };
+}
+
+function persist(next: PaprWorkspaceCacheFile): void {
+  const target = getCachePath();
+  const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(tmp, JSON.stringify(next, null, 2), "utf8");
+    fs.renameSync(tmp, target);
+  } catch (error) {
+    try {
+      fs.rmSync(tmp, { force: true });
+    } catch {
+      // Best effort — a stray temp file is harmless.
+    }
+    // A cache write failing must not break login or workspace switching.
+    console.warn("[PaprWorkspaceCache] Failed to write cache:", error);
+  }
+}
+
+/**
+ * Drop namespace entries past the usable age.
+ *
+ * Pruning by workspace membership would be wrong: a workspace can host several
+ * organizations, and the switcher caches namespaces for orgs that never appear
+ * as any workspace's primary org. Age is the only bound that cannot delete a
+ * still-reachable org.
+ */
+function pruneNamespaces(
+  entries: Record<string, CachedNamespaceEntry>,
+): Record<string, CachedNamespaceEntry> {
+  const kept: Record<string, CachedNamespaceEntry> = {};
+  for (const [orgId, entry] of Object.entries(entries)) {
+    if (!entry?.namespaces?.length) continue;
+    if (ageOf(entry.fetchedAt) > CACHE_MAX_AGE_MS) continue;
+    kept[orgId] = entry;
+  }
+  return kept;
+}
+
+/**
+ * The workspace name with Parse display artifacts removed, or null when nothing
+ * meaningful is left. A placeholder name cannot tell two rows apart.
+ */
+function meaningfulWorkspaceName(workspace: CachedWorkspace): string | null {
+  const raw = (workspace.workspaceName ?? workspace.name ?? "").trim();
+  // Parse renders the viewer's own workspace as "<orgName> (you)", and orgName is
+  // itself often literally "null" for personal workspaces.
+  const name = raw.replace(/\s*\(you\)\s*$/i, "").trim().toLowerCase();
+  if (!name || name === "null" || name === "undefined" || name === "workspace") {
+    return null;
+  }
+  return name;
+}
+
+/** Prefer a real name over "Workspace"/"null"/empty when collapsing rows. */
+function workspaceNameScore(workspace: CachedWorkspace): number {
+  const name = workspace.name?.trim().toLowerCase();
+  if (!name || name === "null" || name === "undefined") return 0;
+  if (name === "workspace") return 1;
+  return 2;
+}
+
+/** Org + namespace a row resolves to. Rows without a namespace stand alone. */
+function workspaceScopeKey(workspace: CachedWorkspace): string {
+  return workspace.defaultNamespaceId
+    ? `${workspace.organizationId ?? ""}::${workspace.defaultNamespaceId}`
+    : `id::${workspace.id}`;
 }
 
 /**
  * Collapse workspaces that resolve to the same org + namespace.
  *
  * Duplicate provisioning (and older builds that created a workspace on every
- * login) can leave several workspace rows pointing at one namespace. They are
- * indistinguishable to the user and make the switcher look broken, so keep the
- * best-named entry per org/namespace pair.
+ * login) can leave several workspace rows pointing at one namespace. Those are
+ * indistinguishable to the user and make the switcher look broken.
+ *
+ * Org + namespace alone is not enough to call two rows duplicates, though.
+ * `resolveNamespaceOrganizationId` maps every workspace where the user owns a
+ * non-matching org onto their single developer org, so genuinely different
+ * workspaces reach this function sharing an organizationId *and* a
+ * defaultNamespaceId. Keying on just those erased all but one, which is how a
+ * user ends up pinned to one workspace with nothing to switch to.
+ *
+ * So within a scope: rows with distinct real names are kept, and placeholder-named
+ * rows are absorbed into the named ones (or collapsed among themselves if no row
+ * in the scope has a real name).
+ *
+ * This runs on read only. The stored rows stay untouched, so a mistake here
+ * hides a workspace until the next deploy instead of destroying it on disk.
  */
 export function dedupeCachedWorkspaces(
   workspaces: CachedWorkspace[],
 ): CachedWorkspace[] {
-  const byScope = new Map<string, CachedWorkspace>();
+  /** scope → (name → best row), preserving first-seen order at both levels. */
+  const scopes = new Map<string, Map<string, CachedWorkspace>>();
+  const placeholders = new Map<string, CachedWorkspace>();
 
   for (const workspace of workspaces) {
-    // Entries without a namespace are not interchangeable — keep them by id.
-    const scopeKey = workspace.defaultNamespaceId
-      ? `${workspace.organizationId ?? ""}::${workspace.defaultNamespaceId}`
-      : `id::${workspace.id}`;
+    const scope = workspaceScopeKey(workspace);
+    const name = meaningfulWorkspaceName(workspace);
 
-    const existing = byScope.get(scopeKey);
-    if (!existing) {
-      byScope.set(scopeKey, workspace);
+    if (!name) {
+      const existing = placeholders.get(scope);
+      if (!existing || workspaceNameScore(workspace) > workspaceNameScore(existing)) {
+        placeholders.set(scope, workspace);
+      }
       continue;
     }
 
-    // Prefer the entry with a real name over "Workspace"/"null"/empty.
-    const score = (candidate: CachedWorkspace): number => {
-      const name = candidate.name?.trim().toLowerCase();
-      if (!name || name === "null" || name === "undefined") return 0;
-      if (name === "workspace") return 1;
-      return 2;
-    };
+    let named = scopes.get(scope);
+    if (!named) {
+      named = new Map<string, CachedWorkspace>();
+      scopes.set(scope, named);
+    }
 
-    if (score(workspace) > score(existing)) {
-      byScope.set(scopeKey, workspace);
+    const existing = named.get(name);
+    if (!existing || workspaceNameScore(workspace) > workspaceNameScore(existing)) {
+      named.set(name, workspace);
     }
   }
 
-  return [...byScope.values()];
+  const result: CachedWorkspace[] = [];
+  const emitted = new Set<string>();
+
+  // Walk the original order so the output is stable for callers and the UI.
+  for (const workspace of workspaces) {
+    const scope = workspaceScopeKey(workspace);
+    const named = scopes.get(scope);
+
+    if (!named) {
+      // Scope has no real name anywhere — emit the single best placeholder.
+      const placeholder = placeholders.get(scope);
+      if (placeholder && !emitted.has(scope)) {
+        emitted.add(scope);
+        result.push(placeholder);
+      }
+      continue;
+    }
+
+    const name = meaningfulWorkspaceName(workspace);
+    // Placeholder rows in a scope that has named rows are duplicates of them.
+    if (!name) continue;
+
+    const key = `${scope}::${name}`;
+    if (emitted.has(key)) continue;
+    emitted.add(key);
+    const best = named.get(name);
+    if (best) result.push(best);
+  }
+
+  return result;
 }
 
-export function writePaprWorkspaceCache(input: {
-  workspaces: CachedWorkspace[];
-  namespacesByOrgId?: Record<string, CachedNamespace[]>;
-}): void {
-  const existing = readPaprWorkspaceCache();
-  const next: PaprWorkspaceCacheFile = {
-    version: 2,
-    updatedAt: new Date().toISOString(),
-    workspaces: dedupeCachedWorkspaces(input.workspaces),
-    namespacesByOrgId: {
-      ...(existing?.namespacesByOrgId ?? {}),
-      ...(input.namespacesByOrgId ?? {}),
-    },
+export interface CachedRead<T> {
+  data: T;
+  ageMs: number;
+  /** Usable now, but a refresh should be kicked off. */
+  isStale: boolean;
+}
+
+/**
+ * Cached workspaces for this user, deduped for display, or null when there is
+ * nothing usable to show.
+ */
+export function readCachedWorkspaces(
+  userId: string,
+): CachedRead<CachedWorkspace[]> | null {
+  const file = readForUser(userId);
+  if (!file || file.workspaces.length === 0) return null;
+
+  const ageMs = ageOf(file.workspacesFetchedAt);
+  if (ageMs > CACHE_MAX_AGE_MS) return null;
+
+  return {
+    data: dedupeCachedWorkspaces(file.workspaces),
+    ageMs,
+    isStale: ageMs > CACHE_FRESH_MS,
   };
-
-  const dir = path.dirname(getCachePath());
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(getCachePath(), JSON.stringify(next, null, 2), "utf8");
 }
 
-export function getCachedNamespaces(orgId: string): CachedNamespace[] | null {
-  const cache = readPaprWorkspaceCache();
-  const list = cache?.namespacesByOrgId?.[orgId];
-  return list?.length ? list : null;
-}
+export function writeCachedWorkspaces(
+  userId: string,
+  workspaces: CachedWorkspace[],
+): void {
+  if (!userId) return;
+  const existing = readForUser(userId);
+  const existingCount = existing?.workspaces.length ?? 0;
 
-export function cacheNamespacesForOrg(orgId: string, namespaces: CachedNamespace[]): void {
-  writePaprWorkspaceCache({
-    workspaces: readPaprWorkspaceCache()?.workspaces ?? [],
-    namespacesByOrgId: { [orgId]: namespaces },
+  // Losing every workspace is nearly always a partial upstream failure rather
+  // than the user leaving all of them, and persisting it empties the switcher
+  // with no way back. A smaller-but-non-empty list can be a real membership
+  // change, so that one is logged and accepted rather than pinning the user to
+  // rows they no longer belong to.
+  if (workspaces.length === 0 && existingCount > 0) {
+    console.warn(
+      `[PaprWorkspaceCache] Refusing to replace ${existingCount} cached ` +
+        `workspaces with an empty list`,
+    );
+    return;
+  }
+  if (existingCount > 0 && workspaces.length < existingCount) {
+    console.log(
+      `[PaprWorkspaceCache] Workspace count fell from ${existingCount} to ` +
+        `${workspaces.length}; accepting as a membership change`,
+    );
+  }
+
+  persist({
+    version: WORKSPACE_CACHE_VERSION,
+    userId,
+    workspacesFetchedAt: new Date().toISOString(),
+    workspaces,
+    namespacesByOrgId: pruneNamespaces(existing?.namespacesByOrgId ?? {}),
   });
+}
+
+export function readCachedNamespaces(
+  userId: string,
+  orgId: string,
+): CachedRead<CachedNamespace[]> | null {
+  const entry = readForUser(userId)?.namespacesByOrgId?.[orgId];
+  if (!entry?.namespaces?.length) return null;
+
+  const ageMs = ageOf(entry.fetchedAt);
+  if (ageMs > CACHE_MAX_AGE_MS) return null;
+
+  return {
+    data: entry.namespaces.map((namespace) => ({ ...namespace })),
+    ageMs,
+    isStale: ageMs > CACHE_FRESH_MS,
+  };
+}
+
+export function writeCachedNamespaces(
+  userId: string,
+  orgId: string,
+  namespaces: CachedNamespace[],
+): void {
+  if (!userId || !orgId) return;
+  const existing = readForUser(userId);
+
+  // Same reasoning as workspaces: an empty namespace list on top of a populated
+  // one is a failed fetch, not a deletion.
+  const existingCount = existing?.namespacesByOrgId?.[orgId]?.namespaces.length ?? 0;
+  if (namespaces.length === 0 && existingCount > 0) {
+    console.warn(
+      `[PaprWorkspaceCache] Refusing to replace ${existingCount} cached ` +
+        `namespaces for org ${orgId} with an empty list`,
+    );
+    return;
+  }
+
+  persist({
+    version: WORKSPACE_CACHE_VERSION,
+    userId,
+    workspacesFetchedAt: existing?.workspacesFetchedAt ?? new Date(0).toISOString(),
+    workspaces: existing?.workspaces ?? [],
+    namespacesByOrgId: {
+      ...pruneNamespaces(existing?.namespacesByOrgId ?? {}),
+      [orgId]: { fetchedAt: new Date().toISOString(), namespaces },
+    },
+  });
+}
+
+/** Drop the cache entirely — used on logout so the next account starts clean. */
+export function clearPaprWorkspaceCache(): void {
+  const target = getCachePath();
+  try {
+    if (!fs.existsSync(target)) return;
+    fs.rmSync(target, { force: true });
+    console.log("[PaprWorkspaceCache] Cleared");
+  } catch (error) {
+    console.warn("[PaprWorkspaceCache] Failed to clear cache:", error);
+  }
 }

--- a/src/electron/ipc/parseTransport.ts
+++ b/src/electron/ipc/parseTransport.ts
@@ -1,0 +1,263 @@
+/**
+ * Hardened transport for Parse GraphQL / Papr platform HTTP calls.
+ *
+ * Node's global fetch keeps sockets alive but places no cap on concurrent
+ * connections per origin, so a burst of callers opens a socket each and
+ * server.papr.ai sheds them as ECONNRESET. Retrying those resets then produces
+ * more load than the original burst, so a degraded server never recovers.
+ *
+ * This module bounds that behaviour:
+ *   - a semaphore caps in-flight requests per origin
+ *   - identical concurrent reads share one request (coalescing)
+ *   - every request has a timeout, so a hung socket cannot be held open
+ *   - retries use jittered backoff, so parallel callers do not retry in lockstep
+ *   - a circuit breaker fails fast while the origin is unhealthy
+ */
+
+/** Sockets we allow against one origin at a time. */
+const MAX_CONCURRENT_PER_ORIGIN = 4;
+
+/** A single attempt may not exceed this. Parse reads are small; slow means broken. */
+export const PARSE_REQUEST_TIMEOUT_MS = 20_000;
+
+const MAX_ATTEMPTS = 3;
+const BASE_BACKOFF_MS = 300;
+
+/** Consecutive failures before we stop calling the origin. */
+const CIRCUIT_FAILURE_THRESHOLD = 6;
+/** How long the circuit stays open before a single probe is allowed through. */
+const CIRCUIT_OPEN_MS = 30_000;
+
+export class ParseCircuitOpenError extends Error {
+  constructor(origin: string, retryInMs: number) {
+    super(
+      `${origin} is temporarily unreachable (circuit open, retrying in ` +
+        `${Math.ceil(retryInMs / 1000)}s)`,
+    );
+    this.name = "ParseCircuitOpenError";
+  }
+}
+
+interface OriginState {
+  active: number;
+  queue: Array<() => void>;
+  consecutiveFailures: number;
+  openedAt: number | null;
+  /** Set while a probe request is testing whether the origin recovered. */
+  probing: boolean;
+}
+
+const origins = new Map<string, OriginState>();
+
+function getOriginState(origin: string): OriginState {
+  let state = origins.get(origin);
+  if (!state) {
+    state = {
+      active: 0,
+      queue: [],
+      consecutiveFailures: 0,
+      openedAt: null,
+      probing: false,
+    };
+    origins.set(origin, state);
+  }
+  return state;
+}
+
+function originOf(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return url;
+  }
+}
+
+async function acquire(state: OriginState): Promise<void> {
+  if (state.active < MAX_CONCURRENT_PER_ORIGIN) {
+    state.active += 1;
+    return;
+  }
+  await new Promise<void>((resolve) => state.queue.push(resolve));
+  state.active += 1;
+}
+
+function release(state: OriginState): void {
+  state.active -= 1;
+  const next = state.queue.shift();
+  if (next) next();
+}
+
+/**
+ * Errors worth retrying: connection-level failures and 5xx. Anything else
+ * (auth, validation, GraphQL errors) will fail the same way on a retry.
+ */
+export function isTransientTransportError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const cause =
+    error instanceof Error && "cause" in error ? String(error.cause) : "";
+  const combined = `${message} ${cause}`;
+  return (
+    combined.includes("Invalid server state") ||
+    combined.includes("ECONNRESET") ||
+    combined.includes("ECONNREFUSED") ||
+    combined.includes("EPIPE") ||
+    combined.includes("ETIMEDOUT") ||
+    combined.includes("fetch failed") ||
+    combined.includes("The operation was aborted") ||
+    combined.includes("TimeoutError") ||
+    combined.includes("502") ||
+    combined.includes("503") ||
+    combined.includes("504") ||
+    /error: 5\d\d/.test(combined)
+  );
+}
+
+/** Circuit state check. Lets one probe through once the open window elapses. */
+function checkCircuit(origin: string, state: OriginState): void {
+  if (state.openedAt === null) return;
+
+  const elapsed = Date.now() - state.openedAt;
+  if (elapsed < CIRCUIT_OPEN_MS) {
+    throw new ParseCircuitOpenError(origin, CIRCUIT_OPEN_MS - elapsed);
+  }
+
+  // Window elapsed: allow a single probe, keep everyone else failing fast so a
+  // recovering server is not hit by the whole backlog at once.
+  if (state.probing) {
+    throw new ParseCircuitOpenError(origin, CIRCUIT_OPEN_MS);
+  }
+  state.probing = true;
+}
+
+function recordSuccess(origin: string, state: OriginState): void {
+  if (state.openedAt !== null) {
+    console.log(`[ParseTransport] ${origin} recovered, closing circuit`);
+  }
+  state.consecutiveFailures = 0;
+  state.openedAt = null;
+  state.probing = false;
+}
+
+function recordFailure(origin: string, state: OriginState): void {
+  state.consecutiveFailures += 1;
+  state.probing = false;
+
+  if (
+    state.consecutiveFailures >= CIRCUIT_FAILURE_THRESHOLD &&
+    state.openedAt === null
+  ) {
+    state.openedAt = Date.now();
+    console.warn(
+      `[ParseTransport] ${origin} failed ${state.consecutiveFailures} times in a row; ` +
+        `pausing requests for ${CIRCUIT_OPEN_MS / 1000}s`,
+    );
+  } else if (state.openedAt !== null) {
+    // Probe failed — restart the open window rather than probing every call.
+    state.openedAt = Date.now();
+  }
+}
+
+function jitteredBackoff(attempt: number): number {
+  const ceiling = BASE_BACKOFF_MS * 2 ** (attempt - 1);
+  // Full jitter: spreads parallel callers instead of having them retry together.
+  return Math.round(ceiling * (0.5 + Math.random() * 0.5));
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface ParseFetchOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string | Buffer;
+  timeoutMs?: number;
+  /** Attempts including the first. Set to 1 for non-idempotent writes. */
+  maxAttempts?: number;
+}
+
+/**
+ * Perform an HTTP request through the bounded pool, with retry and circuit
+ * breaking. Resolves with the Response for the caller to interpret.
+ */
+export async function parseFetch(
+  url: string,
+  options: ParseFetchOptions = {},
+): Promise<Response> {
+  const origin = originOf(url);
+  const state = getOriginState(origin);
+  const maxAttempts = options.maxAttempts ?? MAX_ATTEMPTS;
+  const timeoutMs = options.timeoutMs ?? PARSE_REQUEST_TIMEOUT_MS;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    checkCircuit(origin, state);
+    await acquire(state);
+
+    try {
+      const response = await fetch(url, {
+        method: options.method ?? "POST",
+        headers: options.headers,
+        body: options.body,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+      // 5xx counts against the circuit; 4xx is the caller's problem, not the
+      // origin's health, so it closes the circuit like any other response.
+      if (response.status >= 500) {
+        recordFailure(origin, state);
+        if (attempt < maxAttempts) {
+          const text = await response.text().catch(() => "");
+          lastError = new Error(`Parse error: ${response.status} ${text}`);
+          await sleep(jitteredBackoff(attempt));
+          continue;
+        }
+      } else {
+        recordSuccess(origin, state);
+      }
+
+      return response;
+    } catch (error) {
+      lastError = error;
+      recordFailure(origin, state);
+
+      if (!isTransientTransportError(error) || attempt === maxAttempts) {
+        throw error;
+      }
+      await sleep(jitteredBackoff(attempt));
+    } finally {
+      release(state);
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Request to ${origin} failed`);
+}
+
+/** In-flight reads, keyed by caller-supplied identity, for coalescing. */
+const inFlight = new Map<string, Promise<unknown>>();
+
+/**
+ * Share one in-flight request between identical concurrent callers.
+ *
+ * The profile/workspace/billing refreshes fan out from several independent
+ * renderer triggers at once. Without coalescing each trigger issues its own
+ * round trip for the same data.
+ */
+export function coalesce<T>(key: string, run: () => Promise<T>): Promise<T> {
+  const existing = inFlight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+
+  const promise = run().finally(() => {
+    inFlight.delete(key);
+  });
+  inFlight.set(key, promise);
+  return promise;
+}
+
+/** Test/diagnostic hook — drops circuit + coalescing state. */
+export function resetParseTransportState(): void {
+  origins.clear();
+  inFlight.clear();
+}

--- a/tests/papr-workspace-cache-dedupe.test.ts
+++ b/tests/papr-workspace-cache-dedupe.test.ts
@@ -72,4 +72,47 @@ describe("dedupeCachedWorkspaces", () => {
   it("handles an empty list", () => {
     expect(dedupeCachedWorkspaces([])).toEqual([]);
   });
+
+  // resolveNamespaceOrganizationId maps every workspace where the user owns a
+  // non-matching org onto their single developer org, so distinct workspaces
+  // arrive sharing an organizationId and defaultNamespaceId. Collapsing those
+  // left the switcher with one row and no way out of it.
+  it("keeps differently named workspaces that resolve to the same developer org", () => {
+    const result = dedupeCachedWorkspaces([
+      workspace("ws-sqa", "SQA Service", "ns-dev", "org-dev"),
+      workspace("ws-papr", "papr-ai", "ns-dev", "org-dev"),
+    ]);
+
+    expect(result.map((entry) => entry.name)).toEqual(["SQA Service", "papr-ai"]);
+  });
+
+  it("still absorbs placeholder rows into a named row in the same scope", () => {
+    const result = dedupeCachedWorkspaces([
+      workspace("a", "Workspace", "ns-1"),
+      workspace("b", "papr-ai", "ns-1"),
+      workspace("c", "null (you)", "ns-1"),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("papr-ai");
+  });
+
+  it("collapses repeats of the same name but keeps the other workspace", () => {
+    const result = dedupeCachedWorkspaces([
+      workspace("a1", "Papr", "ns-1"),
+      workspace("a2", "Papr", "ns-1"),
+      workspace("b1", "Acme", "ns-1"),
+    ]);
+
+    expect(result.map((entry) => entry.name)).toEqual(["Papr", "Acme"]);
+  });
+
+  it("treats names differing only by the (you) suffix as the same workspace", () => {
+    const result = dedupeCachedWorkspaces([
+      workspace("a", "Acme", "ns-1"),
+      workspace("b", "Acme (you)", "ns-1"),
+    ]);
+
+    expect(result).toHaveLength(1);
+  });
 });

--- a/tests/papr-workspace-cache-store.test.ts
+++ b/tests/papr-workspace-cache-store.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Redirect the cache to a temp dir. Declared before the factory runs but only
+// read when getPaprBaseDir is actually called, which is inside the tests.
+let baseDir: string;
+
+vi.mock("../src/core/utils/paprWorkspace.js", () => ({
+  getPaprBaseDir: () => baseDir,
+}));
+
+const {
+  CACHE_FRESH_MS,
+  CACHE_MAX_AGE_MS,
+  clearPaprWorkspaceCache,
+  readCachedNamespaces,
+  readCachedWorkspaces,
+  writeCachedNamespaces,
+  writeCachedWorkspaces,
+} = await import("../src/electron/ipc/paprWorkspaceCache.js");
+
+const USER = "user-1";
+const OTHER_USER = "user-2";
+
+function cacheFilePath(): string {
+  return path.join(baseDir, "data", "papr-workspace-cache.json");
+}
+
+function readFileRaw(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(cacheFilePath(), "utf8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+function workspace(id: string, name: string, defaultNamespaceId = "ns-1") {
+  return { id, name, organizationId: "org-1", defaultNamespaceId };
+}
+
+beforeEach(() => {
+  baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "papr-cache-store-"));
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-17T00:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  fs.rmSync(baseDir, { recursive: true, force: true });
+});
+
+describe("workspace cache persistence", () => {
+  it("round-trips workspaces for the user that wrote them", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+
+    const read = readCachedWorkspaces(USER);
+    expect(read?.data.map((entry) => entry.name)).toEqual(["Papr"]);
+    expect(read?.isStale).toBe(false);
+    expect(read?.ageMs).toBe(0);
+  });
+
+  it("returns null when nothing has been cached", () => {
+    expect(readCachedWorkspaces(USER)).toBeNull();
+  });
+
+  // The bug this cache shipped with: dedupe ran on write, so a wrong transform
+  // erased rows on disk and no later fix could recover them.
+  it("stores rows verbatim and only dedupes on read", () => {
+    writeCachedWorkspaces(USER, [
+      workspace("a", "Papr"),
+      workspace("b", "Papr"),
+    ]);
+
+    expect(readCachedWorkspaces(USER)?.data).toHaveLength(1);
+    expect(readFileRaw().workspaces).toHaveLength(2);
+  });
+
+  it("never serves another account's cache", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+
+    expect(readCachedWorkspaces(OTHER_USER)).toBeNull();
+    expect(readCachedNamespaces(OTHER_USER, "org-1")).toBeNull();
+  });
+
+  it("ignores a pre-v3 file, which carries no owner", () => {
+    fs.mkdirSync(path.dirname(cacheFilePath()), { recursive: true });
+    fs.writeFileSync(
+      cacheFilePath(),
+      JSON.stringify({
+        version: 2,
+        updatedAt: new Date().toISOString(),
+        workspaces: [workspace("a", "Papr")],
+        namespacesByOrgId: {},
+      }),
+      "utf8",
+    );
+
+    expect(readCachedWorkspaces(USER)).toBeNull();
+  });
+
+  it("treats a corrupt file as a miss and recovers on the next write", () => {
+    fs.mkdirSync(path.dirname(cacheFilePath()), { recursive: true });
+    fs.writeFileSync(cacheFilePath(), "{ truncated", "utf8");
+
+    expect(readCachedWorkspaces(USER)).toBeNull();
+
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+    expect(readCachedWorkspaces(USER)?.data).toHaveLength(1);
+  });
+
+  it("marks a cache past the freshness window as stale but still usable", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+    vi.advanceTimersByTime(CACHE_FRESH_MS + 1_000);
+
+    const read = readCachedWorkspaces(USER);
+    expect(read?.data).toHaveLength(1);
+    expect(read?.isStale).toBe(true);
+  });
+
+  it("treats a cache past the max age as a miss", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+    vi.advanceTimersByTime(CACHE_MAX_AGE_MS + 1_000);
+
+    expect(readCachedWorkspaces(USER)).toBeNull();
+  });
+
+  it("refuses to replace a populated workspace list with an empty one", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr"), workspace("b", "Acme", "ns-2")]);
+    writeCachedWorkspaces(USER, []);
+
+    expect(readCachedWorkspaces(USER)?.data).toHaveLength(2);
+  });
+
+  it("accepts a smaller non-empty list as a real membership change", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr"), workspace("b", "Acme", "ns-2")]);
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+
+    expect(readCachedWorkspaces(USER)?.data.map((entry) => entry.id)).toEqual(["a"]);
+  });
+
+  it("writes the first list even though it grows from nothing", () => {
+    writeCachedWorkspaces(USER, []);
+    expect(readCachedWorkspaces(USER)).toBeNull();
+
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+    expect(readCachedWorkspaces(USER)?.data).toHaveLength(1);
+  });
+});
+
+describe("namespace cache persistence", () => {
+  it("round-trips namespaces per organization", () => {
+    writeCachedNamespaces(USER, "org-1", [{ id: "ns-1", name: "prod" }]);
+
+    expect(readCachedNamespaces(USER, "org-1")?.data).toEqual([
+      { id: "ns-1", name: "prod" },
+    ]);
+    expect(readCachedNamespaces(USER, "org-2")).toBeNull();
+  });
+
+  it("ages each organization independently", () => {
+    writeCachedNamespaces(USER, "org-1", [{ id: "ns-1", name: "prod" }]);
+    vi.advanceTimersByTime(CACHE_FRESH_MS + 1_000);
+    writeCachedNamespaces(USER, "org-2", [{ id: "ns-2", name: "dev" }]);
+
+    expect(readCachedNamespaces(USER, "org-1")?.isStale).toBe(true);
+    expect(readCachedNamespaces(USER, "org-2")?.isStale).toBe(false);
+  });
+
+  it("refuses to replace populated namespaces with an empty list", () => {
+    writeCachedNamespaces(USER, "org-1", [{ id: "ns-1", name: "prod" }]);
+    writeCachedNamespaces(USER, "org-1", []);
+
+    expect(readCachedNamespaces(USER, "org-1")?.data).toHaveLength(1);
+  });
+
+  it("keeps namespaces when the workspace list is rewritten", () => {
+    writeCachedNamespaces(USER, "org-1", [{ id: "ns-1", name: "prod" }]);
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+
+    expect(readCachedNamespaces(USER, "org-1")?.data).toHaveLength(1);
+  });
+
+  // Entries accumulated forever before this, which is how a cache ends up with
+  // more organizations than the user has workspaces.
+  it("prunes namespace entries past the max age on the next write", () => {
+    writeCachedNamespaces(USER, "org-old", [{ id: "ns-old", name: "old" }]);
+    vi.advanceTimersByTime(CACHE_MAX_AGE_MS + 1_000);
+
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+
+    expect(readFileRaw().namespacesByOrgId).toEqual({});
+  });
+});
+
+describe("clearPaprWorkspaceCache", () => {
+  it("removes the cache so the next account starts clean", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+    clearPaprWorkspaceCache();
+
+    expect(fs.existsSync(cacheFilePath())).toBe(false);
+    expect(readCachedWorkspaces(USER)).toBeNull();
+  });
+
+  it("is safe to call when no cache exists", () => {
+    expect(() => clearPaprWorkspaceCache()).not.toThrow();
+  });
+});

--- a/tests/parse-transport.test.ts
+++ b/tests/parse-transport.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  coalesce,
+  isTransientTransportError,
+  parseFetch,
+  ParseCircuitOpenError,
+  resetParseTransportState,
+} from "../src/electron/ipc/parseTransport.js";
+
+const URL_A = "https://parse.test/graphql";
+
+function jsonResponse(status = 200): Response {
+  return new Response(JSON.stringify({ data: {} }), { status });
+}
+
+function connectionReset(): Error {
+  const error = new TypeError("fetch failed");
+  (error as Error & { cause?: unknown }).cause = Object.assign(
+    new Error("read ECONNRESET"),
+    { code: "ECONNRESET" },
+  );
+  return error;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  resetParseTransportState();
+  vi.useFakeTimers();
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  resetParseTransportState();
+});
+
+/**
+ * Drive fake timers until the promise settles, so backoff sleeps resolve.
+ *
+ * Advances in small steps and stops as soon as it settles: over-advancing would
+ * push the mocked clock past the circuit-breaker window and change behaviour.
+ */
+async function settle<T>(promise: Promise<T>): Promise<T> {
+  let settled = false;
+  const raced = promise.then(
+    (value) => {
+      settled = true;
+      return { ok: true as const, value };
+    },
+    (error: unknown) => {
+      settled = true;
+      return { ok: false as const, error };
+    },
+  );
+
+  for (let i = 0; i < 200 && !settled; i++) {
+    await vi.advanceTimersByTimeAsync(25);
+  }
+
+  const result = await raced;
+  if (result.ok) return result.value;
+  throw result.error;
+}
+
+describe("isTransientTransportError", () => {
+  it("treats connection resets and 5xx as retryable", () => {
+    expect(isTransientTransportError(connectionReset())).toBe(true);
+    expect(isTransientTransportError(new Error("Parse error: 503 busy"))).toBe(true);
+    expect(isTransientTransportError(new Error("ETIMEDOUT"))).toBe(true);
+  });
+
+  it("does not retry auth or validation failures", () => {
+    expect(isTransientTransportError(new Error("Parse error: 401 bad token"))).toBe(
+      false,
+    );
+    expect(isTransientTransportError(new Error("Invalid session"))).toBe(false);
+  });
+});
+
+describe("parseFetch retry", () => {
+  it("retries a connection reset and succeeds", async () => {
+    fetchMock
+      .mockRejectedValueOnce(connectionReset())
+      .mockResolvedValueOnce(jsonResponse());
+
+    const response = await settle(parseFetch(URL_A));
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after the attempt budget instead of retrying forever", async () => {
+    fetchMock.mockRejectedValue(connectionReset());
+
+    await expect(settle(parseFetch(URL_A))).rejects.toThrow();
+
+    // 3 attempts by default — not an unbounded retry loop.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry a 4xx", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(403));
+
+    const response = await settle(parseFetch(URL_A));
+
+    expect(response.status).toBe(403);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("honours maxAttempts: 1 for mutations", async () => {
+    fetchMock.mockRejectedValue(connectionReset());
+
+    await expect(settle(parseFetch(URL_A, { maxAttempts: 1 }))).rejects.toThrow();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes an abort signal so a hung socket cannot be held open", async () => {
+    fetchMock.mockResolvedValue(jsonResponse());
+
+    await settle(parseFetch(URL_A));
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("parseFetch concurrency cap", () => {
+  it("never opens more than the cap against one origin at a time", async () => {
+    let active = 0;
+    let peak = 0;
+
+    fetchMock.mockImplementation(async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      active -= 1;
+      return jsonResponse();
+    });
+
+    const requests = Array.from({ length: 20 }, () => parseFetch(URL_A));
+    await settle(Promise.all(requests));
+
+    expect(fetchMock).toHaveBeenCalledTimes(20);
+    expect(peak).toBeLessThanOrEqual(4);
+  });
+});
+
+describe("parseFetch circuit breaker", () => {
+  it("stops calling an origin that keeps failing", async () => {
+    fetchMock.mockRejectedValue(connectionReset());
+
+    // Two calls × 3 attempts = 6 consecutive failures, hitting the threshold.
+    await expect(settle(parseFetch(URL_A))).rejects.toThrow();
+    await expect(settle(parseFetch(URL_A))).rejects.toThrow();
+    const callsBeforeOpen = fetchMock.mock.calls.length;
+
+    // No timer advance: within the open window the call must fail immediately,
+    // without reaching the network.
+    await expect(parseFetch(URL_A)).rejects.toBeInstanceOf(ParseCircuitOpenError);
+
+    expect(fetchMock.mock.calls.length).toBe(callsBeforeOpen);
+  });
+
+  it("probes again after the open window and closes on success", async () => {
+    fetchMock.mockRejectedValue(connectionReset());
+    await expect(settle(parseFetch(URL_A))).rejects.toThrow();
+    await expect(settle(parseFetch(URL_A))).rejects.toThrow();
+    await expect(settle(parseFetch(URL_A))).rejects.toBeInstanceOf(
+      ParseCircuitOpenError,
+    );
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(jsonResponse());
+
+    const response = await settle(parseFetch(URL_A));
+    expect(response.status).toBe(200);
+
+    // Circuit closed, so normal traffic flows again.
+    const next = await settle(parseFetch(URL_A));
+    expect(next.status).toBe(200);
+  });
+});
+
+describe("coalesce", () => {
+  it("shares one run between concurrent callers with the same key", async () => {
+    const run = vi.fn(
+      () => new Promise<string>((resolve) => setTimeout(() => resolve("value"), 10)),
+    );
+
+    const results = await settle(
+      Promise.all([
+        coalesce("k", run),
+        coalesce("k", run),
+        coalesce("k", run),
+      ]),
+    );
+
+    expect(results).toEqual(["value", "value", "value"]);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not share across different keys", async () => {
+    const run = vi.fn(() => Promise.resolve("value"));
+
+    await settle(Promise.all([coalesce("a", run), coalesce("b", run)]));
+
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the key so later callers run again", async () => {
+    const run = vi.fn(() => Promise.resolve("value"));
+
+    await settle(coalesce("k", run));
+    await settle(coalesce("k", run));
+
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates a rejection to every waiter and clears the key", async () => {
+    const failing = vi.fn(() => Promise.reject(new Error("boom")));
+
+    const first = coalesce("k", failing);
+    const second = coalesce("k", failing);
+
+    await expect(settle(first)).rejects.toThrow("boom");
+    await expect(settle(second)).rejects.toThrow("boom");
+    expect(failing).toHaveBeenCalledTimes(1);
+
+    await expect(settle(coalesce("k", failing))).rejects.toThrow("boom");
+    expect(failing).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/components/Sidebar/ProfileFooter.tsx
+++ b/ui/components/Sidebar/ProfileFooter.tsx
@@ -54,6 +54,13 @@ export function ProfileFooter({ onOpenProfile, onOpenSettings }: ProfileFooterPr
       void loadProfile({ force: true });
     };
 
+    // The workspace cache is rewritten by background Parse refreshes, and the
+    // reload this triggers is what starts those refreshes. Throttling it keeps
+    // the two from driving each other.
+    const refreshFromCacheUpdate = () => {
+      void loadProfile({ force: true, throttle: true });
+    };
+
     window.addEventListener("papr-auth-success", refresh);
     window.addEventListener("papr-logout-success", refresh);
     window.addEventListener("papr-organization-changed", refresh);
@@ -63,7 +70,7 @@ export function ProfileFooter({ onOpenProfile, onOpenSettings }: ProfileFooterPr
     window.electronAPI.papr.onLogoutSuccess(refresh);
     window.electronAPI.papr.onOrganizationChanged(refresh);
     window.electronAPI.papr.onNamespaceChanged(refresh);
-    window.electronAPI.papr.onWorkspaceCacheUpdated(refresh);
+    window.electronAPI.papr.onWorkspaceCacheUpdated(refreshFromCacheUpdate);
 
     return () => {
       window.removeEventListener("papr-auth-success", refresh);
@@ -75,7 +82,9 @@ export function ProfileFooter({ onOpenProfile, onOpenSettings }: ProfileFooterPr
       window.electronAPI.papr.removeLogoutSuccessListener(refresh);
       window.electronAPI.papr.removeOrganizationChangedListener(refresh);
       window.electronAPI.papr.removeNamespaceChangedListener(refresh);
-      window.electronAPI.papr.removeWorkspaceCacheUpdatedListener(refresh);
+      window.electronAPI.papr.removeWorkspaceCacheUpdatedListener(
+        refreshFromCacheUpdate,
+      );
     };
   }, [loadProfile]);
 

--- a/ui/stores/profileStore.ts
+++ b/ui/stores/profileStore.ts
@@ -25,7 +25,15 @@ interface ProfileState {
   namespaceName: string;
   workspaceName: string;
   loaded: boolean;
-  loadProfile: (options?: { force?: boolean }) => Promise<void>;
+  loadProfile: (options?: {
+    force?: boolean;
+    /**
+     * Skip the refresh if one completed very recently. For background triggers
+     * (workspace cache rewrites) where staleness is cheap — never for user
+     * actions like switching org, which must be reflected immediately.
+     */
+    throttle?: boolean;
+  }) => Promise<void>;
   setProfile: (profile: {
     name?: string;
     email?: string;
@@ -41,6 +49,10 @@ const cached = readProfileSidebarCache();
 
 let refreshInFlight: Promise<void> | null = null;
 let profileImageRetryInFlight: Promise<void> | null = null;
+
+/** Shortest gap between background (throttled) refreshes. */
+const MIN_FORCED_REFRESH_INTERVAL_MS = 10_000;
+let lastRefreshAt = 0;
 
 function persistProfileSnapshot(state: {
   name: string;
@@ -248,9 +260,21 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
   loadProfile: async (options) => {
     const force = options?.force === true;
     if (!force && get().loaded) return;
+
+    // Join the running refresh rather than queueing another one behind it.
+    // Previously a forced call awaited the in-flight promise and then started a
+    // second pass, so N concurrent workspace events produced N full refreshes
+    // (profile + plan + workspace list) instead of one.
     if (refreshInFlight) {
       await refreshInFlight;
-      if (!force) return;
+      return;
+    }
+
+    if (
+      options?.throttle === true &&
+      Date.now() - lastRefreshAt < MIN_FORCED_REFRESH_INTERVAL_MS
+    ) {
+      return;
     }
 
     refreshInFlight = (async () => {
@@ -276,6 +300,7 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
         console.error("[ProfileStore] Load error:", err);
         set({ loaded: true });
       } finally {
+        lastRefreshAt = Date.now();
         refreshInFlight = null;
       }
     })();


### PR DESCRIPTION
## What went wrong

Two symptoms from the same incident: the terminal flooded with `Transient Parse error … retrying` and `ECONNRESET` until the gateway health check killed the gateway, and a user was stranded in one workspace unable to see or switch to the others.

**The storm was a feedback loop.** `ProfileFooter` refreshed the profile on six separate events, one of which — `papr:workspace-cache-updated` — was emitted *by the refresh itself*. A partial Parse failure made the fetched workspace list differ from the cache, which re-notified the renderer, which refreshed again. Node's `fetch` places no cap on concurrent sockets per origin, so each cycle opened more, `server.papr.ai` shed them as `ECONNRESET`, and retrying those resets produced more load than the original burst. A degraded server could never recover.

**The cache made a display bug permanent.** `writePaprWorkspaceCache` ran `dedupeCachedWorkspaces` *before* writing, so only post-dedupe rows reached disk. When the dedupe logic was wrong it wrote a truncated list, the original rows were gone, and no later fix could recover them — deleting the JSON file by hand was the only way out.

## Changes

### Bounded Parse transport (new `src/electron/ipc/parseTransport.ts`)

- 4 concurrent sockets per origin, so a burst queues instead of opening a socket each
- 20s timeout per attempt, so a hung socket cannot be held open
- Jittered exponential backoff, so parallel callers stop retrying in lockstep
- Circuit breaker: fail fast for 30s after 6 consecutive failures, then let a single probe through
- Request coalescing, so identical concurrent reads share one round trip

All Parse calls in `paprLogin.ts` and `paprProfileSync.ts` route through it. Non-idempotent mutations pass `maxAttempts: 1`.

### Breaking the loop

- Cache-updated notifications throttled to once per 15s
- A partial failure can no longer overwrite a populated cache with an empty list
- Background workspace refreshes single-flighted
- `loadProfile` genuinely deduplicates concurrent calls instead of chaining them
- Plan summaries cached for 60s, so Stripe is not hit on every profile load (this removes the repeated `Forbidden` lookups)
- Namespace and workspace refreshes now fire only when the cached entry is **stale**, not on every cache hit

### Workspace cache hardening

| Defect | Fix |
|---|---|
| Dedupe applied on write, destroying rows on disk | Store verbatim, dedupe on read |
| Single global file, no owner; logout never cleared it | Scope to `userId`, mismatch is a miss, clear on logout |
| `updatedAt` written but read by nothing | `fetchedAt` per section; reads return `ageMs` / `isStale` |
| Non-empty stale list served forever | Fresh < 5 min, stale refreshes behind the response, miss > 7 days |
| Namespace entries only ever added | Pruned by age |
| A failed fetch could empty the cache | Writes that would empty it are refused |
| `writeFileSync` non-atomic; a partial file reads as "no cache" | Temp file + rename |

Two judgement calls worth reviewing: a *smaller but non-empty* list is accepted (logged, not blocked) because that can be a genuine membership change, and namespaces are pruned by **age rather than workspace membership** because a workspace can host several orgs and the switcher caches namespaces for orgs that never appear as any workspace's primary org.

No mutex was added: these writes are synchronous and only the main process touches the file, so the read-modify-write cannot interleave. The atomic rename is for crashes mid-write, not concurrency.

### Diagnostics

`fetchUserWorkspaces` silently discarded membership rows whose organization had no name. It now logs how many rows Parse returned versus how many were kept, and why any were dropped — this is what will confirm whether the missing org is excluded server-side by the `isMember` filter or client-side by that check.

## Testing

63 tests pass across the 8 files covering this code, including 32 new ones:

- `tests/parse-transport.test.ts` (14) — concurrency cap, retry, circuit breaker, timeout, coalescing
- `tests/papr-workspace-cache-store.test.ts` (18) — user scoping, cross-account isolation, TTL, shrink guard, atomic recovery from a corrupt file, age pruning, and a regression test asserting the file on disk keeps both raw rows while the read collapses to one
- `tests/papr-workspace-cache-dedupe.test.ts` — extended for distinctly-named workspaces resolving to the same developer org

`tsc --noEmit` and `oxlint` clean on all changed files.

## Notes for the reviewer

- The first launch after this refetches once: existing v2 cache files carry no `userId`, so they are intentionally discarded rather than attributed to whoever is signed in.
- The cross-account leak is the most severe item here and is independent of the reported bug — worth confirming the logout path in review.

Made with [Cursor](https://cursor.com)