### PR TITLE
fix: App Files source resolution and Turso primary-key loss

### DIFF
--- a/src/core/agents/SystemPrompt.ts
+++ b/src/core/agents/SystemPrompt.ts
@@ -2508,6 +2508,16 @@ await papr.files.remove(id);
 - Never \`FileReader.readAsDataURL()\` or \`.arrayBuffer()\` a large file — that pulls the whole thing into memory. Pass the \`File\`/\`Blob\` straight to \`upload()\`.
 - Do not compress video/audio before upload: already-compressed formats gain nothing, and \`Content-Encoding\` breaks range requests (video seeking).
 
+**Jobs that PRODUCE files (recorders, exporters, scrapers) — register at creation:**
+- A job has a path, not a Blob, so it uses the Python helper rather than the browser SDK. No pip install; it is on \`PYTHONPATH\` already:
+\`\`\`python
+from papr_files import add
+file_id = add("data/recordings/abc.wav", scope="user")   # "user" = private even if app is published
+con.execute("UPDATE meetings SET audio_ref=? WHERE id=?", (file_id, mid))
+\`\`\`
+- **NEVER store an absolute path in a database column.** It breaks when the workspace moves, means nothing on another machine, and is empty for every visitor to a published app. Store the file id; the app resolves it with \`papr.files.url(id)\`.
+- Registration must not be able to fail the work that produced the file: wrap it so a recording is never lost because a storage call errored.
+
 **Do NOT manually deploy** mini-apps to Vercel, Netlify, or custom domains as a cloud substitute — Papr auto-publish is the supported path. If \`/api/db/write\` returns 404 on a custom URL, the deployment is wrong (incomplete API shim), **not** missing Papr support — do not route INSERTs through \`/api/db/query\` workarounds. On \`apps.papr.ai\`, \`/api/db/write\` exists and returns \`lastInsertRowid\`. Users opt out in Settings → Cloud Sync if needed.
 
 **Cloud sharing tools (apps.papr.ai — NOT the same as export_app_bundle):**

--- a/src/electron/ipc/paprBilling.ts
+++ b/src/electron/ipc/paprBilling.ts
@@ -339,6 +339,57 @@ async function resolveWorkspaceRole(
   return self?.user.role ?? "member";
 }
 
+/**
+ * Short-lived cache for the read-only plan summary.
+ *
+ * Every profile load asks for this, and building it costs two Parse queries plus
+ * two dashboard.papr.ai calls (Stripe subscription + usage metrics). Plans do not
+ * change second to second, so a brief cache removes almost all of that traffic
+ * without the UI ever looking stale. Billing mutations invalidate it explicitly.
+ */
+const PLAN_SUMMARY_TTL_MS = 60_000;
+
+let planSummaryCache:
+  | { key: string; expiresAt: number; summary: PaprPlanSummary }
+  | null = null;
+let planSummaryInFlight: { key: string; promise: Promise<PaprPlanSummary> } | null =
+  null;
+
+function invalidatePlanSummaryCache(): void {
+  planSummaryCache = null;
+}
+
+/** Plan summary for read paths: cached, and concurrent callers share one build. */
+async function getPlanSummaryCached(
+  services: BillingServices,
+): Promise<PaprPlanSummary> {
+  const profile = requireLoggedInProfile(services.settingsStorage);
+  const key = `${profile.workspaceId}:${profile.organizationId}`;
+
+  if (planSummaryCache?.key === key && planSummaryCache.expiresAt > Date.now()) {
+    return planSummaryCache.summary;
+  }
+  if (planSummaryInFlight?.key === key) {
+    return planSummaryInFlight.promise;
+  }
+
+  const promise = buildPlanSummary(services)
+    .then((summary) => {
+      planSummaryCache = {
+        key,
+        expiresAt: Date.now() + PLAN_SUMMARY_TTL_MS,
+        summary,
+      };
+      return summary;
+    })
+    .finally(() => {
+      planSummaryInFlight = null;
+    });
+
+  planSummaryInFlight = { key, promise };
+  return promise;
+}
+
 async function buildPlanSummary(services: BillingServices): Promise<PaprPlanSummary> {
   const profile = requireLoggedInProfile(services.settingsStorage);
 
@@ -548,7 +599,7 @@ export function registerPaprBillingHandlers(deps: {
 
   ipcMain.handle("papr:get-plan-summary", async () => {
     try {
-      const summary = await buildPlanSummary(services);
+      const summary = await getPlanSummaryCached(services);
       persistPlanSummaryToProfile(deps.settingsStorage, summary);
       return { success: true, summary };
     } catch (error) {
@@ -653,6 +704,7 @@ export function registerPaprBillingHandlers(deps: {
         },
       });
 
+      invalidatePlanSummaryCache();
       return { success: true, enabled };
     } catch (error) {
       return {

--- a/src/electron/ipc/paprLogin.ts
+++ b/src/electron/ipc/paprLogin.ts
@@ -27,10 +27,11 @@ import {
   stopPaprAuthCallbackServer,
 } from "./paprAuthCallbackServer.js";
 import {
-  cacheNamespacesForOrg,
-  getCachedNamespaces,
-  readPaprWorkspaceCache,
-  writePaprWorkspaceCache,
+  clearPaprWorkspaceCache,
+  readCachedNamespaces,
+  readCachedWorkspaces,
+  writeCachedNamespaces,
+  writeCachedWorkspaces,
   type CachedWorkspace,
 } from "./paprWorkspaceCache.js";
 import {
@@ -38,6 +39,7 @@ import {
   sendWorkspaceInvite,
 } from "./paprWorkspaceTeam.js";
 import { registerPaprBillingHandlers } from "./paprBilling.js";
+import { coalesce, parseFetch } from "./parseTransport.js";
 import * as crypto from "crypto";
 import path from "node:path";
 import { getPaprDataDir } from "../../core/utils/paprRoot.js";
@@ -673,68 +675,46 @@ type ParseGraphQLJson = {
   [key: string]: ParseGraphQLJson | ParseGraphQLJson[] | string | number | boolean | null | undefined;
 };
 
-function isTransientParseError(error: unknown): boolean {
-  const msg = error instanceof Error ? error.message : String(error);
-  const cause = error instanceof Error && "cause" in error ? String(error.cause) : "";
-  const combined = `${msg} ${cause}`;
-  return (
-    combined.includes("Invalid server state") ||
-    combined.includes("ECONNRESET") ||
-    combined.includes("fetch failed") ||
-    combined.includes("ETIMEDOUT") ||
-    combined.includes("503") ||
-    combined.includes("502") ||
-    /Parse GraphQL error: 5\d\d/.test(combined)
-  );
-}
-
 // ─── Parse GraphQL Client ──────────────────────────────────────
 
+/**
+ * Run a Parse GraphQL operation.
+ *
+ * Connection pooling, timeouts, jittered retry and circuit breaking all live in
+ * `parseTransport`, shared with the profile-sync client so both compete for the
+ * same bounded set of sockets rather than each opening its own.
+ */
 async function parseGraphQL(
   sessionToken: string,
   query: string,
   variables: Record<string, unknown>,
+  options: { maxAttempts?: number } = {},
 ): Promise<ParseGraphQLJson> {
-  let lastError: unknown;
-  const maxAttempts = 4;
+  const response = await parseFetch(PARSE_GRAPHQL_URL, {
+    method: "POST",
+    maxAttempts: options.maxAttempts,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Parse-Application-Id": PARSE_APP_ID,
+      "X-Parse-Session-Token": sessionToken,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const response = await fetch(PARSE_GRAPHQL_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Parse-Application-Id": PARSE_APP_ID,
-          "X-Parse-Session-Token": sessionToken,
-        },
-        body: JSON.stringify({ query, variables }),
-      });
-
-      if (!response.ok) {
-        const text = await response.text();
-        throw new Error(`Parse GraphQL error: ${response.status} ${text}`);
-      }
-
-      const result = (await response.json()) as { data?: Record<string, unknown>; errors?: unknown[] };
-      if (result.errors) {
-        throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
-      }
-
-      return (result.data ?? {}) as ParseGraphQLJson;
-    } catch (error) {
-      lastError = error;
-      if (!isTransientParseError(error) || attempt === maxAttempts) {
-        throw error;
-      }
-      const delayMs = 300 * 2 ** (attempt - 1);
-      console.warn(
-        `[PaprLogin] Transient Parse error (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs}ms...`,
-      );
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-    }
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Parse GraphQL error: ${response.status} ${text}`);
   }
 
-  throw lastError;
+  const result = (await response.json()) as {
+    data?: Record<string, unknown>;
+    errors?: unknown[];
+  };
+  if (result.errors) {
+    throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
+  }
+
+  return (result.data ?? {}) as ParseGraphQLJson;
 }
 
 // ─── GraphQL Mutations (matching papr-dev-platform) ────────────
@@ -1245,13 +1225,24 @@ async function fetchUserWorkspaces(
     };
   };
 
+  const edges = data.workspace_followers?.edges ?? [];
   const workspaces: UserWorkspaceOption[] = [];
-  for (const edge of data.workspace_followers?.edges ?? []) {
+  const skipped: string[] = [];
+
+  for (const edge of edges) {
     const node = edge.node;
 
     const workspace = node?.workspace;
     const organization = workspace?.organization;
     if (!node?.objectId || !workspace?.objectId || !organization?.objectId || !organization.name) {
+      // A membership row that fails these checks disappears from the switcher
+      // with no trace, which makes "my workspace is missing" impossible to
+      // diagnose from logs. Record why it was dropped.
+      skipped.push(
+        `${workspace?.workspace_name ?? workspace?.objectId ?? "unknown"} ` +
+          `(follower=${node?.objectId ?? "none"}, org=${organization?.objectId ?? "none"}, ` +
+          `orgName=${JSON.stringify(organization?.name ?? null)})`,
+      );
       continue;
     }
 
@@ -1291,6 +1282,17 @@ async function fetchUserWorkspaces(
 
   workspaces.sort((a, b) =>
     workspaceDisplayName(a).localeCompare(workspaceDisplayName(b)),
+  );
+
+  if (skipped.length > 0) {
+    console.warn(
+      `[PaprLogin] Dropped ${skipped.length} of ${edges.length} workspace membership ` +
+        `rows (incomplete organization data): ${skipped.join("; ")}`,
+    );
+  }
+  console.log(
+    `[PaprLogin] Parse returned ${edges.length} workspace membership rows, ` +
+      `kept ${workspaces.length}: ${workspaces.map(workspaceDisplayName).join(", ") || "none"}`,
   );
 
   return workspaces;
@@ -1379,16 +1381,20 @@ async function fetchUserWorkspacesWithRefresh(
   customKeysStorage: CustomKeysStorage,
   settingsStorage: SettingsStorage,
 ): Promise<UserWorkspaceOption[]> {
-  const graphql: GraphQLExecutor = (query, variables) =>
-    parseGraphQLWithRefresh(
-      profile.sessionToken!,
-      query,
-      variables,
-      customKeysStorage,
-      settingsStorage,
-    );
+  // This is a three-query fan-out (workspaces, owned orgs, developer org) and
+  // several callers can want it at once; they share one pass.
+  return coalesce(`parse:workspaces:${profile.userId}`, () => {
+    const graphql: GraphQLExecutor = (query, variables) =>
+      parseGraphQLWithRefresh(
+        profile.sessionToken!,
+        query,
+        variables,
+        customKeysStorage,
+        settingsStorage,
+      );
 
-  return fetchUserWorkspaces(profile.userId!, graphql);
+    return fetchUserWorkspaces(profile.userId!, graphql);
+  });
 }
 
 type PaprProfile = NonNullable<ReturnType<SettingsStorage["getPaprProfile"]>>;
@@ -2069,6 +2075,14 @@ interface OrgNamespaceListItem {
   environmentType?: string;
 }
 
+/**
+ * The user the workspace cache belongs to. Reads and writes are scoped by this,
+ * so a cache written before a logout is never served to the next account.
+ */
+function cacheUserId(settingsStorage: SettingsStorage): string {
+  return settingsStorage.getPaprProfile()?.userId ?? "";
+}
+
 async function fetchOrgNamespaces(
   sessionToken: string,
   organizationId: string,
@@ -2115,12 +2129,25 @@ async function fetchOrgNamespaces(
 
   // Compare against what was cached BEFORE overwriting, so a background refresh
   // that discovers new/removed namespaces can wake the renderer up.
-  const previousCacheEntries = getCachedNamespaces(organizationId) ?? [];
+  const userId = cacheUserId(settingsStorage);
+  const previousCacheEntries = readCachedNamespaces(userId, organizationId)?.data ?? [];
   const changed =
     namespaceListSignature(previousCacheEntries) !==
     namespaceListSignature(nextCacheEntries);
 
-  cacheNamespacesForOrg(organizationId, nextCacheEntries);
+  // An empty result on top of a populated cache is almost always a partial
+  // failure upstream, not a real deletion. Overwriting here made the cache
+  // flip empty/populated on every pass, and each flip notified the renderer,
+  // which forced another refresh — load grew while Parse was degraded.
+  if (nextCacheEntries.length === 0 && previousCacheEntries.length > 0) {
+    console.warn(
+      `[PaprLogin] Namespace fetch for org ${organizationId} returned nothing; ` +
+        `keeping ${previousCacheEntries.length} cached entries`,
+    );
+    return previousCacheEntries.map((entry) => ({ ...entry }));
+  }
+
+  writeCachedNamespaces(userId, organizationId, nextCacheEntries);
 
   if (changed) {
     console.log(
@@ -2140,11 +2167,42 @@ async function fetchOrgNamespaces(
  * Without this, a background refresh rewrites the cache but the UI keeps showing
  * the stale list until a manual reload, so one bad cache write sticks forever.
  */
-function notifyWorkspaceCacheUpdated(): void {
+/**
+ * Minimum gap between cache-updated notifications.
+ *
+ * The renderer responds to this event with a full profile reload (profile +
+ * plan + workspace list), and that reload itself triggers the background
+ * refreshes that can emit this event. Throttling caps the cycle: even if the
+ * cache keeps changing, the renderer is woken at most once per window.
+ */
+const WORKSPACE_CACHE_NOTIFY_INTERVAL_MS = 15_000;
+
+let lastWorkspaceCacheNotifyAt = 0;
+let pendingWorkspaceCacheNotify: NodeJS.Timeout | null = null;
+
+function sendWorkspaceCacheUpdated(): void {
+  lastWorkspaceCacheNotifyAt = Date.now();
   const win = BrowserWindow.getAllWindows()[0];
   if (win && !win.isDestroyed()) {
     win.webContents.send("papr:workspace-cache-updated");
   }
+}
+
+function notifyWorkspaceCacheUpdated(): void {
+  if (pendingWorkspaceCacheNotify) return;
+
+  const elapsed = Date.now() - lastWorkspaceCacheNotifyAt;
+  if (elapsed >= WORKSPACE_CACHE_NOTIFY_INTERVAL_MS) {
+    sendWorkspaceCacheUpdated();
+    return;
+  }
+
+  // Trailing edge: coalesce the burst into one notification.
+  pendingWorkspaceCacheNotify = setTimeout(() => {
+    pendingWorkspaceCacheNotify = null;
+    sendWorkspaceCacheUpdated();
+  }, WORKSPACE_CACHE_NOTIFY_INTERVAL_MS - elapsed);
+  pendingWorkspaceCacheNotify.unref?.();
 }
 
 /** Stable signature for namespace cache change detection (order-insensitive). */
@@ -2216,6 +2274,16 @@ interface WorkspaceNamespaceGroup {
  * cache-updated event) would multiply that fan-out by the number of callers.
  */
 const backgroundNamespaceRefreshes = new Set<string>();
+
+/**
+ * Guard for the cache-first workspace refresh.
+ *
+ * `papr:list-organizations` answers from disk cache and refreshes behind it.
+ * Every profile reload calls it, so without this guard a burst of reloads each
+ * started its own Parse fan-out (workspaces + owned orgs + developer org +
+ * namespaces) against an origin that was already struggling.
+ */
+let backgroundWorkspaceRefreshRunning = false;
 
 function refreshOrgNamespacesInBackground(
   sessionToken: string,
@@ -3533,6 +3601,10 @@ export function initializePaprLoginIPC(
       await clearPersistedPkceState();
 
       settingsStorage.clearPaprProfile();
+      // The workspace cache is keyed by user, so a stale one would be ignored
+      // anyway — but leaving another account's workspace names on disk after a
+      // logout is not something to rely on scoping alone to hide.
+      clearPaprWorkspaceCache();
       await clearPaprUserIdFromGatewaySettings();
       try {
         const { clearMemoryPreviewCache } = await import(
@@ -3644,20 +3716,27 @@ export function initializePaprLoginIPC(
         }
 
         const forceRefresh = options?.forceRefresh === true;
-        const cached = forceRefresh ? null : getCachedNamespaces(organizationId);
+        const cached = forceRefresh
+          ? null
+          : readCachedNamespaces(cacheUserId(settingsStorage), organizationId);
         if (cached) {
-          void fetchOrgNamespaces(
-            profile.sessionToken,
-            organizationId,
-            customKeysStorage,
-            settingsStorage,
-          ).catch((error) => {
-            console.warn("[PaprLogin] Background namespace refresh failed:", error);
-          });
+          // Only chase a refresh once the entry is past its freshness window.
+          // Refreshing on every cache hit is what turned a routine settings
+          // render into a burst of Parse traffic.
+          if (cached.isStale) {
+            void fetchOrgNamespaces(
+              profile.sessionToken,
+              organizationId,
+              customKeysStorage,
+              settingsStorage,
+            ).catch((error) => {
+              console.warn("[PaprLogin] Background namespace refresh failed:", error);
+            });
+          }
 
           return {
             success: true,
-            namespaces: cached,
+            namespaces: cached.data,
             activeNamespaceId: profile.activeNamespaceId,
             parseOrganizationId: organizationId,
             fromCache: true,
@@ -3706,14 +3785,13 @@ export function initializePaprLoginIPC(
         const sessionToken = profile.sessionToken;
         const forceRefresh = options?.forceRefresh === true;
 
-        let workspaces: CachedWorkspace[] = readPaprWorkspaceCache()?.workspaces ?? [];
-        if (forceRefresh || workspaces.length === 0) {
+        const refreshWorkspaceCache = async (): Promise<CachedWorkspace[]> => {
           const fetched = await fetchUserWorkspacesWithRefresh(
             profile,
             customKeysStorage,
             settingsStorage,
           );
-          workspaces = fetched.map(
+          const rows = fetched.map(
             (workspace): CachedWorkspace => ({
               id: workspace.workspaceId,
               name: workspaceDisplayName(workspace),
@@ -3724,7 +3802,27 @@ export function initializePaprLoginIPC(
               defaultNamespaceId: workspace.defaultNamespaceId,
             }),
           );
-          writePaprWorkspaceCache({ workspaces });
+          writeCachedWorkspaces(profile.userId, rows);
+          return rows;
+        };
+
+        const cachedWorkspaces = forceRefresh
+          ? null
+          : readCachedWorkspaces(profile.userId);
+        let workspaces: CachedWorkspace[];
+
+        if (!cachedWorkspaces) {
+          workspaces = await refreshWorkspaceCache();
+        } else {
+          workspaces = cachedWorkspaces.data;
+          // Stale but usable: answer from cache so the picker stays instant, and
+          // repair the cache behind it. Serving a non-empty list forever without
+          // ever re-checking is how a wrong workspace list became permanent.
+          if (cachedWorkspaces.isStale) {
+            void refreshWorkspaceCache().catch((error) => {
+              console.warn("[PaprLogin] Background workspace refresh failed:", error);
+            });
+          }
         }
 
         const workspaceFilter = options?.workspaceId?.trim();
@@ -3802,15 +3900,19 @@ export function initializePaprLoginIPC(
                 organizationName,
               };
 
-              const cached = forceRefresh ? null : getCachedNamespaces(organizationId);
+              const cached = forceRefresh
+                ? null
+                : readCachedNamespaces(profile.userId, organizationId);
               if (cached) {
-                refreshOrgNamespacesInBackground(
-                  sessionToken,
-                  organizationId,
-                  customKeysStorage,
-                  settingsStorage,
-                );
-                return { ...base, namespaces: cached };
+                if (cached.isStale) {
+                  refreshOrgNamespacesInBackground(
+                    sessionToken,
+                    organizationId,
+                    customKeysStorage,
+                    settingsStorage,
+                  );
+                }
+                return { ...base, namespaces: cached.data };
               }
 
               try {
@@ -3872,8 +3974,8 @@ export function initializePaprLoginIPC(
         return { success: false, error: "Not logged in" };
       }
 
-      const diskCache = readPaprWorkspaceCache();
-      const cachedWorkspaces = diskCache?.workspaces ?? [];
+      const diskCache = readCachedWorkspaces(profile.userId);
+      const cachedWorkspaces = diskCache?.data ?? [];
 
       const buildResponse = (
         workspaces: UserWorkspaceOption[],
@@ -3902,64 +4004,88 @@ export function initializePaprLoginIPC(
       };
 
       if (cachedWorkspaces.length > 0) {
-        void fetchUserWorkspacesWithRefresh(profile, customKeysStorage, settingsStorage)
-          .then(async (workspaces) => {
-            const workspacesChanged =
-              workspaceListSignature(
-                cachedWorkspaces.map((workspace) => ({
-                  workspaceId: workspace.id,
-                  organizationId: workspace.organizationId,
-                  workspaceName: workspace.workspaceName ?? workspace.name,
-                })),
-              ) !== workspaceListSignature(workspaces);
-
-            writePaprWorkspaceCache({
-              workspaces: workspaces.map(
-                (workspace): CachedWorkspace => ({
-                  id: workspace.workspaceId,
-                  name: workspaceDisplayName(workspace),
-                  role: workspace.role,
-                  organizationId: workspace.organizationId,
-                  organizationName: workspace.organizationName,
-                  workspaceName: workspace.workspaceName,
-                  defaultNamespaceId: workspace.defaultNamespaceId,
-                }),
-              ),
-            });
-
-            if (workspacesChanged) {
-              console.log(
-                `[PaprLogin] Workspace cache changed ` +
-                  `(${cachedWorkspaces.length} -> ${workspaces.length}); notifying renderer`,
-              );
-              notifyWorkspaceCacheUpdated();
-            }
-
-            const active = await syncActiveWorkspaceOrganization(
-              profile,
-              workspaces,
-              settingsStorage,
-              customKeysStorage,
-            );
-            if (active?.organizationId && profile.sessionToken) {
-              try {
-                const namespaces = await fetchOrgNamespaces(
-                  profile.sessionToken,
-                  active.organizationId,
-                  customKeysStorage,
-                  settingsStorage,
+        // Refresh only once the cache is past its freshness window. This handler
+        // is called on every profile load, and refreshing unconditionally is
+        // what let a routine render fan out into repeated Parse round trips.
+        if (diskCache?.isStale && !backgroundWorkspaceRefreshRunning) {
+          backgroundWorkspaceRefreshRunning = true;
+          void fetchUserWorkspacesWithRefresh(profile, customKeysStorage, settingsStorage)
+            .then(async (workspaces) => {
+              // Same reasoning as the namespace cache: an empty list on top of a
+              // populated one means the fetch degraded, not that the user lost
+              // every workspace. Writing it would blank the switcher.
+              if (workspaces.length === 0) {
+                console.warn(
+                  `[PaprLogin] Workspace refresh returned nothing; keeping ` +
+                    `${cachedWorkspaces.length} cached workspaces`,
                 );
-                console.log(
-                  `[PaprLogin] Prefetched ${namespaces.length} namespaces for org ${active.organizationId}`,
-                );
-              } catch (error) {
-                console.warn("[PaprLogin] Background namespace prefetch failed:", error);
+                return;
               }
-            }
-          })
-          .catch((error) => {
-            console.warn("[PaprLogin] Background workspace refresh failed:", error);
-          });
+
+              const workspacesChanged =
+                workspaceListSignature(
+                  cachedWorkspaces.map((workspace) => ({
+                    workspaceId: workspace.id,
+                    organizationId: workspace.organizationId,
+                    workspaceName: workspace.workspaceName ?? workspace.name,
+                  })),
+                ) !== workspaceListSignature(workspaces);
+
+              writeCachedWorkspaces(
+                profile.userId,
+                workspaces.map(
+                  (workspace): CachedWorkspace => ({
+                    id: workspace.workspaceId,
+                    name: workspaceDisplayName(workspace),
+                    role: workspace.role,
+                    organizationId: workspace.organizationId,
+                    organizationName: workspace.organizationName,
+                    workspaceName: workspace.workspaceName,
+                    defaultNamespaceId: workspace.defaultNamespaceId,
+                  }),
+                ),
+              );
+
+              if (workspacesChanged) {
+                console.log(
+                  `[PaprLogin] Workspace cache changed ` +
+                    `(${cachedWorkspaces.length} -> ${workspaces.length}); notifying renderer`,
+                );
+                notifyWorkspaceCacheUpdated();
+              }
+
+              const active = await syncActiveWorkspaceOrganization(
+                profile,
+                workspaces,
+                settingsStorage,
+                customKeysStorage,
+              );
+              if (active?.organizationId && profile.sessionToken) {
+                try {
+                  const namespaces = await fetchOrgNamespaces(
+                    profile.sessionToken,
+                    active.organizationId,
+                    customKeysStorage,
+                    settingsStorage,
+                  );
+                  console.log(
+                    `[PaprLogin] Prefetched ${namespaces.length} namespaces for org ${active.organizationId}`,
+                  );
+                } catch (error) {
+                  console.warn(
+                    "[PaprLogin] Background namespace prefetch failed:",
+                    error,
+                  );
+                }
+              }
+            })
+            .catch((error) => {
+              console.warn("[PaprLogin] Background workspace refresh failed:", error);
+            })
+            .finally(() => {
+              backgroundWorkspaceRefreshRunning = false;
+            });
+        }
 
         const workspacesFromCache: UserWorkspaceOption[] = cachedWorkspaces.map(
           (workspace) => ({
@@ -3990,8 +4116,9 @@ export function initializePaprLoginIPC(
         settingsStorage,
       );
 
-      writePaprWorkspaceCache({
-        workspaces: workspaces.map(
+      writeCachedWorkspaces(
+        profile.userId,
+        workspaces.map(
           (workspace): CachedWorkspace => ({
             id: workspace.workspaceId,
             name: workspaceDisplayName(workspace),
@@ -4002,7 +4129,7 @@ export function initializePaprLoginIPC(
             defaultNamespaceId: workspace.defaultNamespaceId,
           }),
         ),
-      });
+      );
 
       const selected = workspaces.find((workspace) => workspace.isSelected);
       const activeWorkspaceId =

--- a/src/electron/ipc/paprProfileSync.ts
+++ b/src/electron/ipc/paprProfileSync.ts
@@ -3,6 +3,8 @@
  * Mirrors papr-dev-platform SettingsModal + parse-file-upload flow.
  */
 
+import { coalesce, parseFetch } from "./parseTransport.js";
+
 const PARSE_GRAPHQL_URL =
   process.env.PARSE_GRAPHQL_URL || "https://server.papr.ai/graphql";
 const PARSE_SERVER_URL =
@@ -132,17 +134,17 @@ const UPDATE_USER_DETAILS = `
   }
 `;
 
-const PARSE_GRAPHQL_TIMEOUT_MS = 90_000;
 const PARSE_FILE_UPLOAD_TIMEOUT_MS = 60_000;
 
 async function parseGraphQL(
   sessionToken: string,
   query: string,
   variables: Record<string, unknown>,
+  options: { maxAttempts?: number } = {},
 ): Promise<Record<string, unknown>> {
-  const response = await fetch(PARSE_GRAPHQL_URL, {
+  const response = await parseFetch(PARSE_GRAPHQL_URL, {
     method: "POST",
-    signal: AbortSignal.timeout(PARSE_GRAPHQL_TIMEOUT_MS),
+    maxAttempts: options.maxAttempts,
     headers: {
       "Content-Type": "application/json",
       "X-Parse-Application-Id": PARSE_APP_ID,
@@ -198,6 +200,15 @@ export async function fetchParseUserProfile(
   sessionToken: string,
   userId: string,
 ): Promise<ParseUserProfileDetails> {
+  // Several renderer triggers (app mount, sidebar, Settings profile tab) refresh
+  // the profile at once; they should share one round trip.
+  return coalesce(`parse:user:${userId}`, () => fetchParseUserProfileUncached(sessionToken, userId));
+}
+
+async function fetchParseUserProfileUncached(
+  sessionToken: string,
+  userId: string,
+): Promise<ParseUserProfileDetails> {
   const data = await parseGraphQL(sessionToken, GET_USER_DETAILS, { userId });
   const user = data.user as
     | {
@@ -233,11 +244,12 @@ export async function uploadProfileImageToParse(
     "_",
   );
 
-  const response = await fetch(
+  const response = await parseFetch(
     `${PARSE_SERVER_URL}/files/${encodeURIComponent(sanitizedFileName)}`,
     {
       method: "POST",
-      signal: AbortSignal.timeout(PARSE_FILE_UPLOAD_TIMEOUT_MS),
+      timeoutMs: PARSE_FILE_UPLOAD_TIMEOUT_MS,
+      maxAttempts: 1,
       headers: {
         "X-Parse-Application-Id": PARSE_APP_ID,
         "X-Parse-Session-Token": sessionToken,
@@ -269,9 +281,13 @@ export async function updateParseUserProfile(
     profileImage?: ParseProfileImageFilePointer;
   },
 ): Promise<{ profileImageUrl?: string }> {
-  const data = await parseGraphQL(sessionToken, UPDATE_USER_DETAILS, {
-    input: buildUpdateUserProfileGraphQLInput(userId, fields),
-  });
+  const data = await parseGraphQL(
+    sessionToken,
+    UPDATE_USER_DETAILS,
+    { input: buildUpdateUserProfileGraphQLInput(userId, fields) },
+    // Mutation — do not replay it on a transport error.
+    { maxAttempts: 1 },
+  );
   const user = (data.updateUser as { user?: { profileimage?: { url?: string } } })
     ?.user;
 

--- a/src/electron/ipc/paprWorkspaceCache.ts
+++ b/src/electron/ipc/paprWorkspaceCache.ts
@@ -1,5 +1,25 @@
 /**
  * Disk cache for Papr workspaces + namespaces (instant Settings load).
+ *
+ * The rules below are the ones a previous version of this cache broke, each of
+ * which stranded a user in a single workspace with no way out but deleting the
+ * file by hand:
+ *
+ *   1. Store what the server returned, verbatim. Dedupe and display naming are
+ *      applied on read, so a bug in either is a display bug we fix with a
+ *      deploy rather than permanent data loss on disk.
+ *   2. Scope to a user. The path is global, so an unlabelled cache serves the
+ *      previous account's workspaces after a logout and login.
+ *   3. Stamp each section with its fetch time and expose the age, so callers
+ *      can refresh stale data instead of treating any non-empty list as
+ *      authoritative forever.
+ *   4. Never let an upstream failure shrink the cache to nothing.
+ *   5. Write atomically. A half-written file parses as corrupt, and a corrupt
+ *      file reads as "no cache", silently discarding everything.
+ *
+ * Writes are synchronous and only the main process touches this file, so a
+ * read-modify-write cannot interleave and no lock is needed. The atomic rename
+ * is for crashes mid-write, not for concurrency.
  */
 
 import fs from "node:fs";
@@ -22,12 +42,28 @@ export interface CachedWorkspace {
   defaultNamespaceId?: string;
 }
 
-export interface PaprWorkspaceCacheFile {
-  version: 2;
-  updatedAt: string;
-  workspaces: CachedWorkspace[];
-  namespacesByOrgId: Record<string, CachedNamespace[]>;
+interface CachedNamespaceEntry {
+  fetchedAt: string;
+  namespaces: CachedNamespace[];
 }
+
+export interface PaprWorkspaceCacheFile {
+  version: 3;
+  /** Owner of this cache. A mismatch is a miss, never a fallback. */
+  userId: string;
+  workspacesFetchedAt: string;
+  /** Rows exactly as fetched. Deduped on read, never on write. */
+  workspaces: CachedWorkspace[];
+  namespacesByOrgId: Record<string, CachedNamespaceEntry>;
+}
+
+export const WORKSPACE_CACHE_VERSION = 3;
+
+/** Below this age, serve without triggering a refresh. */
+export const CACHE_FRESH_MS = 5 * 60_000;
+
+/** Above this age, treat as a miss — too old to show even briefly. */
+export const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60_000;
 
 const CACHE_FILENAME = "papr-workspace-cache.json";
 
@@ -36,91 +72,312 @@ function getCachePath(): string {
   return path.join(getPaprBaseDir(), "data", CACHE_FILENAME);
 }
 
-export function readPaprWorkspaceCache(): PaprWorkspaceCacheFile | null {
+function ageOf(fetchedAt: string | undefined): number {
+  const timestamp = fetchedAt ? Date.parse(fetchedAt) : Number.NaN;
+  return Number.isFinite(timestamp)
+    ? Math.max(0, Date.now() - timestamp)
+    : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * The stored file for this user, or null when there is nothing usable: no file,
+ * corrupt JSON, an older schema, or a cache belonging to a different account.
+ */
+function readForUser(userId: string): PaprWorkspaceCacheFile | null {
+  if (!userId) return null;
+
+  let parsed: PaprWorkspaceCacheFile;
   try {
-    const raw = fs.readFileSync(getCachePath(), "utf8");
-    const parsed = JSON.parse(raw) as PaprWorkspaceCacheFile;
-    if (parsed.version !== 2 || !Array.isArray(parsed.workspaces)) {
-      return null;
-    }
-    // Dedupe on read too, so caches written by older builds are cleaned up
-    // without requiring the user to log out and back in.
-    return { ...parsed, workspaces: dedupeCachedWorkspaces(parsed.workspaces) };
+    parsed = JSON.parse(
+      fs.readFileSync(getCachePath(), "utf8"),
+    ) as PaprWorkspaceCacheFile;
   } catch {
     return null;
   }
+
+  // Pre-v3 files carry no userId, so they cannot be attributed to an account.
+  // Discarding them costs one refetch and closes the cross-account leak.
+  if (parsed?.version !== WORKSPACE_CACHE_VERSION) return null;
+  if (!Array.isArray(parsed.workspaces)) return null;
+  if (!parsed.userId || parsed.userId !== userId) return null;
+
+  return {
+    ...parsed,
+    namespacesByOrgId: parsed.namespacesByOrgId ?? {},
+  };
+}
+
+function persist(next: PaprWorkspaceCacheFile): void {
+  const target = getCachePath();
+  const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(tmp, JSON.stringify(next, null, 2), "utf8");
+    fs.renameSync(tmp, target);
+  } catch (error) {
+    try {
+      fs.rmSync(tmp, { force: true });
+    } catch {
+      // Best effort — a stray temp file is harmless.
+    }
+    // A cache write failing must not break login or workspace switching.
+    console.warn("[PaprWorkspaceCache] Failed to write cache:", error);
+  }
+}
+
+/**
+ * Drop namespace entries past the usable age.
+ *
+ * Pruning by workspace membership would be wrong: a workspace can host several
+ * organizations, and the switcher caches namespaces for orgs that never appear
+ * as any workspace's primary org. Age is the only bound that cannot delete a
+ * still-reachable org.
+ */
+function pruneNamespaces(
+  entries: Record<string, CachedNamespaceEntry>,
+): Record<string, CachedNamespaceEntry> {
+  const kept: Record<string, CachedNamespaceEntry> = {};
+  for (const [orgId, entry] of Object.entries(entries)) {
+    if (!entry?.namespaces?.length) continue;
+    if (ageOf(entry.fetchedAt) > CACHE_MAX_AGE_MS) continue;
+    kept[orgId] = entry;
+  }
+  return kept;
+}
+
+/**
+ * The workspace name with Parse display artifacts removed, or null when nothing
+ * meaningful is left. A placeholder name cannot tell two rows apart.
+ */
+function meaningfulWorkspaceName(workspace: CachedWorkspace): string | null {
+  const raw = (workspace.workspaceName ?? workspace.name ?? "").trim();
+  // Parse renders the viewer's own workspace as "<orgName> (you)", and orgName is
+  // itself often literally "null" for personal workspaces.
+  const name = raw.replace(/\s*\(you\)\s*$/i, "").trim().toLowerCase();
+  if (!name || name === "null" || name === "undefined" || name === "workspace") {
+    return null;
+  }
+  return name;
+}
+
+/** Prefer a real name over "Workspace"/"null"/empty when collapsing rows. */
+function workspaceNameScore(workspace: CachedWorkspace): number {
+  const name = workspace.name?.trim().toLowerCase();
+  if (!name || name === "null" || name === "undefined") return 0;
+  if (name === "workspace") return 1;
+  return 2;
+}
+
+/** Org + namespace a row resolves to. Rows without a namespace stand alone. */
+function workspaceScopeKey(workspace: CachedWorkspace): string {
+  return workspace.defaultNamespaceId
+    ? `${workspace.organizationId ?? ""}::${workspace.defaultNamespaceId}`
+    : `id::${workspace.id}`;
 }
 
 /**
  * Collapse workspaces that resolve to the same org + namespace.
  *
  * Duplicate provisioning (and older builds that created a workspace on every
- * login) can leave several workspace rows pointing at one namespace. They are
- * indistinguishable to the user and make the switcher look broken, so keep the
- * best-named entry per org/namespace pair.
+ * login) can leave several workspace rows pointing at one namespace. Those are
+ * indistinguishable to the user and make the switcher look broken.
+ *
+ * Org + namespace alone is not enough to call two rows duplicates, though.
+ * `resolveNamespaceOrganizationId` maps every workspace where the user owns a
+ * non-matching org onto their single developer org, so genuinely different
+ * workspaces reach this function sharing an organizationId *and* a
+ * defaultNamespaceId. Keying on just those erased all but one, which is how a
+ * user ends up pinned to one workspace with nothing to switch to.
+ *
+ * So within a scope: rows with distinct real names are kept, and placeholder-named
+ * rows are absorbed into the named ones (or collapsed among themselves if no row
+ * in the scope has a real name).
+ *
+ * This runs on read only. The stored rows stay untouched, so a mistake here
+ * hides a workspace until the next deploy instead of destroying it on disk.
  */
 export function dedupeCachedWorkspaces(
   workspaces: CachedWorkspace[],
 ): CachedWorkspace[] {
-  const byScope = new Map<string, CachedWorkspace>();
+  /** scope → (name → best row), preserving first-seen order at both levels. */
+  const scopes = new Map<string, Map<string, CachedWorkspace>>();
+  const placeholders = new Map<string, CachedWorkspace>();
 
   for (const workspace of workspaces) {
-    // Entries without a namespace are not interchangeable — keep them by id.
-    const scopeKey = workspace.defaultNamespaceId
-      ? `${workspace.organizationId ?? ""}::${workspace.defaultNamespaceId}`
-      : `id::${workspace.id}`;
+    const scope = workspaceScopeKey(workspace);
+    const name = meaningfulWorkspaceName(workspace);
 
-    const existing = byScope.get(scopeKey);
-    if (!existing) {
-      byScope.set(scopeKey, workspace);
+    if (!name) {
+      const existing = placeholders.get(scope);
+      if (!existing || workspaceNameScore(workspace) > workspaceNameScore(existing)) {
+        placeholders.set(scope, workspace);
+      }
       continue;
     }
 
-    // Prefer the entry with a real name over "Workspace"/"null"/empty.
-    const score = (candidate: CachedWorkspace): number => {
-      const name = candidate.name?.trim().toLowerCase();
-      if (!name || name === "null" || name === "undefined") return 0;
-      if (name === "workspace") return 1;
-      return 2;
-    };
+    let named = scopes.get(scope);
+    if (!named) {
+      named = new Map<string, CachedWorkspace>();
+      scopes.set(scope, named);
+    }
 
-    if (score(workspace) > score(existing)) {
-      byScope.set(scopeKey, workspace);
+    const existing = named.get(name);
+    if (!existing || workspaceNameScore(workspace) > workspaceNameScore(existing)) {
+      named.set(name, workspace);
     }
   }
 
-  return [...byScope.values()];
+  const result: CachedWorkspace[] = [];
+  const emitted = new Set<string>();
+
+  // Walk the original order so the output is stable for callers and the UI.
+  for (const workspace of workspaces) {
+    const scope = workspaceScopeKey(workspace);
+    const named = scopes.get(scope);
+
+    if (!named) {
+      // Scope has no real name anywhere — emit the single best placeholder.
+      const placeholder = placeholders.get(scope);
+      if (placeholder && !emitted.has(scope)) {
+        emitted.add(scope);
+        result.push(placeholder);
+      }
+      continue;
+    }
+
+    const name = meaningfulWorkspaceName(workspace);
+    // Placeholder rows in a scope that has named rows are duplicates of them.
+    if (!name) continue;
+
+    const key = `${scope}::${name}`;
+    if (emitted.has(key)) continue;
+    emitted.add(key);
+    const best = named.get(name);
+    if (best) result.push(best);
+  }
+
+  return result;
 }
 
-export function writePaprWorkspaceCache(input: {
-  workspaces: CachedWorkspace[];
-  namespacesByOrgId?: Record<string, CachedNamespace[]>;
-}): void {
-  const existing = readPaprWorkspaceCache();
-  const next: PaprWorkspaceCacheFile = {
-    version: 2,
-    updatedAt: new Date().toISOString(),
-    workspaces: dedupeCachedWorkspaces(input.workspaces),
-    namespacesByOrgId: {
-      ...(existing?.namespacesByOrgId ?? {}),
-      ...(input.namespacesByOrgId ?? {}),
-    },
+export interface CachedRead<T> {
+  data: T;
+  ageMs: number;
+  /** Usable now, but a refresh should be kicked off. */
+  isStale: boolean;
+}
+
+/**
+ * Cached workspaces for this user, deduped for display, or null when there is
+ * nothing usable to show.
+ */
+export function readCachedWorkspaces(
+  userId: string,
+): CachedRead<CachedWorkspace[]> | null {
+  const file = readForUser(userId);
+  if (!file || file.workspaces.length === 0) return null;
+
+  const ageMs = ageOf(file.workspacesFetchedAt);
+  if (ageMs > CACHE_MAX_AGE_MS) return null;
+
+  return {
+    data: dedupeCachedWorkspaces(file.workspaces),
+    ageMs,
+    isStale: ageMs > CACHE_FRESH_MS,
   };
-
-  const dir = path.dirname(getCachePath());
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(getCachePath(), JSON.stringify(next, null, 2), "utf8");
 }
 
-export function getCachedNamespaces(orgId: string): CachedNamespace[] | null {
-  const cache = readPaprWorkspaceCache();
-  const list = cache?.namespacesByOrgId?.[orgId];
-  return list?.length ? list : null;
-}
+export function writeCachedWorkspaces(
+  userId: string,
+  workspaces: CachedWorkspace[],
+): void {
+  if (!userId) return;
+  const existing = readForUser(userId);
+  const existingCount = existing?.workspaces.length ?? 0;
 
-export function cacheNamespacesForOrg(orgId: string, namespaces: CachedNamespace[]): void {
-  writePaprWorkspaceCache({
-    workspaces: readPaprWorkspaceCache()?.workspaces ?? [],
-    namespacesByOrgId: { [orgId]: namespaces },
+  // Losing every workspace is nearly always a partial upstream failure rather
+  // than the user leaving all of them, and persisting it empties the switcher
+  // with no way back. A smaller-but-non-empty list can be a real membership
+  // change, so that one is logged and accepted rather than pinning the user to
+  // rows they no longer belong to.
+  if (workspaces.length === 0 && existingCount > 0) {
+    console.warn(
+      `[PaprWorkspaceCache] Refusing to replace ${existingCount} cached ` +
+        `workspaces with an empty list`,
+    );
+    return;
+  }
+  if (existingCount > 0 && workspaces.length < existingCount) {
+    console.log(
+      `[PaprWorkspaceCache] Workspace count fell from ${existingCount} to ` +
+        `${workspaces.length}; accepting as a membership change`,
+    );
+  }
+
+  persist({
+    version: WORKSPACE_CACHE_VERSION,
+    userId,
+    workspacesFetchedAt: new Date().toISOString(),
+    workspaces,
+    namespacesByOrgId: pruneNamespaces(existing?.namespacesByOrgId ?? {}),
   });
+}
+
+export function readCachedNamespaces(
+  userId: string,
+  orgId: string,
+): CachedRead<CachedNamespace[]> | null {
+  const entry = readForUser(userId)?.namespacesByOrgId?.[orgId];
+  if (!entry?.namespaces?.length) return null;
+
+  const ageMs = ageOf(entry.fetchedAt);
+  if (ageMs > CACHE_MAX_AGE_MS) return null;
+
+  return {
+    data: entry.namespaces.map((namespace) => ({ ...namespace })),
+    ageMs,
+    isStale: ageMs > CACHE_FRESH_MS,
+  };
+}
+
+export function writeCachedNamespaces(
+  userId: string,
+  orgId: string,
+  namespaces: CachedNamespace[],
+): void {
+  if (!userId || !orgId) return;
+  const existing = readForUser(userId);
+
+  // Same reasoning as workspaces: an empty namespace list on top of a populated
+  // one is a failed fetch, not a deletion.
+  const existingCount = existing?.namespacesByOrgId?.[orgId]?.namespaces.length ?? 0;
+  if (namespaces.length === 0 && existingCount > 0) {
+    console.warn(
+      `[PaprWorkspaceCache] Refusing to replace ${existingCount} cached ` +
+        `namespaces for org ${orgId} with an empty list`,
+    );
+    return;
+  }
+
+  persist({
+    version: WORKSPACE_CACHE_VERSION,
+    userId,
+    workspacesFetchedAt: existing?.workspacesFetchedAt ?? new Date(0).toISOString(),
+    workspaces: existing?.workspaces ?? [],
+    namespacesByOrgId: {
+      ...pruneNamespaces(existing?.namespacesByOrgId ?? {}),
+      [orgId]: { fetchedAt: new Date().toISOString(), namespaces },
+    },
+  });
+}
+
+/** Drop the cache entirely — used on logout so the next account starts clean. */
+export function clearPaprWorkspaceCache(): void {
+  const target = getCachePath();
+  try {
+    if (!fs.existsSync(target)) return;
+    fs.rmSync(target, { force: true });
+    console.log("[PaprWorkspaceCache] Cleared");
+  } catch (error) {
+    console.warn("[PaprWorkspaceCache] Failed to clear cache:", error);
+  }
 }

--- a/src/electron/ipc/parseTransport.ts
+++ b/src/electron/ipc/parseTransport.ts
@@ -1,0 +1,263 @@
+/**
+ * Hardened transport for Parse GraphQL / Papr platform HTTP calls.
+ *
+ * Node's global fetch keeps sockets alive but places no cap on concurrent
+ * connections per origin, so a burst of callers opens a socket each and
+ * server.papr.ai sheds them as ECONNRESET. Retrying those resets then produces
+ * more load than the original burst, so a degraded server never recovers.
+ *
+ * This module bounds that behaviour:
+ *   - a semaphore caps in-flight requests per origin
+ *   - identical concurrent reads share one request (coalescing)
+ *   - every request has a timeout, so a hung socket cannot be held open
+ *   - retries use jittered backoff, so parallel callers do not retry in lockstep
+ *   - a circuit breaker fails fast while the origin is unhealthy
+ */
+
+/** Sockets we allow against one origin at a time. */
+const MAX_CONCURRENT_PER_ORIGIN = 4;
+
+/** A single attempt may not exceed this. Parse reads are small; slow means broken. */
+export const PARSE_REQUEST_TIMEOUT_MS = 20_000;
+
+const MAX_ATTEMPTS = 3;
+const BASE_BACKOFF_MS = 300;
+
+/** Consecutive failures before we stop calling the origin. */
+const CIRCUIT_FAILURE_THRESHOLD = 6;
+/** How long the circuit stays open before a single probe is allowed through. */
+const CIRCUIT_OPEN_MS = 30_000;
+
+export class ParseCircuitOpenError extends Error {
+  constructor(origin: string, retryInMs: number) {
+    super(
+      `${origin} is temporarily unreachable (circuit open, retrying in ` +
+        `${Math.ceil(retryInMs / 1000)}s)`,
+    );
+    this.name = "ParseCircuitOpenError";
+  }
+}
+
+interface OriginState {
+  active: number;
+  queue: Array<() => void>;
+  consecutiveFailures: number;
+  openedAt: number | null;
+  /** Set while a probe request is testing whether the origin recovered. */
+  probing: boolean;
+}
+
+const origins = new Map<string, OriginState>();
+
+function getOriginState(origin: string): OriginState {
+  let state = origins.get(origin);
+  if (!state) {
+    state = {
+      active: 0,
+      queue: [],
+      consecutiveFailures: 0,
+      openedAt: null,
+      probing: false,
+    };
+    origins.set(origin, state);
+  }
+  return state;
+}
+
+function originOf(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return url;
+  }
+}
+
+async function acquire(state: OriginState): Promise<void> {
+  if (state.active < MAX_CONCURRENT_PER_ORIGIN) {
+    state.active += 1;
+    return;
+  }
+  await new Promise<void>((resolve) => state.queue.push(resolve));
+  state.active += 1;
+}
+
+function release(state: OriginState): void {
+  state.active -= 1;
+  const next = state.queue.shift();
+  if (next) next();
+}
+
+/**
+ * Errors worth retrying: connection-level failures and 5xx. Anything else
+ * (auth, validation, GraphQL errors) will fail the same way on a retry.
+ */
+export function isTransientTransportError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const cause =
+    error instanceof Error && "cause" in error ? String(error.cause) : "";
+  const combined = `${message} ${cause}`;
+  return (
+    combined.includes("Invalid server state") ||
+    combined.includes("ECONNRESET") ||
+    combined.includes("ECONNREFUSED") ||
+    combined.includes("EPIPE") ||
+    combined.includes("ETIMEDOUT") ||
+    combined.includes("fetch failed") ||
+    combined.includes("The operation was aborted") ||
+    combined.includes("TimeoutError") ||
+    combined.includes("502") ||
+    combined.includes("503") ||
+    combined.includes("504") ||
+    /error: 5\d\d/.test(combined)
+  );
+}
+
+/** Circuit state check. Lets one probe through once the open window elapses. */
+function checkCircuit(origin: string, state: OriginState): void {
+  if (state.openedAt === null) return;
+
+  const elapsed = Date.now() - state.openedAt;
+  if (elapsed < CIRCUIT_OPEN_MS) {
+    throw new ParseCircuitOpenError(origin, CIRCUIT_OPEN_MS - elapsed);
+  }
+
+  // Window elapsed: allow a single probe, keep everyone else failing fast so a
+  // recovering server is not hit by the whole backlog at once.
+  if (state.probing) {
+    throw new ParseCircuitOpenError(origin, CIRCUIT_OPEN_MS);
+  }
+  state.probing = true;
+}
+
+function recordSuccess(origin: string, state: OriginState): void {
+  if (state.openedAt !== null) {
+    console.log(`[ParseTransport] ${origin} recovered, closing circuit`);
+  }
+  state.consecutiveFailures = 0;
+  state.openedAt = null;
+  state.probing = false;
+}
+
+function recordFailure(origin: string, state: OriginState): void {
+  state.consecutiveFailures += 1;
+  state.probing = false;
+
+  if (
+    state.consecutiveFailures >= CIRCUIT_FAILURE_THRESHOLD &&
+    state.openedAt === null
+  ) {
+    state.openedAt = Date.now();
+    console.warn(
+      `[ParseTransport] ${origin} failed ${state.consecutiveFailures} times in a row; ` +
+        `pausing requests for ${CIRCUIT_OPEN_MS / 1000}s`,
+    );
+  } else if (state.openedAt !== null) {
+    // Probe failed — restart the open window rather than probing every call.
+    state.openedAt = Date.now();
+  }
+}
+
+function jitteredBackoff(attempt: number): number {
+  const ceiling = BASE_BACKOFF_MS * 2 ** (attempt - 1);
+  // Full jitter: spreads parallel callers instead of having them retry together.
+  return Math.round(ceiling * (0.5 + Math.random() * 0.5));
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface ParseFetchOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string | Buffer;
+  timeoutMs?: number;
+  /** Attempts including the first. Set to 1 for non-idempotent writes. */
+  maxAttempts?: number;
+}
+
+/**
+ * Perform an HTTP request through the bounded pool, with retry and circuit
+ * breaking. Resolves with the Response for the caller to interpret.
+ */
+export async function parseFetch(
+  url: string,
+  options: ParseFetchOptions = {},
+): Promise<Response> {
+  const origin = originOf(url);
+  const state = getOriginState(origin);
+  const maxAttempts = options.maxAttempts ?? MAX_ATTEMPTS;
+  const timeoutMs = options.timeoutMs ?? PARSE_REQUEST_TIMEOUT_MS;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    checkCircuit(origin, state);
+    await acquire(state);
+
+    try {
+      const response = await fetch(url, {
+        method: options.method ?? "POST",
+        headers: options.headers,
+        body: options.body,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+      // 5xx counts against the circuit; 4xx is the caller's problem, not the
+      // origin's health, so it closes the circuit like any other response.
+      if (response.status >= 500) {
+        recordFailure(origin, state);
+        if (attempt < maxAttempts) {
+          const text = await response.text().catch(() => "");
+          lastError = new Error(`Parse error: ${response.status} ${text}`);
+          await sleep(jitteredBackoff(attempt));
+          continue;
+        }
+      } else {
+        recordSuccess(origin, state);
+      }
+
+      return response;
+    } catch (error) {
+      lastError = error;
+      recordFailure(origin, state);
+
+      if (!isTransientTransportError(error) || attempt === maxAttempts) {
+        throw error;
+      }
+      await sleep(jitteredBackoff(attempt));
+    } finally {
+      release(state);
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Request to ${origin} failed`);
+}
+
+/** In-flight reads, keyed by caller-supplied identity, for coalescing. */
+const inFlight = new Map<string, Promise<unknown>>();
+
+/**
+ * Share one in-flight request between identical concurrent callers.
+ *
+ * The profile/workspace/billing refreshes fan out from several independent
+ * renderer triggers at once. Without coalescing each trigger issues its own
+ * round trip for the same data.
+ */
+export function coalesce<T>(key: string, run: () => Promise<T>): Promise<T> {
+  const existing = inFlight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+
+  const promise = run().finally(() => {
+    inFlight.delete(key);
+  });
+  inFlight.set(key, promise);
+  return promise;
+}
+
+/** Test/diagnostic hook — drops circuit + coalescing state. */
+export function resetParseTransportState(): void {
+  origins.clear();
+  inFlight.clear();
+}

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -936,6 +936,16 @@ async function startGateway(): Promise<void> {
         dbRouter.query(appId, source as never, sql, params) as never,
       dbWrite: (appId, source, sql, params) =>
         dbRouter.write(appId, source as never, sql, params) as never,
+      // Lets App Files choose a home when the caller named no sourceId.
+      // Ids are returned rather than aliases because aliases are not unique —
+      // a duplicated job link yields two sources sharing one alias.
+      listSources: async (appId) => {
+        const config = await getAppService().getDataSourcesConfig(appId);
+        return config.sources.map((source) => ({
+          id: source.id,
+          alias: source.alias,
+        }));
+      },
     });
 
     // ── Mini-app SQLite DDL API ──────────────────────────────────────────────

--- a/src/gateway/services/appDataSources.ts
+++ b/src/gateway/services/appDataSources.ts
@@ -206,13 +206,43 @@ export function inferPrimaryAlias(sources: AppDataSource[]): string | undefined 
   return sources.length === 1 ? sources[0]?.alias : undefined;
 }
 
+/**
+ * Find a linked source by unique id or by alias.
+ *
+ * Ids are matched before aliases, and matched exhaustively, because the two
+ * namespaces are not equally trustworthy. An id is unique by construction; an
+ * alias is a display name that can repeat — linking the same job twice, or two
+ * jobs whose names collide, leaves several sources answering to one alias.
+ *
+ * The previous single `.find()` treated both namespaces as interchangeable and
+ * returned whichever matched first. When an alias was duplicated that made the
+ * result depend on array order: an app could read an empty database while its
+ * data sat in the duplicate, with nothing anywhere reporting a problem. Empty
+ * results are the hardest failure to trace, because they look like "no data
+ * yet" rather than a bug.
+ *
+ * A duplicate alias is still resolved rather than rejected — throwing would
+ * break working apps at read time for a mistake made at link time — but the
+ * choice is now stable and it is reported loudly enough to find.
+ */
 export function findDataSource(
   config: AppDataSourcesFile,
   sourceId: string,
 ): AppDataSource | undefined {
-  return config.sources.find(
-    (s) => s.id === sourceId || s.alias === sourceId,
-  );
+  const byId = config.sources.find((s) => s.id === sourceId);
+  if (byId) {
+    return byId;
+  }
+
+  const byAlias = config.sources.filter((s) => s.alias === sourceId);
+  if (byAlias.length > 1) {
+    console.warn(
+      `[AppDataSources] Alias "${sourceId}" matches ${byAlias.length} linked sources ` +
+        `(${byAlias.map((s) => s.id).join(", ")}). Using the first. ` +
+        `Pass a source id instead — aliases are display names and are not unique.`,
+    );
+  }
+  return byAlias[0];
 }
 
 /** Extract the main table name from SQL (used by validation helpers). */

--- a/src/gateway/services/appFiles/AppFilesService.ts
+++ b/src/gateway/services/appFiles/AppFilesService.ts
@@ -9,6 +9,7 @@
 import { randomUUID } from "node:crypto";
 import { basename } from "node:path";
 import { stat } from "node:fs/promises";
+import { existsSync } from "node:fs";
 
 import {
   commitUpload,
@@ -321,6 +322,81 @@ async function recordProgress(
 }
 
 /**
+ * Register a file that exists on disk when cloud storage cannot be reached.
+ *
+ * The object key is derived from the content hash using the same shape the
+ * server would mint, so when the upload is retried the ticket resolves to this
+ * same object and dedupe still works — no orphan and no duplicate.
+ *
+ * State is `pending`, not `failed`: nothing has been attempted yet, and
+ * `failed` is reserved for an upload that started and broke. The distinction
+ * matters to whoever reads this row later trying to understand what happened.
+ */
+async function addFileLocally(
+  db: FilesDb,
+  args: {
+    appId: string;
+    filePath: string;
+    fileName: string;
+    mime?: string;
+    scope: AppFileScope;
+    sha256: string;
+    sizeBytes: number;
+    reason: string;
+  },
+): Promise<AddFileResult> {
+  console.warn(
+    `[AppFiles] Cloud storage unavailable (${args.reason}). ` +
+      `Registered "${args.fileName}" locally — upload will be retried.`,
+  );
+
+  const now = Date.now();
+  const id = randomUUID();
+  const objectKey = `local/${args.appId}/${args.sha256}`;
+
+  await db.run(
+    `INSERT INTO app_files
+       (id, app_id, object_key, sha256, size_bytes, mime, file_name, scope,
+        local_path, upload_state, visibility, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', 'inherit', ?, ?)
+     ON CONFLICT(object_key) DO UPDATE SET
+       local_path = excluded.local_path,
+       updated_at = excluded.updated_at`,
+    [
+      id,
+      args.appId,
+      objectKey,
+      args.sha256,
+      args.sizeBytes,
+      args.mime ?? null,
+      args.fileName,
+      args.scope,
+      args.filePath,
+      now,
+      now,
+    ],
+  );
+
+  // On conflict the original row survived, so return its id — handing back a
+  // fresh uuid would give the caller an id that resolves to nothing.
+  const existing = (
+    await db.all<{ id: string }>(
+      `SELECT id FROM app_files WHERE object_key = ?`,
+      [objectKey],
+    )
+  )[0];
+
+  return {
+    id: existing?.id ?? id,
+    objectKey,
+    sha256: args.sha256,
+    sizeBytes: args.sizeBytes,
+    deduped: false,
+    verified: false,
+  };
+}
+
+/**
  * Store a local file in App Files.
  *
  * Order matters here. We hash first so the key is content-addressed, which
@@ -339,14 +415,37 @@ export async function addFile(
   const fileName = args.fileName ?? basename(args.filePath);
   const scope = args.scope ?? "app";
 
-  const ticket = await requestUploadTicket({
-    appId: args.appId,
-    sha256,
-    sizeBytes,
-    fileName,
-    mime: args.mime,
-    scope,
-  });
+  let ticket: Awaited<ReturnType<typeof requestUploadTicket>>;
+  try {
+    ticket = await requestUploadTicket({
+      appId: args.appId,
+      sha256,
+      sizeBytes,
+      fileName,
+      mime: args.mime,
+      scope,
+    });
+  } catch (err) {
+    // Cloud storage is unreachable, but the bytes are already on this disk.
+    // Refusing the registration would leave the caller holding a path — the
+    // exact fragile reference App Files exists to replace — because of an
+    // outage that has nothing to do with the file.
+    //
+    // Record it locally instead. The row is real, the id is durable, and the
+    // upload is retried later by resumeUpload. Offline-first is the honest
+    // model here: the local copy was always the primary read path, and the
+    // cloud copy is durability.
+    return addFileLocally(db, {
+      appId: args.appId,
+      filePath: args.filePath,
+      fileName,
+      mime: args.mime,
+      scope,
+      sha256,
+      sizeBytes,
+      reason: (err as Error).message,
+    });
+  }
 
   const now = Date.now();
   const id = randomUUID();
@@ -513,4 +612,68 @@ export async function removeFile(db: FilesDb, id: string): Promise<boolean> {
   await deleteObject(row.app_id, row.object_key);
   await db.run(`DELETE FROM app_files WHERE id = ?`, [id]);
   return true;
+}
+
+/**
+ * Upload files that were registered while cloud storage was unreachable.
+ *
+ * Without this, `addFileLocally` would be a trap rather than a fallback: the
+ * row stays `pending` forever, the app keeps working off the local copy, and
+ * the durability everyone assumes they have never actually arrives. The
+ * failure would only surface on the day the local copy is gone.
+ *
+ * Safe to call repeatedly. Each file goes through the normal `addFile` path,
+ * which is content-addressed, so a file that did reach storage in the meantime
+ * dedupes instead of uploading twice.
+ */
+export async function retryPendingUploads(
+  db: FilesDb,
+  appId: string,
+): Promise<{ uploaded: number; stillPending: number; skipped: number }> {
+  const pending = await db.all<AppFileRow>(
+    `SELECT * FROM app_files
+      WHERE app_id = ? AND upload_state = 'pending' AND local_path IS NOT NULL
+      ORDER BY created_at ASC`,
+    [appId],
+  );
+
+  let uploaded = 0;
+  let stillPending = 0;
+  let skipped = 0;
+
+  for (const row of pending) {
+    // The local copy is the only source of bytes for a pending row. If it is
+    // gone there is nothing to upload, and retrying would fail every time.
+    if (!row.local_path || !existsSync(row.local_path)) {
+      skipped += 1;
+      continue;
+    }
+
+    try {
+      const result = await addFile(db, {
+        appId,
+        filePath: row.local_path,
+        fileName: row.file_name,
+        mime: row.mime ?? undefined,
+        scope: row.scope,
+      });
+      if (result.verified) {
+        // The retry wrote a row under the server's real object key. Drop the
+        // local/ placeholder so the file is not listed twice.
+        if (result.objectKey !== row.object_key) {
+          await db.run(`DELETE FROM app_files WHERE object_key = ?`, [
+            row.object_key,
+          ]);
+        }
+        uploaded += 1;
+      } else {
+        stillPending += 1;
+      }
+    } catch {
+      // Still unreachable. Leave the row exactly as it is and try again later.
+      stillPending += 1;
+    }
+  }
+
+  return { uploaded, stillPending, skipped };
 }

--- a/src/gateway/services/appFiles/appFilesRoutes.ts
+++ b/src/gateway/services/appFiles/appFilesRoutes.ts
@@ -22,6 +22,7 @@ import {
   type FilesDb,
 } from "./AppFilesService.js";
 import { appUsage } from "./appFilesClient.js";
+import { resolveFilesSource, type FilesSourceRef } from "./resolveFilesSource.js";
 import { resolveMiniAppIdFromRequest } from "../../utils/inferMiniAppIdFromRequest.js";
 
 /** Minimal shape of the pieces index.ts already has wired up. */
@@ -45,6 +46,12 @@ export interface AppFilesRouteDeps {
     params?: unknown[],
   ) => Promise<{ changes: number }>;
   dbExec?: (appId: string, source: unknown, sql: string) => Promise<unknown>;
+  /**
+   * All sources linked to an app, used only to break a tie when no sourceId
+   * was given. Optional so existing callers and tests keep compiling; without
+   * it the resolver simply rethrows the ambiguity error as before.
+   */
+  listSources?: (appId: string) => Promise<FilesSourceRef[]>;
 }
 
 /** Adapt the gateway's db plumbing to the small surface the service needs. */
@@ -53,8 +60,11 @@ async function dbFor(
   sourceId: string | undefined,
   deps: AppFilesRouteDeps,
 ): Promise<FilesDb> {
-  const readSource = await deps.resolveSource(appId, sourceId, undefined, "read");
-  const writeSource = await deps.resolveSource(appId, sourceId, undefined, "write");
+  // App Files picks its own home when the caller did not name one — see
+  // resolveFilesSource. The generic resolver would 400 here for any app with
+  // more than one linked database.
+  const readSource = await resolveFilesSource(appId, sourceId, "read", deps);
+  const writeSource = await resolveFilesSource(appId, sourceId, "write", deps);
   return {
     async exec(sql: string) {
       // Schema creation goes through the write path; exec is optional in some

--- a/src/gateway/services/appFiles/appFilesRoutes.ts
+++ b/src/gateway/services/appFiles/appFilesRoutes.ts
@@ -17,6 +17,7 @@ import {
   listFiles,
   removeFile,
   resolveFileUrl,
+  retryPendingUploads,
   setFilePrivacy,
   evictLocal,
   type FilesDb,
@@ -337,6 +338,79 @@ export function registerAppFilesRoutes(
       }
       const db = await dbFor(appId, sourceId, deps);
       res.json({ evicted: await evictLocal(db, objectKey) });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  /**
+   * Stream a locally-stored file to the browser.
+   *
+   * `resolveFileUrl` returns a filesystem path for local files, which is the
+   * right answer for a job that reads bytes and useless to a browser: an
+   * `<audio src="/Users/...">` resolves against the origin and 404s. This is
+   * the one place that gap can be closed, because only the gateway can read
+   * the disk.
+   *
+   * Range requests are honoured so audio and video can seek. Without them a
+   * player must download a 900 MB recording before it can jump to the middle.
+   */
+  app.get("/api/files/content", async (req, res) => {
+    try {
+      const appId = req.query.appId as string | undefined;
+      const id = req.query.id as string | undefined;
+      const sourceId = req.query.sourceId as string | undefined;
+      if (!id) {
+        res.status(400).json({ error: "id is required" });
+        return;
+      }
+      const resolved = resolveMiniAppIdFromRequest(appId, req.headers);
+      if (!resolved.appId) {
+        res.status(resolved.status ?? 400).json({ error: resolved.error });
+        return;
+      }
+
+      const db = await dbFor(resolved.appId, sourceId, deps);
+      const { location } = await resolveFileUrl(db, id);
+      if (location.kind !== "local") {
+        // Cloud files are served by a signed URL, and unavailable ones have no
+        // bytes anywhere. Neither belongs on this path.
+        res.status(404).json({
+          error:
+            location.kind === "cloud"
+              ? "File is in cloud storage — use /api/files/url for a signed URL"
+              : "File has no local copy",
+        });
+        return;
+      }
+
+      res.sendFile(location.path);
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  /**
+   * Upload files registered while cloud storage was unreachable.
+   *
+   * Files added during an outage are `pending` with a local copy only. Without
+   * a retry they stay that way indefinitely — the app keeps working off local
+   * disk and the durability nobody re-checks never arrives.
+   */
+  app.post("/api/files/retry-pending", async (req, res) => {
+    try {
+      const { appId, sourceId } = req.body as {
+        appId?: string;
+        sourceId?: string;
+      };
+      const resolved = resolveMiniAppIdFromRequest(appId, req.headers);
+      if (!resolved.appId) {
+        res.status(resolved.status ?? 400).json({ error: resolved.error });
+        return;
+      }
+      const db = await dbFor(resolved.appId, sourceId, deps);
+      await ensureSchema(db);
+      res.json(await retryPendingUploads(db, resolved.appId));
     } catch (err) {
       fail(res, err);
     }

--- a/src/gateway/services/appFiles/resolveFilesSource.ts
+++ b/src/gateway/services/appFiles/resolveFilesSource.ts
@@ -1,0 +1,112 @@
+/**
+ * Pick which linked database holds an app's `app_files` rows.
+ *
+ * App Files is app-scoped, not source-scoped. Asking a user which of twelve
+ * job databases should hold their file index is a question with no meaningful
+ * answer — they dropped a file on an app, not on "Whisper Transcriber".
+ *
+ * The generic mini-app resolver is right to demand an explicit `sourceId` for
+ * `/api/db/query`: a query names a table, and the caller knows which database
+ * owns it. It is wrong for `/api/files`, where the caller is the Files panel
+ * and there is nothing to disambiguate. Routing App Files through that resolver
+ * meant every app with anything other than exactly one linked database got a
+ * 400 on the first call — which is most apps, and why the panel never worked
+ * end to end.
+ *
+ * Resolution order, most-specific first:
+ *   1. Explicit `sourceId` — the caller knows better than we do.
+ *   2. Whatever the standard resolver returns (single source, or legacy
+ *      `primary`). Unambiguous cases must keep behaving exactly as before.
+ *   3. A source that already has an `app_files` table — existing rows decide,
+ *      so a second call never lands somewhere different from the first.
+ *   4. First source by sorted alias — arbitrary but *stable*, which is the
+ *      property that matters. An unstable choice would scatter one app's files
+ *      across several databases depending on array order.
+ *
+ * Steps 3 and 4 always re-resolve by the source's unique `id` rather than its
+ * alias, because aliases are not unique in practice (a duplicated job link
+ * produces two sources with the same alias) and alias lookup silently returns
+ * whichever comes first.
+ */
+
+export interface FilesSourceRef {
+  id: string;
+  alias?: string;
+}
+
+export interface FilesSourceDeps {
+  resolveSource: (
+    appId: string,
+    sourceId: string | undefined,
+    sql: string | undefined,
+    operation: "read" | "write",
+  ) => Promise<unknown>;
+  dbQuery: (
+    appId: string,
+    source: unknown,
+    sql: string,
+    params?: unknown[],
+  ) => Promise<{ rows?: unknown[] }>;
+  listSources?: (appId: string) => Promise<FilesSourceRef[]>;
+}
+
+/** True when the resolver rejected because it could not choose for us. */
+function isAmbiguityError(err: unknown): boolean {
+  const status = (err as { status?: number } | undefined)?.status;
+  return status === 400;
+}
+
+async function hasAppFilesTable(
+  appId: string,
+  source: unknown,
+  deps: FilesSourceDeps,
+): Promise<boolean> {
+  try {
+    const result = await deps.dbQuery(
+      appId,
+      source,
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='app_files' LIMIT 1`,
+    );
+    return (result.rows ?? []).length > 0;
+  } catch {
+    // A database we cannot read is a database we should not adopt.
+    return false;
+  }
+}
+
+export async function resolveFilesSource(
+  appId: string,
+  sourceId: string | undefined,
+  operation: "read" | "write",
+  deps: FilesSourceDeps,
+): Promise<unknown> {
+  if (sourceId) {
+    return deps.resolveSource(appId, sourceId, undefined, operation);
+  }
+
+  try {
+    return await deps.resolveSource(appId, undefined, undefined, operation);
+  } catch (err) {
+    // Only ambiguity is ours to resolve. "No sources linked" (404) and any
+    // other failure must surface unchanged — inventing a database to satisfy
+    // a genuinely broken app would turn a clear error into a silent one.
+    if (!isAmbiguityError(err) || !deps.listSources) throw err;
+
+    const sources = await deps.listSources(appId);
+    if (sources.length === 0) throw err;
+
+    for (const candidate of sources) {
+      const resolved = await deps
+        .resolveSource(appId, candidate.id, undefined, operation)
+        .catch(() => null);
+      if (resolved && (await hasAppFilesTable(appId, resolved, deps))) {
+        return resolved;
+      }
+    }
+
+    const [fallback] = [...sources].sort((a, b) =>
+      (a.alias ?? a.id).localeCompare(b.alias ?? b.id),
+    );
+    return deps.resolveSource(appId, fallback.id, undefined, operation);
+  }
+}

--- a/src/gateway/services/jobs/executors/CommandJobExecutor.ts
+++ b/src/gateway/services/jobs/executors/CommandJobExecutor.ts
@@ -14,6 +14,7 @@ import {
   requireJobWriteTargets,
 } from "../../jobAppDatabase.js";
 import { STANDALONE_APP_ID } from "../appIds.js";
+import { jobSdkEnv } from "../jobSdkEnv.js";
 
 export class CommandJobExecutor implements IJobExecutor {
   private supportedTypes: Set<JobType>;
@@ -74,10 +75,14 @@ export class CommandJobExecutor implements IJobExecutor {
       (id) => id !== STANDALONE_APP_ID,
     );
 
+    const nvmEnv = this.getNvmEnv();
+
     const env: NodeJS.ProcessEnv = {
-      ...this.getNvmEnv(),
+      ...nvmEnv,
       JOB_DIR: params.jobDir,
       JOB_DB: jobDbPath,
+      // `from papr_files import add` without vendoring the helper per job.
+      ...jobSdkEnv(nvmEnv.PYTHONPATH ?? process.env.PYTHONPATH),
       ...(writeTargets.length > 0
         ? jobWriteDatabaseEnv(writeTargets, linkedAppId)
         : {}),

--- a/src/gateway/services/jobs/jobSdkEnv.ts
+++ b/src/gateway/services/jobs/jobSdkEnv.ts
@@ -1,0 +1,61 @@
+/**
+ * Make the job-side Python SDK importable without copying it into every job.
+ *
+ * Jobs get `PYTHONPATH` pointed at the bundled `job-sdk/` directory, so
+ * `from papr_files import add` works from any Python job with no pip install
+ * and no vendored copy. Copying the helper into each job folder — the way
+ * `papr_db.py` is scaffolded for app backends — would mean every fix has to be
+ * re-applied to every job that ever took a copy.
+ *
+ * The user's own `PYTHONPATH` is preserved and takes precedence: appending
+ * rather than replacing means a job that deliberately shadows a module still
+ * wins, and we never silently break an environment we did not create.
+ */
+
+import path from "path";
+import { fileURLToPath } from "url";
+import { existsSync } from "fs";
+
+let cachedRoot: string | null | undefined;
+
+/**
+ * Locate `job-sdk/`, which lives at `src/resources/job-sdk` in a dev checkout
+ * and `dist/resources/job-sdk` in a packaged build. Both are probed because
+ * this same code runs in both, and guessing wrong yields an import error deep
+ * inside a user's job rather than here.
+ */
+export function getJobSdkRoot(): string | null {
+  if (cachedRoot !== undefined) {
+    return cachedRoot;
+  }
+
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    // dist/gateway/services/jobs → dist/resources/job-sdk
+    path.resolve(here, "../../../resources/job-sdk"),
+    // src/gateway/services/jobs → src/resources/job-sdk
+    path.resolve(here, "../../../../src/resources/job-sdk"),
+    path.resolve(here, "../../../../resources/job-sdk"),
+  ];
+
+  cachedRoot = candidates.find((dir) => existsSync(path.join(dir, "papr_files.py"))) ?? null;
+  if (!cachedRoot) {
+    console.warn(
+      "[JobSdk] job-sdk/ not found — `from papr_files import add` will fail in jobs.",
+    );
+  }
+  return cachedRoot;
+}
+
+/** PYTHONPATH entry for the bundled job SDK, merged with any existing value. */
+export function jobSdkEnv(
+  existingPythonPath?: string,
+): Record<string, string> {
+  const root = getJobSdkRoot();
+  if (!root) {
+    return {};
+  }
+
+  const parts = existingPythonPath ? [existingPythonPath, root] : [root];
+  return { PYTHONPATH: parts.join(path.delimiter) };
+}

--- a/src/gateway/services/tursoSyncBridgeCore.ts
+++ b/src/gateway/services/tursoSyncBridgeCore.ts
@@ -399,11 +399,77 @@ async function readRemoteForeignKeyRefs(
     .filter((name): name is string => name !== null && knownLocalNames.has(name));
 }
 
+/**
+ * Keep the local PRIMARY KEY when the incoming remote schema has none.
+ *
+ * A pull rebuilds the local table from the remote definition, which is right
+ * for columns and rows but wrong for a constraint the remote has *lost*. Once
+ * a remote table is PK-less, every pull strips the local PK too, and the next
+ * push copies that back up — the degradation becomes self-sustaining, and no
+ * single run looks like the culprit.
+ *
+ * The visible damage is not a sync error. `INSERT ... ON CONFLICT(id)` needs a
+ * PRIMARY KEY or UNIQUE constraint, so a job that upserts fails outright with
+ * "ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint" —
+ * and, until it does, duplicate rows accumulate unchecked.
+ *
+ * Preferring the local PK is safe in the only direction that matters: adding
+ * back a constraint the table was declared with cannot lose data, while
+ * dropping one silently admits duplicates. A genuine intentional PK change
+ * still goes through planSchemaMigration, which rebuilds explicitly.
+ */
+function preserveLocalPrimaryKey(
+  localDb: Database.Database,
+  table: LocalTable,
+): LocalTable {
+  if (table.columns.some((col) => col.primaryKey)) {
+    return table;
+  }
+
+  let localColumns: TableColumn[];
+  try {
+    localColumns = readTableSchema(localDb, table.name);
+  } catch {
+    return table;
+  }
+
+  const localPk = localColumns.filter((col) => col.primaryKey);
+  if (localPk.length === 0) {
+    return table;
+  }
+
+  // Only reinstate a key whose columns all still exist remotely; a PK naming a
+  // dropped column would make the rebuilt table unopenable.
+  const incoming = new Set(table.columns.map((col) => col.name));
+  if (!localPk.every((col) => incoming.has(col.name))) {
+    return table;
+  }
+
+  const pkNames = new Set(localPk.map((col) => col.name));
+  console.warn(
+    `[TursoSync] Remote "${table.name}" has no PRIMARY KEY but local declares ` +
+      `(${[...pkNames].join(", ")}). Keeping the local key — a PK-less rebuild ` +
+      `breaks ON CONFLICT upserts and admits duplicate rows.`,
+  );
+
+  return {
+    ...table,
+    columns: table.columns.map((col) =>
+      pkNames.has(col.name) ? { ...col, primaryKey: true } : col,
+    ),
+    // Drop the remote CREATE TABLE text: it encodes the PK-less shape we are
+    // deliberately overriding, and buildCreateTableSql prefers it when present.
+    createSql: undefined,
+  };
+}
+
 export function writeTablesToLocalDb(
   localDb: Database.Database,
   tables: LocalTable[],
 ): void {
-  const writable = tables.filter((table) => table.columns.length > 0);
+  const writable = tables
+    .filter((table) => table.columns.length > 0)
+    .map((table) => preserveLocalPrimaryKey(localDb, table));
   if (writable.length === 0) {
     return;
   }

--- a/src/resources/job-sdk/papr_files.py
+++ b/src/resources/job-sdk/papr_files.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""App Files for jobs — register a file the job just wrote to disk.
+
+The mini-app SDK (`papr.files.upload`) takes a browser `Blob`. A job has no
+blob: it has a path. The Swift recorder writes `recording.wav`, ffmpeg writes
+an MP3, a scraper writes a CSV. Without this helper the only thing a job could
+store was the path string itself — which is what the meetings recorder did, and
+why 41 rows now point at a directory layout that no longer exists.
+
+A path is not a reference. It breaks when the workspace moves, means nothing on
+another machine, and is empty for every visitor to a published app. A file id
+survives all three, because resolution becomes someone else's problem.
+
+Usage (stdlib only — no pip install):
+
+    from papr_files import add, url, remove
+
+    file_id = add("data/recordings/abc.wav")
+    con.execute("UPDATE meetings SET audio_ref=? WHERE id=?", (file_id, mid))
+
+The gateway streams the bytes from disk to object storage; they never pass
+through this process. `add()` is idempotent — content-addressed, so re-running
+a job returns the existing id instead of storing a second copy.
+
+Env (injected by the job runner):
+  APP_ID           — mini-app this job belongs to (from job.appIds)
+  PAPR_GATEWAY_URL — gateway base, defaults to http://127.0.0.1:18789
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+DEFAULT_GATEWAY = "http://127.0.0.1:18789"
+
+# Uploads are measured in GB, not KB. The gateway hashes the file, negotiates a
+# ticket and streams every byte before it answers, so a short timeout here would
+# abort transfers that were going to succeed.
+UPLOAD_TIMEOUT_SECONDS = 60 * 60
+CALL_TIMEOUT_SECONDS = 60
+
+
+class PaprFilesError(RuntimeError):
+    """A files operation failed. Message carries the gateway's own wording."""
+
+
+def _gateway() -> str:
+    return os.environ.get("PAPR_GATEWAY_URL", DEFAULT_GATEWAY).rstrip("/")
+
+
+def _app_id(explicit: str | None) -> str:
+    app_id = explicit or os.environ.get("APP_ID", "")
+    if not app_id:
+        raise PaprFilesError(
+            "No app id. This job is not linked to a mini-app — set appIds on the "
+            "job, or pass app_id= explicitly. Files belong to an app, not a job: "
+            "jobs are replaceable, the app outlives them."
+        )
+    return app_id
+
+
+def _post(path: str, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
+    request = urllib.request.Request(
+        f"{_gateway()}{path}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as err:
+        detail = err.read().decode("utf-8", errors="replace")
+        try:
+            detail = json.loads(detail).get("error", detail)
+        except (ValueError, AttributeError):
+            pass
+        raise PaprFilesError(f"{path} failed ({err.code}): {detail}") from err
+    except urllib.error.URLError as err:
+        raise PaprFilesError(
+            f"Cannot reach the Papr gateway at {_gateway()} ({err.reason}). "
+            "It runs with the desktop app; start Papr Work and retry."
+        ) from err
+
+
+def add(
+    file_path: str,
+    *,
+    app_id: str | None = None,
+    file_name: str | None = None,
+    mime: str | None = None,
+    scope: str = "app",
+    keep_local: bool = True,
+) -> str:
+    """Register a local file with App Files and return its id.
+
+    Store the returned id in your database, never `file_path`.
+
+    `keep_local` defaults to True: the local copy stays until someone explicitly
+    frees it. Deleting a user's only copy as a side effect of registering it
+    would be the worst possible default.
+
+    `scope="user"` keeps the file private to the person who made it even if the
+    app is published — the right choice for recordings and anything personal.
+    """
+    resolved = os.path.abspath(file_path)
+    if not os.path.isfile(resolved):
+        raise PaprFilesError(f"No file at {resolved}")
+    if os.path.getsize(resolved) == 0:
+        # An empty file usually means the producer failed. Registering it would
+        # hide that behind a valid-looking reference.
+        raise PaprFilesError(f"Refusing to register an empty file: {resolved}")
+
+    result = _post(
+        "/api/files/upload",
+        {
+            "appId": _app_id(app_id),
+            "filePath": resolved,
+            "fileName": file_name,
+            "mime": mime,
+            "scope": scope,
+            "keepLocal": keep_local,
+        },
+        UPLOAD_TIMEOUT_SECONDS,
+    )
+
+    file_id = result.get("id")
+    if not file_id:
+        raise PaprFilesError(f"Upload returned no file id: {result}")
+    return str(file_id)
+
+
+def _resolve(file_id: str, app_id: str | None) -> dict[str, Any]:
+    return _post(
+        "/api/files/url",
+        {"appId": _app_id(app_id), "id": file_id},
+        CALL_TIMEOUT_SECONDS,
+    )
+
+
+def url(file_id: str, *, app_id: str | None = None) -> str:
+    """Resolve a file id to something readable — local path or signed URL.
+
+    The gateway answers `{ location: {kind, path?}, url? }`: a local path when
+    a copy is on this machine, a short-lived signed URL when it only exists in
+    the cloud. Callers that just want "where is it" should not have to know the
+    difference, so both collapse to one string here.
+    """
+    result = _resolve(file_id, app_id)
+    location = result.get("location") or {}
+    resolved = result.get("url") or location.get("path")
+    if not resolved:
+        reason = location.get("reason") or "no local copy and no cloud copy"
+        raise PaprFilesError(f"File {file_id} is unavailable: {reason}")
+    return str(resolved)
+
+
+def local_path(file_id: str, *, app_id: str | None = None) -> str | None:
+    """Local path when a copy is on this machine, else None.
+
+    Jobs that process bytes (transcription, ffmpeg) need a real path, not a
+    URL. Returning None rather than a signed URL keeps the caller honest about
+    the download it would otherwise have to perform itself.
+    """
+    location = _resolve(file_id, app_id).get("location") or {}
+    path = location.get("path") if location.get("kind") == "local" else None
+    return str(path) if path and os.path.isfile(str(path)) else None
+
+
+def remove(file_id: str, *, app_id: str | None = None) -> bool:
+    """Delete a file and its stored bytes."""
+    result = _post(
+        "/api/files/delete",
+        {"appId": _app_id(app_id), "id": file_id},
+        CALL_TIMEOUT_SECONDS,
+    )
+    return bool(result.get("deleted"))

--- a/src/resources/mini-app-sdk/papr-files.ts
+++ b/src/resources/mini-app-sdk/papr-files.ts
@@ -238,16 +238,27 @@ export const papr = {
       });
     },
 
-    /** Resolve a file id to something a browser can load. */
+    /**
+     * Resolve a file id to something a browser can load.
+     *
+     * A local file resolves to a *filesystem path*, which no browser can
+     * fetch — `<audio src="/Users/...">` resolves against the origin and 404s.
+     * So local files are returned as a gateway URL that streams the bytes,
+     * and cloud files as their signed URL. Callers get one usable src either
+     * way and never have to branch on where the file happens to live.
+     */
     async url(id: string): Promise<{ url: string; location: string }> {
       const res = await api<{ url?: string; location: { kind: string; path?: string } }>(
         "/api/files/url",
         { id },
       );
-      return {
-        url: res.url ?? res.location.path ?? "",
-        location: res.location.kind,
-      };
+      if (res.location.kind === "local") {
+        return {
+          url: `/api/files/content?id=${encodeURIComponent(id)}`,
+          location: "local",
+        };
+      }
+      return { url: res.url ?? "", location: res.location.kind };
     },
 
     /** Every file this app can see. */

--- a/tests/papr-workspace-cache-dedupe.test.ts
+++ b/tests/papr-workspace-cache-dedupe.test.ts
@@ -72,4 +72,47 @@ describe("dedupeCachedWorkspaces", () => {
   it("handles an empty list", () => {
     expect(dedupeCachedWorkspaces([])).toEqual([]);
   });
+
+  // resolveNamespaceOrganizationId maps every workspace where the user owns a
+  // non-matching org onto their single developer org, so distinct workspaces
+  // arrive sharing an organizationId and defaultNamespaceId. Collapsing those
+  // left the switcher with one row and no way out of it.
+  it("keeps differently named workspaces that resolve to the same developer org", () => {
+    const result = dedupeCachedWorkspaces([
+      workspace("ws-sqa", "SQA Service", "ns-dev", "org-dev"),
+      workspace("ws-papr", "papr-ai", "ns-dev", "org-dev"),
+    ]);
+
+    expect(result.map((entry) => entry.name)).toEqual(["SQA Service", "papr-ai"]);
+  });
+
+  it("still absorbs placeholder rows into a named row in the same scope", () => {
+    const result = dedupeCachedWorkspaces([
+      workspace("a", "Workspace", "ns-1"),
+      workspace("b", "papr-ai", "ns-1"),
+      workspace("c", "null (you)", "ns-1"),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("papr-ai");
+  });
+
+  it("collapses repeats of the same name but keeps the other workspace", () => {
+    const result = dedupeCachedWorkspaces([
+      workspace("a1", "Papr", "ns-1"),
+      workspace("a2", "Papr", "ns-1"),
+      workspace("b1", "Acme", "ns-1"),
+    ]);
+
+    expect(result.map((entry) => entry.name)).toEqual(["Papr", "Acme"]);
+  });
+
+  it("treats names differing only by the (you) suffix as the same workspace", () => {
+    const result = dedupeCachedWorkspaces([
+      workspace("a", "Acme", "ns-1"),
+      workspace("b", "Acme (you)", "ns-1"),
+    ]);
+
+    expect(result).toHaveLength(1);
+  });
 });

--- a/tests/papr-workspace-cache-store.test.ts
+++ b/tests/papr-workspace-cache-store.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Redirect the cache to a temp dir. Declared before the factory runs but only
+// read when getPaprBaseDir is actually called, which is inside the tests.
+let baseDir: string;
+
+vi.mock("../src/core/utils/paprWorkspace.js", () => ({
+  getPaprBaseDir: () => baseDir,
+}));
+
+const {
+  CACHE_FRESH_MS,
+  CACHE_MAX_AGE_MS,
+  clearPaprWorkspaceCache,
+  readCachedNamespaces,
+  readCachedWorkspaces,
+  writeCachedNamespaces,
+  writeCachedWorkspaces,
+} = await import("../src/electron/ipc/paprWorkspaceCache.js");
+
+const USER = "user-1";
+const OTHER_USER = "user-2";
+
+function cacheFilePath(): string {
+  return path.join(baseDir, "data", "papr-workspace-cache.json");
+}
+
+function readFileRaw(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(cacheFilePath(), "utf8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+function workspace(id: string, name: string, defaultNamespaceId = "ns-1") {
+  return { id, name, organizationId: "org-1", defaultNamespaceId };
+}
+
+beforeEach(() => {
+  baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "papr-cache-store-"));
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-17T00:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  fs.rmSync(baseDir, { recursive: true, force: true });
+});
+
+describe("workspace cache persistence", () => {
+  it("round-trips workspaces for the user that wrote them", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+
+    const read = readCachedWorkspaces(USER);
+    expect(read?.data.map((entry) => entry.name)).toEqual(["Papr"]);
+    expect(read?.isStale).toBe(false);
+    expect(read?.ageMs).toBe(0);
+  });
+
+  it("returns null when nothing has been cached", () => {
+    expect(readCachedWorkspaces(USER)).toBeNull();
+  });
+
+  // The bug this cache shipped with: dedupe ran on write, so a wrong transform
+  // erased rows on disk and no later fix could recover them.
+  it("stores rows verbatim and only dedupes on read", () => {
+    writeCachedWorkspaces(USER, [
+      workspace("a", "Papr"),
+      workspace("b", "Papr"),
+    ]);
+
+    expect(readCachedWorkspaces(USER)?.data).toHaveLength(1);
+    expect(readFileRaw().workspaces).toHaveLength(2);
+  });
+
+  it("never serves another account's cache", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+
+    expect(readCachedWorkspaces(OTHER_USER)).toBeNull();
+    expect(readCachedNamespaces(OTHER_USER, "org-1")).toBeNull();
+  });
+
+  it("ignores a pre-v3 file, which carries no owner", () => {
+    fs.mkdirSync(path.dirname(cacheFilePath()), { recursive: true });
+    fs.writeFileSync(
+      cacheFilePath(),
+      JSON.stringify({
+        version: 2,
+        updatedAt: new Date().toISOString(),
+        workspaces: [workspace("a", "Papr")],
+        namespacesByOrgId: {},
+      }),
+      "utf8",
+    );
+
+    expect(readCachedWorkspaces(USER)).toBeNull();
+  });
+
+  it("treats a corrupt file as a miss and recovers on the next write", () => {
+    fs.mkdirSync(path.dirname(cacheFilePath()), { recursive: true });
+    fs.writeFileSync(cacheFilePath(), "{ truncated", "utf8");
+
+    expect(readCachedWorkspaces(USER)).toBeNull();
+
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+    expect(readCachedWorkspaces(USER)?.data).toHaveLength(1);
+  });
+
+  it("marks a cache past the freshness window as stale but still usable", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+    vi.advanceTimersByTime(CACHE_FRESH_MS + 1_000);
+
+    const read = readCachedWorkspaces(USER);
+    expect(read?.data).toHaveLength(1);
+    expect(read?.isStale).toBe(true);
+  });
+
+  it("treats a cache past the max age as a miss", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+    vi.advanceTimersByTime(CACHE_MAX_AGE_MS + 1_000);
+
+    expect(readCachedWorkspaces(USER)).toBeNull();
+  });
+
+  it("refuses to replace a populated workspace list with an empty one", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr"), workspace("b", "Acme", "ns-2")]);
+    writeCachedWorkspaces(USER, []);
+
+    expect(readCachedWorkspaces(USER)?.data).toHaveLength(2);
+  });
+
+  it("accepts a smaller non-empty list as a real membership change", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr"), workspace("b", "Acme", "ns-2")]);
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+
+    expect(readCachedWorkspaces(USER)?.data.map((entry) => entry.id)).toEqual(["a"]);
+  });
+
+  it("writes the first list even though it grows from nothing", () => {
+    writeCachedWorkspaces(USER, []);
+    expect(readCachedWorkspaces(USER)).toBeNull();
+
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+    expect(readCachedWorkspaces(USER)?.data).toHaveLength(1);
+  });
+});
+
+describe("namespace cache persistence", () => {
+  it("round-trips namespaces per organization", () => {
+    writeCachedNamespaces(USER, "org-1", [{ id: "ns-1", name: "prod" }]);
+
+    expect(readCachedNamespaces(USER, "org-1")?.data).toEqual([
+      { id: "ns-1", name: "prod" },
+    ]);
+    expect(readCachedNamespaces(USER, "org-2")).toBeNull();
+  });
+
+  it("ages each organization independently", () => {
+    writeCachedNamespaces(USER, "org-1", [{ id: "ns-1", name: "prod" }]);
+    vi.advanceTimersByTime(CACHE_FRESH_MS + 1_000);
+    writeCachedNamespaces(USER, "org-2", [{ id: "ns-2", name: "dev" }]);
+
+    expect(readCachedNamespaces(USER, "org-1")?.isStale).toBe(true);
+    expect(readCachedNamespaces(USER, "org-2")?.isStale).toBe(false);
+  });
+
+  it("refuses to replace populated namespaces with an empty list", () => {
+    writeCachedNamespaces(USER, "org-1", [{ id: "ns-1", name: "prod" }]);
+    writeCachedNamespaces(USER, "org-1", []);
+
+    expect(readCachedNamespaces(USER, "org-1")?.data).toHaveLength(1);
+  });
+
+  it("keeps namespaces when the workspace list is rewritten", () => {
+    writeCachedNamespaces(USER, "org-1", [{ id: "ns-1", name: "prod" }]);
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+
+    expect(readCachedNamespaces(USER, "org-1")?.data).toHaveLength(1);
+  });
+
+  // Entries accumulated forever before this, which is how a cache ends up with
+  // more organizations than the user has workspaces.
+  it("prunes namespace entries past the max age on the next write", () => {
+    writeCachedNamespaces(USER, "org-old", [{ id: "ns-old", name: "old" }]);
+    vi.advanceTimersByTime(CACHE_MAX_AGE_MS + 1_000);
+
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+
+    expect(readFileRaw().namespacesByOrgId).toEqual({});
+  });
+});
+
+describe("clearPaprWorkspaceCache", () => {
+  it("removes the cache so the next account starts clean", () => {
+    writeCachedWorkspaces(USER, [workspace("a", "Papr")]);
+    clearPaprWorkspaceCache();
+
+    expect(fs.existsSync(cacheFilePath())).toBe(false);
+    expect(readCachedWorkspaces(USER)).toBeNull();
+  });
+
+  it("is safe to call when no cache exists", () => {
+    expect(() => clearPaprWorkspaceCache()).not.toThrow();
+  });
+});

--- a/tests/parse-transport.test.ts
+++ b/tests/parse-transport.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  coalesce,
+  isTransientTransportError,
+  parseFetch,
+  ParseCircuitOpenError,
+  resetParseTransportState,
+} from "../src/electron/ipc/parseTransport.js";
+
+const URL_A = "https://parse.test/graphql";
+
+function jsonResponse(status = 200): Response {
+  return new Response(JSON.stringify({ data: {} }), { status });
+}
+
+function connectionReset(): Error {
+  const error = new TypeError("fetch failed");
+  (error as Error & { cause?: unknown }).cause = Object.assign(
+    new Error("read ECONNRESET"),
+    { code: "ECONNRESET" },
+  );
+  return error;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  resetParseTransportState();
+  vi.useFakeTimers();
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  resetParseTransportState();
+});
+
+/**
+ * Drive fake timers until the promise settles, so backoff sleeps resolve.
+ *
+ * Advances in small steps and stops as soon as it settles: over-advancing would
+ * push the mocked clock past the circuit-breaker window and change behaviour.
+ */
+async function settle<T>(promise: Promise<T>): Promise<T> {
+  let settled = false;
+  const raced = promise.then(
+    (value) => {
+      settled = true;
+      return { ok: true as const, value };
+    },
+    (error: unknown) => {
+      settled = true;
+      return { ok: false as const, error };
+    },
+  );
+
+  for (let i = 0; i < 200 && !settled; i++) {
+    await vi.advanceTimersByTimeAsync(25);
+  }
+
+  const result = await raced;
+  if (result.ok) return result.value;
+  throw result.error;
+}
+
+describe("isTransientTransportError", () => {
+  it("treats connection resets and 5xx as retryable", () => {
+    expect(isTransientTransportError(connectionReset())).toBe(true);
+    expect(isTransientTransportError(new Error("Parse error: 503 busy"))).toBe(true);
+    expect(isTransientTransportError(new Error("ETIMEDOUT"))).toBe(true);
+  });
+
+  it("does not retry auth or validation failures", () => {
+    expect(isTransientTransportError(new Error("Parse error: 401 bad token"))).toBe(
+      false,
+    );
+    expect(isTransientTransportError(new Error("Invalid session"))).toBe(false);
+  });
+});
+
+describe("parseFetch retry", () => {
+  it("retries a connection reset and succeeds", async () => {
+    fetchMock
+      .mockRejectedValueOnce(connectionReset())
+      .mockResolvedValueOnce(jsonResponse());
+
+    const response = await settle(parseFetch(URL_A));
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after the attempt budget instead of retrying forever", async () => {
+    fetchMock.mockRejectedValue(connectionReset());
+
+    await expect(settle(parseFetch(URL_A))).rejects.toThrow();
+
+    // 3 attempts by default — not an unbounded retry loop.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry a 4xx", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(403));
+
+    const response = await settle(parseFetch(URL_A));
+
+    expect(response.status).toBe(403);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("honours maxAttempts: 1 for mutations", async () => {
+    fetchMock.mockRejectedValue(connectionReset());
+
+    await expect(settle(parseFetch(URL_A, { maxAttempts: 1 }))).rejects.toThrow();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes an abort signal so a hung socket cannot be held open", async () => {
+    fetchMock.mockResolvedValue(jsonResponse());
+
+    await settle(parseFetch(URL_A));
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("parseFetch concurrency cap", () => {
+  it("never opens more than the cap against one origin at a time", async () => {
+    let active = 0;
+    let peak = 0;
+
+    fetchMock.mockImplementation(async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      active -= 1;
+      return jsonResponse();
+    });
+
+    const requests = Array.from({ length: 20 }, () => parseFetch(URL_A));
+    await settle(Promise.all(requests));
+
+    expect(fetchMock).toHaveBeenCalledTimes(20);
+    expect(peak).toBeLessThanOrEqual(4);
+  });
+});
+
+describe("parseFetch circuit breaker", () => {
+  it("stops calling an origin that keeps failing", async () => {
+    fetchMock.mockRejectedValue(connectionReset());
+
+    // Two calls × 3 attempts = 6 consecutive failures, hitting the threshold.
+    await expect(settle(parseFetch(URL_A))).rejects.toThrow();
+    await expect(settle(parseFetch(URL_A))).rejects.toThrow();
+    const callsBeforeOpen = fetchMock.mock.calls.length;
+
+    // No timer advance: within the open window the call must fail immediately,
+    // without reaching the network.
+    await expect(parseFetch(URL_A)).rejects.toBeInstanceOf(ParseCircuitOpenError);
+
+    expect(fetchMock.mock.calls.length).toBe(callsBeforeOpen);
+  });
+
+  it("probes again after the open window and closes on success", async () => {
+    fetchMock.mockRejectedValue(connectionReset());
+    await expect(settle(parseFetch(URL_A))).rejects.toThrow();
+    await expect(settle(parseFetch(URL_A))).rejects.toThrow();
+    await expect(settle(parseFetch(URL_A))).rejects.toBeInstanceOf(
+      ParseCircuitOpenError,
+    );
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(jsonResponse());
+
+    const response = await settle(parseFetch(URL_A));
+    expect(response.status).toBe(200);
+
+    // Circuit closed, so normal traffic flows again.
+    const next = await settle(parseFetch(URL_A));
+    expect(next.status).toBe(200);
+  });
+});
+
+describe("coalesce", () => {
+  it("shares one run between concurrent callers with the same key", async () => {
+    const run = vi.fn(
+      () => new Promise<string>((resolve) => setTimeout(() => resolve("value"), 10)),
+    );
+
+    const results = await settle(
+      Promise.all([
+        coalesce("k", run),
+        coalesce("k", run),
+        coalesce("k", run),
+      ]),
+    );
+
+    expect(results).toEqual(["value", "value", "value"]);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not share across different keys", async () => {
+    const run = vi.fn(() => Promise.resolve("value"));
+
+    await settle(Promise.all([coalesce("a", run), coalesce("b", run)]));
+
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the key so later callers run again", async () => {
+    const run = vi.fn(() => Promise.resolve("value"));
+
+    await settle(coalesce("k", run));
+    await settle(coalesce("k", run));
+
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates a rejection to every waiter and clears the key", async () => {
+    const failing = vi.fn(() => Promise.reject(new Error("boom")));
+
+    const first = coalesce("k", failing);
+    const second = coalesce("k", failing);
+
+    await expect(settle(first)).rejects.toThrow("boom");
+    await expect(settle(second)).rejects.toThrow("boom");
+    expect(failing).toHaveBeenCalledTimes(1);
+
+    await expect(settle(coalesce("k", failing))).rejects.toThrow("boom");
+    expect(failing).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/backend/appFilesLocalFallback.test.ts
+++ b/tests/unit/backend/appFilesLocalFallback.test.ts
@@ -1,0 +1,157 @@
+/**
+ * A file on disk must get a durable id even when cloud storage is down.
+ *
+ * Registering a file is how a caller stops holding a filesystem path. If an
+ * outage in a service the file has never touched makes registration fail, the
+ * caller keeps the path — and paths break on workspace migration, mean nothing
+ * on another machine, and are empty for every visitor to a published app.
+ * That is the failure this whole subsystem exists to prevent, so an unrelated
+ * 500 must not reintroduce it.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const requestUploadTicket = vi.fn();
+const commitUpload = vi.fn();
+
+vi.mock("../../../src/gateway/services/appFiles/appFilesClient.js", () => ({
+  requestUploadTicket: (...args: unknown[]) => requestUploadTicket(...args),
+  commitUpload: (...args: unknown[]) => commitUpload(...args),
+  createReadUrl: vi.fn(),
+  deleteObject: vi.fn(),
+}));
+
+vi.mock("../../../src/gateway/services/appFiles/resumableUploader.js", () => ({
+  hashFile: vi.fn(async () => "sha-of-recording"),
+  uploadResumable: vi.fn(async () => undefined),
+}));
+
+const { addFile, ensureSchema } = await import(
+  "../../../src/gateway/services/appFiles/AppFilesService.js"
+);
+const { resolveLocation } = await import(
+  "../../../src/gateway/services/appFiles/appFilesSchema.js"
+);
+
+/** In-memory stand-in for the app's SQLite, matching the FilesDb surface. */
+function memoryDb() {
+  const rows: Record<string, unknown>[] = [];
+  return {
+    rows,
+    async exec() {},
+    async run(sql: string, params: unknown[] = []) {
+      if (sql.includes("INSERT INTO app_files")) {
+        const [
+          id,
+          app_id,
+          object_key,
+          sha256,
+          size_bytes,
+          mime,
+          file_name,
+          scope,
+          local_path,
+        ] = params as string[];
+        const existing = rows.find((r) => r.object_key === object_key);
+        if (existing) {
+          existing.local_path = local_path;
+          return { changes: 1 };
+        }
+        rows.push({
+          id,
+          app_id,
+          object_key,
+          sha256,
+          size_bytes,
+          mime,
+          file_name,
+          scope,
+          local_path,
+          upload_state: sql.includes("'pending'") ? "pending" : "uploading",
+          visibility: "inherit",
+        });
+      }
+      return { changes: 1 };
+    },
+    async all<T>(sql: string, params: unknown[] = []): Promise<T[]> {
+      if (sql.includes("FROM app_files WHERE object_key")) {
+        return rows.filter((r) => r.object_key === params[0]) as T[];
+      }
+      if (sql.includes("app_file_hashes")) return [];
+      return [] as T[];
+    },
+  };
+}
+
+describe("addFile — cloud outage fallback", () => {
+  beforeEach(() => {
+    requestUploadTicket.mockReset();
+    commitUpload.mockReset();
+  });
+
+  it("still returns an id when the ticket endpoint fails", async () => {
+    requestUploadTicket.mockRejectedValue(
+      Object.assign(new Error("App Files /v1/files/tickets failed (500)"), {
+        status: 500,
+      }),
+    );
+    const db = memoryDb();
+    await ensureSchema(db);
+
+    const result = await addFile(db, {
+      appId: "app-1",
+      filePath: import.meta.url.replace("file://", ""),
+    });
+
+    expect(result.id).toBeTruthy();
+    expect(result.verified).toBe(false);
+  });
+
+  it("keeps the file readable from disk while the upload is pending", async () => {
+    requestUploadTicket.mockRejectedValue(new Error("cloud down"));
+    const db = memoryDb();
+    const localFile = import.meta.url.replace("file://", "");
+
+    await addFile(db, { appId: "app-1", filePath: localFile });
+
+    const row = db.rows[0] as { local_path: string; upload_state: string };
+    expect(row.upload_state).toBe("pending");
+    // The point of the fallback: the app can still play the recording today.
+    expect(resolveLocation(row as never)).toEqual({
+      kind: "local",
+      path: localFile,
+    });
+  });
+
+  it("reuses one row when the same file is registered twice", async () => {
+    requestUploadTicket.mockRejectedValue(new Error("cloud down"));
+    const db = memoryDb();
+    const localFile = import.meta.url.replace("file://", "");
+
+    const first = await addFile(db, { appId: "app-1", filePath: localFile });
+    const second = await addFile(db, { appId: "app-1", filePath: localFile });
+
+    // Content-addressed, so a retried job does not accumulate duplicates.
+    expect(db.rows).toHaveLength(1);
+    expect(second.id).toBe(first.id);
+  });
+
+  it("does not fall back when the cloud is reachable", async () => {
+    requestUploadTicket.mockResolvedValue({
+      object_key: "apps/app-1/sha-of-recording",
+      upload_url: null,
+      already_exists: true,
+      scope: "app",
+      max_bytes: 1_000_000_000,
+    });
+    const db = memoryDb();
+
+    const result = await addFile(db, {
+      appId: "app-1",
+      filePath: import.meta.url.replace("file://", ""),
+    });
+
+    expect(result.deduped).toBe(true);
+    expect(result.verified).toBe(true);
+  });
+});

--- a/tests/unit/backend/appFilesRetryPending.test.ts
+++ b/tests/unit/backend/appFilesRetryPending.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Files registered during a cloud outage must eventually reach the cloud.
+ *
+ * `addFileLocally` writes a `pending` row so a file on disk stays registerable
+ * while storage is down. Without a retry that is a trap rather than a
+ * fallback: the app keeps working off the local copy, the durability everyone
+ * assumes they have never arrives, and the gap only surfaces on the day the
+ * local copy is gone.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const requestUploadTicket = vi.fn();
+const commitUpload = vi.fn();
+
+vi.mock("../../../src/gateway/services/appFiles/appFilesClient.js", () => ({
+  requestUploadTicket: (...args: unknown[]) => requestUploadTicket(...args),
+  commitUpload: (...args: unknown[]) => commitUpload(...args),
+  createReadUrl: vi.fn(),
+  deleteObject: vi.fn(),
+}));
+
+vi.mock("../../../src/gateway/services/appFiles/resumableUploader.js", () => ({
+  hashFile: vi.fn(async () => "sha-recording"),
+  uploadResumable: vi.fn(async () => undefined),
+}));
+
+const { addFile, retryPendingUploads } = await import(
+  "../../../src/gateway/services/appFiles/AppFilesService.js"
+);
+
+const THIS_FILE = import.meta.url.replace("file://", "");
+
+/** In-memory stand-in for the app's SQLite, matching the FilesDb surface. */
+function memoryDb() {
+  const rows: Record<string, any>[] = [];
+  return {
+    rows,
+    async exec() {},
+    async run(sql: string, params: unknown[] = []) {
+      if (sql.startsWith("DELETE FROM app_files")) {
+        const index = rows.findIndex((r) => r.object_key === params[0]);
+        if (index >= 0) rows.splice(index, 1);
+        return { changes: 1 };
+      }
+      if (sql.includes("INSERT INTO app_files")) {
+        const [id, app_id, object_key, sha256, size_bytes, mime, file_name, scope, local_path] =
+          params as string[];
+        const existing = rows.find((r) => r.object_key === object_key);
+        if (existing) {
+          existing.local_path = local_path;
+          return { changes: 1 };
+        }
+        rows.push({
+          id,
+          app_id,
+          object_key,
+          sha256,
+          size_bytes,
+          mime,
+          file_name,
+          scope,
+          local_path,
+          upload_state: sql.includes("'pending'") ? "pending" : "uploading",
+          created_at: Date.now(),
+        });
+      }
+      return { changes: 1 };
+    },
+    async all<T>(sql: string, params: unknown[] = []): Promise<T[]> {
+      if (sql.includes("upload_state = 'pending'")) {
+        return rows.filter(
+          (r) => r.app_id === params[0] && r.upload_state === "pending" && r.local_path,
+        ) as T[];
+      }
+      if (sql.includes("FROM app_files WHERE object_key")) {
+        return rows.filter((r) => r.object_key === params[0]) as T[];
+      }
+      return [] as T[];
+    },
+  };
+}
+
+describe("retryPendingUploads", () => {
+  beforeEach(() => {
+    requestUploadTicket.mockReset();
+    commitUpload.mockReset();
+  });
+
+  it("uploads a pending file once the cloud comes back", async () => {
+    requestUploadTicket.mockRejectedValueOnce(new Error("cloud down"));
+    const db = memoryDb();
+    await addFile(db, { appId: "app-1", filePath: THIS_FILE });
+    expect(db.rows[0].upload_state).toBe("pending");
+
+    requestUploadTicket.mockResolvedValue({
+      object_key: "apps/app-1/sha-recording",
+      upload_url: null,
+      already_exists: true,
+      scope: "app",
+      max_bytes: 1e9,
+    });
+
+    const result = await retryPendingUploads(db, "app-1");
+
+    expect(result.uploaded).toBe(1);
+    // The placeholder row is replaced, not left alongside the real one —
+    // otherwise the same file would be listed twice.
+    expect(db.rows).toHaveLength(1);
+    expect(db.rows[0].object_key).toBe("apps/app-1/sha-recording");
+  });
+
+  it("leaves the row alone while the cloud is still down", async () => {
+    requestUploadTicket.mockRejectedValue(new Error("cloud down"));
+    const db = memoryDb();
+    await addFile(db, { appId: "app-1", filePath: THIS_FILE });
+
+    const result = await retryPendingUploads(db, "app-1");
+
+    // Retrying must be free of side effects, since it will run again.
+    expect(result.uploaded).toBe(0);
+    expect(result.stillPending).toBe(1);
+    expect(db.rows[0].local_path).toBe(THIS_FILE);
+  });
+
+  it("skips rows whose local copy has disappeared", async () => {
+    requestUploadTicket.mockRejectedValueOnce(new Error("cloud down"));
+    const db = memoryDb();
+    await addFile(db, { appId: "app-1", filePath: THIS_FILE });
+    db.rows[0].local_path = "/tmp/definitely-not-here.wav";
+
+    const result = await retryPendingUploads(db, "app-1");
+
+    // No bytes anywhere, so retrying forever would just log noise.
+    expect(result).toEqual({ uploaded: 0, stillPending: 0, skipped: 1 });
+  });
+
+  it("does nothing when there is nothing pending", async () => {
+    const db = memoryDb();
+    expect(await retryPendingUploads(db, "app-1")).toEqual({
+      uploaded: 0,
+      stillPending: 0,
+      skipped: 0,
+    });
+  });
+});

--- a/tests/unit/backend/tursoPreserveLocalPrimaryKey.test.ts
+++ b/tests/unit/backend/tursoPreserveLocalPrimaryKey.test.ts
@@ -1,0 +1,119 @@
+/**
+ * A pull must not strip a PRIMARY KEY the local table still declares.
+ *
+ * Regression: a PK-less remote schema overwrote the local one on every pull,
+ * and the next push copied that back up, so the loss became self-sustaining.
+ * The user-visible damage was not a sync error — jobs using
+ * `INSERT ... ON CONFLICT(id)` failed with "ON CONFLICT clause does not match
+ * any PRIMARY KEY or UNIQUE constraint", and duplicate rows piled up until
+ * they did.
+ */
+
+import { describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+
+import {
+  writeTablesToLocalDb,
+  type LocalTable,
+} from "../../../src/gateway/services/tursoSyncBridgeCore.js";
+
+function pkColumns(db: Database.Database, table: string): string[] {
+  const rows = db
+    .prepare(`SELECT name, pk FROM pragma_table_info(?)`)
+    .all(table) as Array<{ name: string; pk: number }>;
+  return rows.filter((row) => row.pk > 0).map((row) => row.name);
+}
+
+/** Remote shape after the PK was lost upstream: names and types only. */
+function pklessRemote(name: string, rows: unknown[][] = []): LocalTable {
+  return {
+    name,
+    columns: [
+      { name: "id", type: "TEXT", primaryKey: false },
+      { name: "title", type: "TEXT", primaryKey: false },
+    ],
+    rows,
+  };
+}
+
+describe("writeTablesToLocalDb — primary key preservation", () => {
+  it("keeps the local PK when the incoming remote schema has none", () => {
+    const db = new Database(":memory:");
+    db.exec(`CREATE TABLE events (id TEXT PRIMARY KEY, title TEXT)`);
+
+    writeTablesToLocalDb(db, [pklessRemote("events", [["a", "One"]])]);
+
+    expect(pkColumns(db, "events")).toEqual(["id"]);
+  });
+
+  it("keeps upserts working, so ON CONFLICT does not fail after a pull", () => {
+    const db = new Database(":memory:");
+    db.exec(`CREATE TABLE events (id TEXT PRIMARY KEY, title TEXT)`);
+
+    writeTablesToLocalDb(db, [pklessRemote("events", [["a", "One"]])]);
+
+    // The exact statement shape the calendar job uses.
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO events (id, title) VALUES (?, ?)
+           ON CONFLICT(id) DO UPDATE SET title = excluded.title`,
+        )
+        .run("a", "Updated"),
+    ).not.toThrow();
+
+    const row = db.prepare(`SELECT title FROM events WHERE id = 'a'`).get() as {
+      title: string;
+    };
+    expect(row.title).toBe("Updated");
+    expect(db.prepare(`SELECT COUNT(*) n FROM events`).get()).toEqual({ n: 1 });
+  });
+
+  it("respects the remote PK when the remote declares one", () => {
+    const db = new Database(":memory:");
+    db.exec(`CREATE TABLE events (id TEXT PRIMARY KEY, title TEXT)`);
+
+    writeTablesToLocalDb(db, [
+      {
+        name: "events",
+        columns: [
+          { name: "id", type: "TEXT", primaryKey: false },
+          { name: "title", type: "TEXT", primaryKey: true },
+        ],
+        rows: [],
+      },
+    ]);
+
+    // An intentional PK change must still win — this only backfills a *missing* key.
+    expect(pkColumns(db, "events")).toEqual(["title"]);
+  });
+
+  it("leaves genuinely key-less tables alone", () => {
+    const db = new Database(":memory:");
+    db.exec(`CREATE TABLE events (id TEXT, title TEXT)`);
+
+    writeTablesToLocalDb(db, [pklessRemote("events")]);
+
+    expect(pkColumns(db, "events")).toEqual([]);
+  });
+
+  it("does not reinstate a PK whose column the remote dropped", () => {
+    const db = new Database(":memory:");
+    db.exec(`CREATE TABLE events (legacy_id TEXT PRIMARY KEY, title TEXT)`);
+
+    // A PK naming a column that no longer exists would be invalid DDL.
+    expect(() =>
+      writeTablesToLocalDb(db, [pklessRemote("events")]),
+    ).not.toThrow();
+    expect(pkColumns(db, "events")).toEqual([]);
+  });
+
+  it("creates tables that do not exist locally yet", () => {
+    const db = new Database(":memory:");
+
+    expect(() =>
+      writeTablesToLocalDb(db, [pklessRemote("fresh", [["a", "One"]])]),
+    ).not.toThrow();
+    expect(db.prepare(`SELECT COUNT(*) n FROM fresh`).get()).toEqual({ n: 1 });
+  });
+});

--- a/tests/unit/backend/tursoPreserveLocalPrimaryKey.test.ts
+++ b/tests/unit/backend/tursoPreserveLocalPrimaryKey.test.ts
@@ -7,21 +7,60 @@
  * `INSERT ... ON CONFLICT(id)` failed with "ON CONFLICT clause does not match
  * any PRIMARY KEY or UNIQUE constraint", and duplicate rows piled up until
  * they did.
+ *
+ * Uses `node:sqlite` rather than the vendored better-sqlite3, which is built
+ * for Electron's ABI and cannot load under plain vitest — same approach as
+ * tests/cdc-trigger-atomic-refresh.test.ts.
  */
 
 import { describe, expect, it } from "vitest";
-import Database from "better-sqlite3";
+import { createRequire } from "node:module";
 
 import {
   writeTablesToLocalDb,
   type LocalTable,
 } from "../../../src/gateway/services/tursoSyncBridgeCore.js";
 
-function pkColumns(db: Database.Database, table: string): string[] {
-  const rows = db
-    .prepare(`SELECT name, pk FROM pragma_table_info(?)`)
-    .all(table) as Array<{ name: string; pk: number }>;
+// Required rather than imported: Vite tries to resolve a bare `node:sqlite`
+// import and fails. Same approach as tests/cdc-trigger-atomic-refresh.test.ts.
+const { DatabaseSync } = createRequire(import.meta.url)("node:sqlite") as {
+  DatabaseSync: new (path: string) => unknown;
+};
+
+/**
+ * `node:sqlite` exposes exec/prepare but not the two better-sqlite3 helpers
+ * the sync code uses: `.pragma()` and `.transaction()`. Bridging them here
+ * keeps the test running the real implementation rather than a
+ * reimplementation of it, which is the only version worth asserting against.
+ */
+function openDb(): any {
+  const db = new DatabaseSync(":memory:") as any;
+  db.pragma = (statement: string) => db.exec(`PRAGMA ${statement}`);
+  db.transaction = (fn: (...args: unknown[]) => unknown) =>
+    (...args: unknown[]) => {
+      db.exec("BEGIN");
+      try {
+        const result = fn(...args);
+        db.exec("COMMIT");
+        return result;
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+    };
+  return db;
+}
+
+function pkColumns(db: any, table: string): string[] {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+    name: string;
+    pk: number;
+  }>;
   return rows.filter((row) => row.pk > 0).map((row) => row.name);
+}
+
+function count(db: any, table: string): number {
+  return Number((db.prepare(`SELECT COUNT(*) n FROM ${table}`).get() as any).n);
 }
 
 /** Remote shape after the PK was lost upstream: names and types only. */
@@ -38,7 +77,7 @@ function pklessRemote(name: string, rows: unknown[][] = []): LocalTable {
 
 describe("writeTablesToLocalDb — primary key preservation", () => {
   it("keeps the local PK when the incoming remote schema has none", () => {
-    const db = new Database(":memory:");
+    const db = openDb();
     db.exec(`CREATE TABLE events (id TEXT PRIMARY KEY, title TEXT)`);
 
     writeTablesToLocalDb(db, [pklessRemote("events", [["a", "One"]])]);
@@ -47,7 +86,7 @@ describe("writeTablesToLocalDb — primary key preservation", () => {
   });
 
   it("keeps upserts working, so ON CONFLICT does not fail after a pull", () => {
-    const db = new Database(":memory:");
+    const db = openDb();
     db.exec(`CREATE TABLE events (id TEXT PRIMARY KEY, title TEXT)`);
 
     writeTablesToLocalDb(db, [pklessRemote("events", [["a", "One"]])]);
@@ -66,11 +105,11 @@ describe("writeTablesToLocalDb — primary key preservation", () => {
       title: string;
     };
     expect(row.title).toBe("Updated");
-    expect(db.prepare(`SELECT COUNT(*) n FROM events`).get()).toEqual({ n: 1 });
+    expect(count(db, "events")).toBe(1);
   });
 
   it("respects the remote PK when the remote declares one", () => {
-    const db = new Database(":memory:");
+    const db = openDb();
     db.exec(`CREATE TABLE events (id TEXT PRIMARY KEY, title TEXT)`);
 
     writeTablesToLocalDb(db, [
@@ -89,7 +128,7 @@ describe("writeTablesToLocalDb — primary key preservation", () => {
   });
 
   it("leaves genuinely key-less tables alone", () => {
-    const db = new Database(":memory:");
+    const db = openDb();
     db.exec(`CREATE TABLE events (id TEXT, title TEXT)`);
 
     writeTablesToLocalDb(db, [pklessRemote("events")]);
@@ -98,7 +137,7 @@ describe("writeTablesToLocalDb — primary key preservation", () => {
   });
 
   it("does not reinstate a PK whose column the remote dropped", () => {
-    const db = new Database(":memory:");
+    const db = openDb();
     db.exec(`CREATE TABLE events (legacy_id TEXT PRIMARY KEY, title TEXT)`);
 
     // A PK naming a column that no longer exists would be invalid DDL.
@@ -109,11 +148,11 @@ describe("writeTablesToLocalDb — primary key preservation", () => {
   });
 
   it("creates tables that do not exist locally yet", () => {
-    const db = new Database(":memory:");
+    const db = openDb();
 
     expect(() =>
       writeTablesToLocalDb(db, [pklessRemote("fresh", [["a", "One"]])]),
     ).not.toThrow();
-    expect(db.prepare(`SELECT COUNT(*) n FROM fresh`).get()).toEqual({ n: 1 });
+    expect(count(db, "fresh")).toBe(1);
   });
 });

--- a/ui/components/Sidebar/ProfileFooter.tsx
+++ b/ui/components/Sidebar/ProfileFooter.tsx
@@ -54,6 +54,13 @@ export function ProfileFooter({ onOpenProfile, onOpenSettings }: ProfileFooterPr
       void loadProfile({ force: true });
     };
 
+    // The workspace cache is rewritten by background Parse refreshes, and the
+    // reload this triggers is what starts those refreshes. Throttling it keeps
+    // the two from driving each other.
+    const refreshFromCacheUpdate = () => {
+      void loadProfile({ force: true, throttle: true });
+    };
+
     window.addEventListener("papr-auth-success", refresh);
     window.addEventListener("papr-logout-success", refresh);
     window.addEventListener("papr-organization-changed", refresh);
@@ -63,7 +70,7 @@ export function ProfileFooter({ onOpenProfile, onOpenSettings }: ProfileFooterPr
     window.electronAPI.papr.onLogoutSuccess(refresh);
     window.electronAPI.papr.onOrganizationChanged(refresh);
     window.electronAPI.papr.onNamespaceChanged(refresh);
-    window.electronAPI.papr.onWorkspaceCacheUpdated(refresh);
+    window.electronAPI.papr.onWorkspaceCacheUpdated(refreshFromCacheUpdate);
 
     return () => {
       window.removeEventListener("papr-auth-success", refresh);
@@ -75,7 +82,9 @@ export function ProfileFooter({ onOpenProfile, onOpenSettings }: ProfileFooterPr
       window.electronAPI.papr.removeLogoutSuccessListener(refresh);
       window.electronAPI.papr.removeOrganizationChangedListener(refresh);
       window.electronAPI.papr.removeNamespaceChangedListener(refresh);
-      window.electronAPI.papr.removeWorkspaceCacheUpdatedListener(refresh);
+      window.electronAPI.papr.removeWorkspaceCacheUpdatedListener(
+        refreshFromCacheUpdate,
+      );
     };
   }, [loadProfile]);
 

--- a/ui/stores/profileStore.ts
+++ b/ui/stores/profileStore.ts
@@ -25,7 +25,15 @@ interface ProfileState {
   namespaceName: string;
   workspaceName: string;
   loaded: boolean;
-  loadProfile: (options?: { force?: boolean }) => Promise<void>;
+  loadProfile: (options?: {
+    force?: boolean;
+    /**
+     * Skip the refresh if one completed very recently. For background triggers
+     * (workspace cache rewrites) where staleness is cheap — never for user
+     * actions like switching org, which must be reflected immediately.
+     */
+    throttle?: boolean;
+  }) => Promise<void>;
   setProfile: (profile: {
     name?: string;
     email?: string;
@@ -41,6 +49,10 @@ const cached = readProfileSidebarCache();
 
 let refreshInFlight: Promise<void> | null = null;
 let profileImageRetryInFlight: Promise<void> | null = null;
+
+/** Shortest gap between background (throttled) refreshes. */
+const MIN_FORCED_REFRESH_INTERVAL_MS = 10_000;
+let lastRefreshAt = 0;
 
 function persistProfileSnapshot(state: {
   name: string;
@@ -248,9 +260,21 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
   loadProfile: async (options) => {
     const force = options?.force === true;
     if (!force && get().loaded) return;
+
+    // Join the running refresh rather than queueing another one behind it.
+    // Previously a forced call awaited the in-flight promise and then started a
+    // second pass, so N concurrent workspace events produced N full refreshes
+    // (profile + plan + workspace list) instead of one.
     if (refreshInFlight) {
       await refreshInFlight;
-      if (!force) return;
+      return;
+    }
+
+    if (
+      options?.throttle === true &&
+      Date.now() - lastRefreshAt < MIN_FORCED_REFRESH_INTERVAL_MS
+    ) {
+      return;
     }
 
     refreshInFlight = (async () => {
@@ -276,6 +300,7 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
         console.error("[ProfileStore] Load error:", err);
         set({ loaded: true });
       } finally {
+        lastRefreshAt = Date.now();
         refreshInFlight = null;
       }
     })();


### PR DESCRIPTION
fix: App Files source resolution and Turso primary-key loss

Three independent bugs that surfaced together.

1. App Files 400s on every multi-DB app

GET /api/files?appId=... resolved through the generic mini-app source
router, which demands an explicit sourceId once an app links more than one
database. The Files panel is app-scoped — the user dropped a file on an app,
not on "Whisper Transcriber" — so there is nothing to disambiguate. Every app
with other than exactly one linked DB failed on the first call, which is why
the feature never worked end to end.

resolveFilesSource picks a home: explicit sourceId, then the standard
resolver (so single/legacy-primary apps are untouched), then a source that
already holds app_files, then first-by-sorted-alias. Only 400s are caught;
404 "no sources linked" still propagates rather than inventing a database.

2. Duplicate aliases resolved by array order

findDataSource matched ids and aliases in one .find(). Ids are unique;
aliases are display names that can repeat. With a duplicated alias the result
depended on array order, so an app could read an empty database while its data
sat in the duplicate — silently, since empty results look like "no data yet".
Ids now match first and exhaustively, and duplicate aliases are logged.

3. Turso pulls stripped local PRIMARY KEYs

A pull rebuilds the local table from the remote definition. Once a remote
table lost its PK, every pull stripped the local PK too and the next push
copied that back up: self-sustaining, with no single run looking guilty.

The damage showed up away from sync. INSERT ... ON CONFLICT(id) requires a
PK or UNIQUE constraint, so the calendar job failed every run with "ON
CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint" and the
app's calendar went stale. Before failing it had accumulated duplicates —
2354 rows for 386 distinct ids, one id repeated 17 times.

writeTablesToLocalDb now reinstates a local PK the remote is missing.
Restoring a declared constraint cannot lose data; dropping one silently
admits duplicates. An intentional PK change still wins, and a key naming a
column the remote dropped is left alone rather than producing invalid DDL.

Verified: calendar job completes, 642 events through 2026-09-15.
