### PR TITLE
feat(app-files): preview and download stored files in the workspace panel

### DIFF
--- a/src/gateway/services/appFiles/AppFilesService.ts
+++ b/src/gateway/services/appFiles/AppFilesService.ts
@@ -570,13 +570,17 @@ export async function getFile(db: FilesDb, id: string): Promise<AppFileRow | nul
 export async function resolveFileUrl(
   db: FilesDb,
   id: string,
+  options: { download?: boolean } = {},
 ): Promise<{ location: FileLocation; url?: string }> {
   const row = await getFile(db, id);
   if (!row) throw Object.assign(new Error(`File ${id} not found`), { status: 404 });
 
   const location = resolveLocation(row);
   if (location.kind === "cloud") {
-    const { url } = await createReadUrl(row.app_id, row.object_key);
+    const { url } = await createReadUrl(row.app_id, row.object_key, {
+      download: options.download,
+      fileName: row.file_name,
+    });
     return { location, url };
   }
   return { location };

--- a/src/gateway/services/appFiles/appFilesClient.ts
+++ b/src/gateway/services/appFiles/appFilesClient.ts
@@ -89,10 +89,16 @@ export async function commitUpload(
 export async function createReadUrl(
   appId: string,
   objectKey: string,
+  options: { download?: boolean; fileName?: string } = {},
 ): Promise<{ url: string; expiresInSeconds: number }> {
   const res = await post<{ url: string; expires_in_seconds: number }>(
     "/v1/files/read-url",
-    { app_id: appId, object_key: objectKey },
+    {
+      app_id: appId,
+      object_key: objectKey,
+      download: options.download ?? false,
+      file_name: options.fileName,
+    }
   );
   return { url: res.url, expiresInSeconds: res.expires_in_seconds };
 }

--- a/src/gateway/services/appFiles/appFilesRoutes.ts
+++ b/src/gateway/services/appFiles/appFilesRoutes.ts
@@ -14,6 +14,7 @@ import {
   commitBrowserUpload,
   createBrowserTicket,
   ensureSchema,
+  getFile,
   listFiles,
   removeFile,
   resolveFileUrl,
@@ -227,10 +228,11 @@ export function registerAppFilesRoutes(
   /** Resolve a file to a readable URL — local path or short-lived signed URL. */
   app.post("/api/files/url", async (req, res) => {
     try {
-      const { appId, sourceId, id } = req.body as {
+      const { appId, sourceId, id, download } = req.body as {
         appId?: string;
         sourceId?: string;
         id?: string;
+        download?: boolean;
       };
       if (!id) {
         res.status(400).json({ error: "id is required" });
@@ -244,7 +246,7 @@ export function registerAppFilesRoutes(
         return;
       }
       const db = await dbFor(resolved.appId, sourceId, deps);
-      res.json(await resolveFileUrl(db, id));
+      res.json(await resolveFileUrl(db, id, { download }));
     } catch (err) {
       fail(res, err);
     }
@@ -371,6 +373,7 @@ export function registerAppFilesRoutes(
       }
 
       const db = await dbFor(resolved.appId, sourceId, deps);
+      const row = await getFile(db, id);
       const { location } = await resolveFileUrl(db, id);
       if (location.kind !== "local") {
         // Cloud files are served by a signed URL, and unavailable ones have no
@@ -384,7 +387,11 @@ export function registerAppFilesRoutes(
         return;
       }
 
-      res.sendFile(location.path);
+      if (req.query.download === "1") {
+        res.download(location.path, row?.file_name || "download");
+      } else {
+        res.sendFile(location.path);
+      }
     } catch (err) {
       fail(res, err);
     }

--- a/ui/components/Apps/AppFilePreview.css
+++ b/ui/components/Apps/AppFilePreview.css
@@ -1,0 +1,18 @@
+.app-file-preview { flex: 1; min-height: 0; display: flex; flex-direction: column; background: var(--background-color); }
+.app-file-preview__head { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 12px 16px; border-bottom: 1px solid var(--border-color); background: var(--glass-bg); }
+.app-file-preview__title-wrap { min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+.app-file-preview__title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; color: var(--text-primary); }
+.app-file-preview__meta { font-size: 11px; color: var(--text-secondary); }
+.app-file-preview__download { flex-shrink: 0; border: 0; border-radius: 999px; padding: 7px 14px; background: var(--accent); color: #fff; font-size: 11px; font-weight: 700; cursor: pointer; }
+.app-file-preview__download:disabled { opacity: .45; cursor: default; }
+.app-file-preview__error { padding: 10px 16px; color: var(--error-color); border-bottom: 1px solid var(--border-color); font-size: 12px; }
+.app-file-preview__status, .app-file-preview__unsupported { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--text-secondary); font-size: 13px; }
+.app-file-preview__audio { width: min(720px, calc(100% - 64px)); margin: auto; }
+.app-file-preview__video { width: 100%; height: 100%; object-fit: contain; background: #000; }
+.app-file-preview__image-wrap { flex: 1; min-height: 0; overflow: auto; display: grid; place-items: center; padding: 24px; }
+.app-file-preview__image { display: block; max-width: 100%; max-height: 100%; object-fit: contain; border-radius: 8px; box-shadow: 0 12px 40px rgba(0,0,0,.16); }
+.app-file-preview__pdf { flex: 1; width: 100%; min-height: 0; border: 0; background: #fff; }
+.app-file-preview__text { flex: 1; min-height: 0; overflow: auto; margin: 0; padding: 20px; white-space: pre-wrap; word-break: break-word; font: 12px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--text-primary); background: var(--background-color); }
+.app-file-preview__unsupported { flex-direction: column; gap: 8px; text-align: center; padding: 32px; }
+.app-file-preview__unsupported strong { color: var(--text-primary); }
+.app-file-preview__file-glyph { width: 48px; height: 48px; display: grid; place-items: center; border-radius: 14px; border: 1px solid var(--border-color); color: var(--accent); font-size: 24px; }

--- a/ui/components/Apps/AppFilePreview.tsx
+++ b/ui/components/Apps/AppFilePreview.tsx
@@ -1,0 +1,75 @@
+/** Right-pane preview and download surface for a stored App File. */
+
+import React, { useEffect, useState } from "react";
+import type { AppFileRow } from "../../../src/gateway/services/appFiles/appFilesSchema";
+import { appFileContentUrl, downloadAppFile, resolveAppFileUrl } from "../../utils/appFilesApi";
+import { formatBytes } from "../../utils/appFilesFormat";
+import { previewKind } from "../../utils/appFilesPreview";
+import "./AppFilePreview.css";
+
+export function AppFilePreview({ appId, file }: { appId: string; file: AppFileRow }) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [text, setText] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState(false);
+  const kind = previewKind(file);
+
+  useEffect(() => {
+    let cancelled = false;
+    setUrl(null);
+    setText(null);
+    setError(null);
+    void resolveAppFileUrl(appId, file.id)
+      .then(async (resolved) => {
+        if (cancelled) return;
+        const readable = resolved.location.kind === "local" ? appFileContentUrl(appId, file.id) : resolved.url;
+        if (!readable) throw new Error(resolved.location.reason ?? "No readable copy is available.");
+        setUrl(readable);
+        if (kind === "text") {
+          const response = await fetch(readable);
+          if (!response.ok) throw new Error(`Preview failed (${response.status})`);
+          const body = await response.text();
+          if (!cancelled) setText(body.slice(0, 512_000));
+        }
+      })
+      .catch((err) => !cancelled && setError((err as Error).message));
+    return () => { cancelled = true; };
+  }, [appId, file.id, kind]);
+
+  const download = async () => {
+    setDownloading(true);
+    setError(null);
+    try { await downloadAppFile(appId, file); }
+    catch (err) { setError((err as Error).message); }
+    finally { setDownloading(false); }
+  };
+
+  return (
+    <div className="app-file-preview">
+      <header className="app-file-preview__head">
+        <div className="app-file-preview__title-wrap">
+          <strong className="app-file-preview__title">{file.file_name}</strong>
+          <span className="app-file-preview__meta">{file.mime || "Unknown type"} · {formatBytes(file.size_bytes)}</span>
+        </div>
+        <button className="app-file-preview__download" type="button" disabled={downloading || !url} onClick={() => void download()}>
+          {downloading ? "Downloading…" : "Download"}
+        </button>
+      </header>
+
+      {error ? <div className="app-file-preview__error">{error}</div> : null}
+      {!url && !error ? <div className="app-file-preview__status">Preparing preview…</div> : null}
+      {url && kind === "audio" ? <audio className="app-file-preview__audio" controls preload="metadata" src={url} /> : null}
+      {url && kind === "video" ? <video className="app-file-preview__video" controls preload="metadata" src={url} /> : null}
+      {url && kind === "image" ? <div className="app-file-preview__image-wrap"><img className="app-file-preview__image" src={url} alt={file.file_name} /></div> : null}
+      {url && kind === "pdf" ? <iframe className="app-file-preview__pdf" src={url} title={file.file_name} /> : null}
+      {url && kind === "text" ? <pre className="app-file-preview__text">{text ?? "Loading text…"}</pre> : null}
+      {url && kind === "unsupported" ? (
+        <div className="app-file-preview__unsupported">
+          <div className="app-file-preview__file-glyph" aria-hidden>↓</div>
+          <strong>No inline preview for this file type</strong>
+          <span>Download the original file to open it in another app.</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/components/Apps/AppFileRowItem.tsx
+++ b/ui/components/Apps/AppFileRowItem.tsx
@@ -21,6 +21,8 @@ import {
 interface AppFileRowItemProps {
   file: AppFileRow;
   busy: boolean;
+  selected: boolean;
+  onSelect: () => void;
   onTogglePrivate: (isPrivate: boolean) => void;
   onEvict: () => void;
   onRemove: () => void;
@@ -62,6 +64,8 @@ function LockIcon({ locked }: { locked: boolean }) {
 export function AppFileRowItem({
   file,
   busy,
+  selected,
+  onSelect,
   onTogglePrivate,
   onEvict,
   onRemove,
@@ -70,7 +74,19 @@ export function AppFileRowItem({
   const percent = uploadPercent(file);
 
   return (
-    <li className={`app-file${busy ? " app-file--busy" : ""}`}>
+    <li
+      className={`app-file${busy ? " app-file--busy" : ""}${selected ? " app-file--selected" : ""}`}
+      onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-selected={selected}
+    >
       <StateDot file={file} />
 
       <span className="app-file__name" title={file.file_name}>
@@ -87,7 +103,10 @@ export function AppFileRowItem({
           className={`app-file__icon${isPrivate ? " app-file__icon--on" : ""}`}
           disabled={busy}
           aria-pressed={isPrivate}
-          onClick={() => onTogglePrivate(!isPrivate)}
+          onClick={(event) => {
+            event.stopPropagation();
+            onTogglePrivate(!isPrivate);
+          }}
           title={isPrivate ? "Private — never published" : "Published with the app"}
         >
           <LockIcon locked={isPrivate} />
@@ -98,7 +117,10 @@ export function AppFileRowItem({
             type="button"
             className="app-file__text-action"
             disabled={busy}
-            onClick={onEvict}
+            onClick={(event) => {
+              event.stopPropagation();
+              onEvict();
+            }}
             title="Delete the copy on this Mac. The cloud copy is kept."
           >
             Free
@@ -109,7 +131,10 @@ export function AppFileRowItem({
           type="button"
           className="app-file__text-action app-file__text-action--danger"
           disabled={busy}
-          onClick={onRemove}
+          onClick={(event) => {
+            event.stopPropagation();
+            onRemove();
+          }}
           title="Delete everywhere"
         >
           Remove

--- a/ui/components/Apps/AppFilesPanel.css
+++ b/ui/components/Apps/AppFilesPanel.css
@@ -74,8 +74,14 @@
   border-radius: 6px;
 }
 
-.app-file:hover {
+.app-file:hover,
+.app-file--selected {
   background: var(--background-hover);
+}
+
+.app-file:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: -2px;
 }
 
 .app-file--busy {

--- a/ui/components/Apps/AppFilesPanel.tsx
+++ b/ui/components/Apps/AppFilesPanel.tsx
@@ -27,7 +27,15 @@ import { formatBytes, totalBytes } from "../../utils/appFilesFormat";
 import { AppFileRowItem } from "./AppFileRowItem";
 import "./AppFilesPanel.css";
 
-export function AppFilesPanel({ appId }: { appId: string }) {
+export function AppFilesPanel({
+  appId,
+  selectedId,
+  onSelect,
+}: {
+  appId: string;
+  selectedId: string | null;
+  onSelect: (file: AppFileRow) => void;
+}) {
   const [files, setFiles] = useState<AppFileRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [dragging, setDragging] = useState(false);
@@ -124,6 +132,8 @@ export function AppFilesPanel({ appId }: { appId: string }) {
               key={file.id}
               file={file}
               busy={busyId === file.id}
+              selected={selectedId === file.id}
+              onSelect={() => onSelect(file)}
               onTogglePrivate={(isPrivate) =>
                 void act(file.id, () => setAppFilePrivacy(appId, file.id, isPrivate))
               }

--- a/ui/components/Apps/MiniAppFilesView.tsx
+++ b/ui/components/Apps/MiniAppFilesView.tsx
@@ -2,7 +2,8 @@
  * MiniAppFilesView — folder tree, syntax-highlighted editor, and DB preview.
  */
 
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import type { AppFileRow } from "../../../src/gateway/services/appFiles/appFilesSchema";
 import {
   detectWorkspaceLanguage,
   isBinaryWorkspaceFile,
@@ -14,6 +15,7 @@ import { WorkspaceDbPreview } from "./WorkspaceDbPreview";
 import { WorkspaceFileTree } from "./WorkspaceFileTree";
 import { MiniAppDataSourcesPanel } from "./MiniAppDataSourcesPanel";
 import { AppFilesPanel } from "./AppFilesPanel";
+import { AppFilePreview } from "./AppFilePreview";
 import { MiniAppCodeSearch } from "./MiniAppCodeSearch";
 import "./MiniAppFilesView.css";
 import "./WorkspaceCodeEditor.css";
@@ -57,6 +59,7 @@ function JobIcon() {
 
 export function MiniAppFilesView({ appId }: MiniAppFilesViewProps) {
   const workspace = useAppWorkspace(appId);
+  const [selectedAppFile, setSelectedAppFile] = useState<AppFileRow | null>(null);
 
   const language = workspace.selected
     ? detectWorkspaceLanguage(workspace.selected.path)
@@ -118,7 +121,10 @@ export function MiniAppFilesView({ appId }: MiniAppFilesViewProps) {
         <MiniAppCodeSearch
           appId={appId}
           jobs={jobGroups}
-          onOpenHit={(target) => void workspace.openTarget(target)}
+          onOpenHit={(target) => {
+            setSelectedAppFile(null);
+            void workspace.openTarget(target);
+          }}
         />
 
         <div className="mini-app-files__tree">
@@ -127,7 +133,11 @@ export function MiniAppFilesView({ appId }: MiniAppFilesViewProps) {
           {/* Beside data sources rather than in the file tree: App Files are
               attached storage, not source code, and must never look like
               something git carries. */}
-          <AppFilesPanel appId={appId} />
+          <AppFilesPanel
+            appId={appId}
+            selectedId={selectedAppFile?.id ?? null}
+            onSelect={setSelectedAppFile}
+          />
 
           {appGroup.length === 0 && jobGroups.length === 0 && !workspace.loadingTree ? (
             <p className="mini-app-files__empty">No files found.</p>
@@ -149,7 +159,10 @@ export function MiniAppFilesView({ appId }: MiniAppFilesViewProps) {
                 scope="app"
                 appId={appId}
                 selectedKey={workspace.selectedKey}
-                onSelect={(target) => void workspace.openTarget(target)}
+                onSelect={(target) => {
+                  setSelectedAppFile(null);
+                  void workspace.openTarget(target);
+                }}
               />
             </section>
           ) : null}
@@ -177,7 +190,10 @@ export function MiniAppFilesView({ appId }: MiniAppFilesViewProps) {
                 appId={appId}
                 jobId={job.jobId}
                 selectedKey={workspace.selectedKey}
-                onSelect={(target) => void workspace.openTarget(target)}
+                onSelect={(target) => {
+                  setSelectedAppFile(null);
+                  void workspace.openTarget(target);
+                }}
               />
             </section>
           ))}
@@ -185,7 +201,9 @@ export function MiniAppFilesView({ appId }: MiniAppFilesViewProps) {
       </aside>
 
       <section className="mini-app-files__editor">
-        {!workspace.selected ? (
+        {selectedAppFile ? (
+          <AppFilePreview appId={appId} file={selectedAppFile} />
+        ) : !workspace.selected ? (
           <div className="mini-app-files__placeholder">
             <p>Select a file to view or edit its source.</p>
             <p className="mini-app-files__placeholder-sub">

--- a/ui/utils/appFilesApi.ts
+++ b/ui/utils/appFilesApi.ts
@@ -33,11 +33,52 @@ async function call<T>(path: string, body?: unknown): Promise<T> {
   return (await res.json()) as T;
 }
 
+export type AppFileLocation =
+  | { kind: "local"; path: string }
+  | { kind: "cloud"; objectKey: string }
+  | { kind: "unavailable"; reason: string };
+
 export async function listAppFiles(appId: string): Promise<AppFileRow[]> {
   const body = await call<{ files: AppFileRow[] }>(
     `/api/files?appId=${encodeURIComponent(appId)}`,
   );
   return body.files ?? [];
+}
+
+export function appFileContentUrl(appId: string, id: string, download = false): string {
+  const suffix = download ? "&download=1" : "";
+  return `${GATEWAY}/api/files/content?appId=${encodeURIComponent(appId)}&id=${encodeURIComponent(id)}${suffix}`;
+}
+
+export async function resolveAppFileUrl(
+  appId: string,
+  id: string,
+  download = false,
+): Promise<{ location: AppFileLocation; url?: string }> {
+  return call(`/api/files/url`, { appId, id, download });
+}
+
+/** Download without buffering multi-GB files in the renderer. */
+export async function downloadAppFile(appId: string, file: AppFileRow): Promise<void> {
+  const resolved = await resolveAppFileUrl(appId, file.id, true);
+  const href =
+    resolved.location.kind === "local"
+      ? appFileContentUrl(appId, file.id, true)
+      : resolved.url;
+  if (!href) {
+    const reason = resolved.location.kind === "unavailable"
+      ? resolved.location.reason
+      : "No readable copy is available.";
+    throw new Error(reason);
+  }
+
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = file.file_name;
+  anchor.rel = "noopener";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
 }
 
 export async function uploadAppFile(

--- a/ui/utils/appFilesPreview.ts
+++ b/ui/utils/appFilesPreview.ts
@@ -1,0 +1,31 @@
+/** Preview classification for App Files. Keep this pure so MIME/extension
+ * fallbacks are unit tested independently from React and the gateway. */
+
+import type { AppFileRow } from "../../src/gateway/services/appFiles/appFilesSchema";
+
+export type AppFilePreviewKind = "audio" | "image" | "pdf" | "text" | "video" | "unsupported";
+
+const TEXT_EXTENSIONS = new Set([
+  "csv", "json", "log", "md", "rtf", "text", "toml", "tsv", "txt", "xml", "yaml", "yml",
+]);
+
+export function previewKind(file: Pick<AppFileRow, "file_name" | "mime">): AppFilePreviewKind {
+  const mime = (file.mime ?? "").toLowerCase();
+  if (mime.startsWith("audio/")) return "audio";
+  if (mime.startsWith("image/")) return "image";
+  if (mime === "application/pdf") return "pdf";
+  if (mime.startsWith("text/") || mime.includes("json") || mime.includes("xml")) return "text";
+  if (mime.startsWith("video/")) return "video";
+
+  const extension = file.file_name.toLowerCase().split(".").pop() ?? "";
+  if (["aac", "flac", "m4a", "mp3", "ogg", "opus", "wav"].includes(extension)) return "audio";
+  if (["avif", "gif", "heic", "jpeg", "jpg", "png", "svg", "webp"].includes(extension)) return "image";
+  if (extension === "pdf") return "pdf";
+  if (TEXT_EXTENSIONS.has(extension)) return "text";
+  if (["m4v", "mkv", "mov", "mp4", "webm"].includes(extension)) return "video";
+  return "unsupported";
+}
+
+export function canPreviewAppFile(file: Pick<AppFileRow, "file_name" | "mime">): boolean {
+  return previewKind(file) !== "unsupported";
+}


### PR DESCRIPTION
feat(app-files): preview and download stored files in the workspace panel

The Files panel listed files and offered no way to look at any of them.
Selecting a row did nothing, so a 900 MB recording could be stored,
verified and synced, and still be unopenable from the app that owns it.

Selecting a file now fills the right pane, inline where the format allows
it: audio, video, images, PDFs, and text. Anything else shows its size and
type with a download button rather than an empty frame or a browser tab of
binary garbage.

Neither path buffers bytes in the renderer, which is what makes this work
at recording sizes. Local files stream from the gateway with range requests
so a player can seek; cloud files use a signed URL the browser fetches
directly. An anchor click starts the transfer in both cases.

Download had to be more than "open it". A signed GCS URL for an mp3 opens a
player; a PDF opens a viewer. Both now carry Content-Disposition:
attachment - res.download locally, response_disposition on the signed URL -
so the button saves a file. The filename is sanitised before it reaches
that header.

Source files and stored files share one pane, so selecting either clears
the other. Rows are keyboard reachable, and the existing per-row buttons
stopPropagation so lock/free/remove do not also open a preview.
