### PR TITLE
fix(papr): stop login provisioning from claiming a shared workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ certificate.*
 # Local data exports (personal snapshots, not app source)
 batch.json
 data_snapshot.json
+papr-members-*.csv
 
 # Python
 __pycache__/

--- a/scripts/check-papr-role-membership.cjs
+++ b/scripts/check-papr-role-membership.cjs
@@ -1,0 +1,149 @@
+/**
+ * Inspect a workspace's Parse _Role and who is inside it.
+ *
+ * The Organization ACL grants read to `role:member-<workspaceId>`, so a user can
+ * only see their team's org if they are actually a member of that _Role. Adding a
+ * workspace_follower row is a separate write, so the two can disagree.
+ *
+ *   node_modules/.bin/electron scripts/check-papr-role-membership.cjs [workspaceId] [userId...]
+ *
+ * Contains no mutations.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const electron = require("electron");
+
+const { app, safeStorage } = electron;
+
+app.setName("Papr Work");
+
+const PARSE_SERVER_URL =
+  process.env.PARSE_SERVER_URL || "https://server.papr.ai/parse";
+const PARSE_APP_ID =
+  process.env.PARSE_APP_ID || "671e705a-f735-4ec0-8474-15899a475440";
+
+const args = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+const WORKSPACE_ID = args[0] || "qDgAdi2eMf";
+const USER_IDS = args.length > 1 ? args.slice(1) : ["9TXbNLCGtE", "mkcNHhG5KP"];
+
+function readSessionToken() {
+  const keysFile = path.join(
+    app.getPath("userData"),
+    "data",
+    "custom-keys.global.json",
+  );
+  const store = JSON.parse(fs.readFileSync(keysFile, "utf8"));
+  const entry = Object.values(store).find(
+    (k) => k && k.name === "PAPR_SESSION_TOKEN",
+  );
+  if (!entry?.encryptedValue) throw new Error("PAPR_SESSION_TOKEN not found");
+  return safeStorage.decryptString(Buffer.from(entry.encryptedValue, "base64"));
+}
+
+async function restGet(sessionToken, urlPath, params) {
+  const url = new URL(`${PARSE_SERVER_URL}${urlPath}`);
+  for (const [key, value] of Object.entries(params ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  const response = await fetch(url.toString(), {
+    headers: {
+      "X-Parse-Application-Id": PARSE_APP_ID,
+      "X-Parse-Session-Token": sessionToken,
+    },
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Parse REST ${response.status}: ${text.slice(0, 300)}`);
+  }
+  return JSON.parse(text);
+}
+
+function relatedToUsers(roleId) {
+  return {
+    $relatedTo: {
+      object: { __type: "Pointer", className: "_Role", objectId: roleId },
+      key: "users",
+    },
+  };
+}
+
+async function main() {
+  await app.whenReady();
+  const sessionToken = readSessionToken();
+
+  const roleNames = [`member-${WORKSPACE_ID}`, `Follower-${WORKSPACE_ID}`];
+  console.log(`Looking for roles ${roleNames.join(", ")} on ${PARSE_SERVER_URL}\n`);
+
+  const roles = await restGet(sessionToken, "/roles", {
+    where: JSON.stringify({ name: { $in: roleNames } }),
+    limit: "10",
+  });
+
+  if (!roles.results.length) {
+    console.log(`No roles named ${roleNames.join(" or ")} exist.`);
+    console.log(
+      "That alone would make the Organization unreadable to every member.",
+    );
+    return;
+  }
+
+  for (const role of roles.results) {
+    console.log(
+      `_Role ${role.objectId}  name="${role.name}"  created=${role.createdAt}  updated=${role.updatedAt}`,
+    );
+
+    const count = await restGet(sessionToken, "/users", {
+      where: JSON.stringify(relatedToUsers(role.objectId)),
+      count: "1",
+      limit: "0",
+    });
+    console.log(`  users in role: ${count.count}`);
+
+    for (const userId of USER_IDS) {
+      const hit = await restGet(sessionToken, "/users", {
+        where: JSON.stringify({
+          ...relatedToUsers(role.objectId),
+          objectId: userId,
+        }),
+        keys: "objectId,email,displayName",
+        limit: "1",
+      });
+      const found = hit.results[0];
+      console.log(
+        `  ${userId}: ${found ? `IN ROLE (${found.email ?? found.displayName ?? "?"})` : "NOT in role"}`,
+      );
+    }
+  }
+
+  console.log("\nFollower rows on this workspace for the same users:");
+  for (const userId of USER_IDS) {
+    const followers = await restGet(sessionToken, "/classes/workspace_follower", {
+      where: JSON.stringify({
+        user: { __type: "Pointer", className: "_User", objectId: userId },
+        workspace: {
+          __type: "Pointer",
+          className: "WorkSpace",
+          objectId: WORKSPACE_ID,
+        },
+      }),
+      keys: "objectId,isMember,isFollower,archive,createdAt",
+      limit: "5",
+    });
+    const row = followers.results[0];
+    console.log(
+      `  ${userId}: ${
+        row
+          ? `follower ${row.objectId} isMember=${row.isMember} archive=${row.archive} created=${row.createdAt}`
+          : "no follower row"
+      }`,
+    );
+  }
+}
+
+main()
+  .then(() => app.exit(0))
+  .catch((error) => {
+    console.error("\nFAILED:", error.message);
+    app.exit(1);
+  });

--- a/scripts/inspect-papr-org-pointers.cjs
+++ b/scripts/inspect-papr-org-pointers.cjs
@@ -1,0 +1,215 @@
+/**
+ * Read-only map of the organization/workspace pointer graph for one workspace.
+ *
+ * Organization carries a `workspace` pointer and WorkSpace carries an
+ * `organization` pointer, so the two can disagree and several organizations can
+ * claim the same workspace. `resolveNamespaceOrganizationId` decides what the
+ * desktop does when they disagree, and that decision picks the namespace the
+ * user's data lands in — so it is worth seeing the raw graph.
+ *
+ *   node_modules/.bin/electron scripts/inspect-papr-org-pointers.cjs [workspaceId]
+ *
+ * Contains no mutations.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const electron = require("electron");
+
+const { app, safeStorage } = electron;
+
+app.setName("Papr Work");
+
+const PARSE_GRAPHQL_URL =
+  process.env.PARSE_GRAPHQL_URL || "https://server.papr.ai/graphql";
+const PARSE_APP_ID =
+  process.env.PARSE_APP_ID || "671e705a-f735-4ec0-8474-15899a475440";
+
+const WORKSPACE_ID = process.argv.slice(2).find((a) => !a.startsWith("--")) ||
+  "qDgAdi2eMf";
+
+function readSessionToken() {
+  const keysFile = path.join(
+    app.getPath("userData"),
+    "data",
+    "custom-keys.global.json",
+  );
+  const store = JSON.parse(fs.readFileSync(keysFile, "utf8"));
+  const entry = Object.values(store).find(
+    (k) => k && k.name === "PAPR_SESSION_TOKEN",
+  );
+  if (!entry?.encryptedValue) {
+    throw new Error("PAPR_SESSION_TOKEN not found");
+  }
+  return safeStorage.decryptString(Buffer.from(entry.encryptedValue, "base64"));
+}
+
+async function graphql(sessionToken, query, variables) {
+  const response = await fetch(PARSE_GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Parse-Application-Id": PARSE_APP_ID,
+      "X-Parse-Session-Token": sessionToken,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Parse GraphQL ${response.status}: ${text.slice(0, 300)}`);
+  }
+  const result = JSON.parse(text);
+  if (result.errors) {
+    throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
+  }
+  return result.data ?? {};
+}
+
+const ORG_FIELDS = `
+  objectId
+  name
+  plan_tier
+  createdAt
+  updatedAt
+  owner_user_id
+  workspace { objectId workspace_url workspace_name memberCount }
+  default_namespace { objectId name environment_type }
+`;
+
+const WORKSPACE = `
+  query Ws($id: ID!) {
+    workSpace(id: $id) {
+      objectId
+      workspace_name
+      workspace_url
+      memberCount
+      archive
+      createdAt
+      updatedAt
+      organization { ${ORG_FIELDS} }
+    }
+  }
+`;
+
+const ORGS_CLAIMING_WORKSPACE = `
+  query OrgsForWs($id: ID!) {
+    organizations(
+      where: { workspace: { have: { objectId: { equalTo: $id } } } }
+      order: createdAt_DESC
+    ) {
+      edges { node { ${ORG_FIELDS} } }
+    }
+  }
+`;
+
+const MY_ORGS = `
+  query MyOrgs($userId: ID!) {
+    organizations(
+      where: { owner: { have: { objectId: { equalTo: $userId } } } }
+      order: createdAt_DESC
+    ) {
+      edges { node { ${ORG_FIELDS} } }
+    }
+  }
+`;
+
+const ORG_NAMESPACES = `
+  query OrgNamespaces($orgId: ID!) {
+    namespaces(
+      where: { organization: { have: { objectId: { equalTo: $orgId } } } }
+      order: createdAt_DESC
+    ) {
+      edges { node { objectId name environment_type is_active } }
+    }
+  }
+`;
+
+const ME = `
+  query Me {
+    viewer { user { objectId organization_id } }
+  }
+`;
+
+function printOrg(prefix, org) {
+  if (!org) {
+    console.log(`${prefix}(none)`);
+    return;
+  }
+  console.log(
+    `${prefix}${org.objectId}  name=${JSON.stringify(org.name)}  tier=${org.plan_tier}`,
+  );
+  console.log(
+    `${prefix}  workspace -> ${org.workspace?.objectId ?? "(none)"} ` +
+      `(${org.workspace?.workspace_url ?? "-"}, members=${org.workspace?.memberCount ?? "?"})`,
+  );
+  console.log(
+    `${prefix}  default_namespace -> ${org.default_namespace?.objectId ?? "(none)"} ` +
+      `(${org.default_namespace?.name ?? "-"}, ${org.default_namespace?.environment_type ?? "-"})`,
+  );
+  console.log(
+    `${prefix}  owner=${org.owner_user_id}  created=${org.createdAt}  updated=${org.updatedAt}`,
+  );
+}
+
+async function main() {
+  await app.whenReady();
+  const sessionToken = readSessionToken();
+
+  const me = await graphql(sessionToken, ME, {});
+  const userId = me.viewer?.user?.objectId;
+  const developerOrgId = me.viewer?.user?.organization_id;
+
+  console.log(`user.objectId        = ${userId}`);
+  console.log(`user.organization_id = ${developerOrgId}   (developer org)\n`);
+
+  const wsData = await graphql(sessionToken, WORKSPACE, { id: WORKSPACE_ID });
+  const ws = wsData.workSpace;
+  console.log(`WORKSPACE ${WORKSPACE_ID}`);
+  console.log(`  name=${JSON.stringify(ws?.workspace_name)}  slug=${ws?.workspace_url}`);
+  console.log(`  memberCount=${ws?.memberCount}  archive=${ws?.archive}`);
+  console.log(`  created=${ws?.createdAt}  updated=${ws?.updatedAt}`);
+  console.log(`  workspace.organization  ->`);
+  printOrg("      ", ws?.organization);
+
+  console.log(`\nORGANIZATIONS whose \`workspace\` pointer claims ${WORKSPACE_ID}:`);
+  const claiming = await graphql(sessionToken, ORGS_CLAIMING_WORKSPACE, {
+    id: WORKSPACE_ID,
+  });
+  const claimingOrgs = (claiming.organizations?.edges ?? []).map((e) => e.node);
+  if (claimingOrgs.length === 0) console.log("  (none)");
+  for (const org of claimingOrgs) printOrg("  ", org);
+
+  console.log(`\nORGANIZATIONS owned by ${userId}:`);
+  const mine = await graphql(sessionToken, MY_ORGS, { userId });
+  const myOrgs = (mine.organizations?.edges ?? []).map((e) => e.node);
+  if (myOrgs.length === 0) console.log("  (none)");
+  for (const org of myOrgs) printOrg("  ", org);
+
+  const orgIds = new Set(
+    [
+      ws?.organization?.objectId,
+      developerOrgId,
+      ...claimingOrgs.map((o) => o.objectId),
+      ...myOrgs.map((o) => o.objectId),
+    ].filter(Boolean),
+  );
+
+  for (const orgId of orgIds) {
+    const nsData = await graphql(sessionToken, ORG_NAMESPACES, { orgId });
+    const namespaces = (nsData.namespaces?.edges ?? []).map((e) => e.node);
+    console.log(`\nNAMESPACES in org ${orgId} (${namespaces.length}):`);
+    for (const ns of namespaces) {
+      console.log(
+        `  ${ns.objectId}  ${String(ns.name).padEnd(28)} ` +
+          `${String(ns.environment_type ?? "-").padEnd(12)} active=${ns.is_active}`,
+      );
+    }
+  }
+}
+
+main()
+  .then(() => app.exit(0))
+  .catch((error) => {
+    console.error("\nFAILED:", error.message);
+    app.exit(1);
+  });

--- a/scripts/list-papr-workspace-members.cjs
+++ b/scripts/list-papr-workspace-members.cjs
@@ -1,0 +1,270 @@
+/**
+ * List every workspace_follower with isMember=true on a workspace, with the
+ * user's email, and flag whether they are actually inside member-<workspaceId>.
+ *
+ * Read-only. Writes a CSV next to the repo for manual review; the terminal
+ * output is a compact version of the same rows.
+ *
+ *   node_modules/.bin/electron scripts/list-papr-workspace-members.cjs [workspaceId]
+ */
+
+const fs = require("fs");
+const path = require("path");
+const electron = require("electron");
+
+const { app, safeStorage } = electron;
+
+app.setName("Papr Work");
+
+const PARSE_SERVER_URL =
+  process.env.PARSE_SERVER_URL || "https://server.papr.ai/parse";
+const PARSE_APP_ID =
+  process.env.PARSE_APP_ID || "671e705a-f735-4ec0-8474-15899a475440";
+
+const WORKSPACE_ID =
+  process.argv.slice(2).find((a) => !a.startsWith("--")) || "qDgAdi2eMf";
+
+const PAGE = 500;
+
+function readSessionToken() {
+  const keysFile = path.join(
+    app.getPath("userData"),
+    "data",
+    "custom-keys.global.json",
+  );
+  const store = JSON.parse(fs.readFileSync(keysFile, "utf8"));
+  const entry = Object.values(store).find(
+    (k) => k && k.name === "PAPR_SESSION_TOKEN",
+  );
+  if (!entry?.encryptedValue) throw new Error("PAPR_SESSION_TOKEN not found");
+  return safeStorage.decryptString(Buffer.from(entry.encryptedValue, "base64"));
+}
+
+async function restGet(sessionToken, urlPath, params) {
+  const url = new URL(`${PARSE_SERVER_URL}${urlPath}`);
+  for (const [key, value] of Object.entries(params ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  const response = await fetch(url.toString(), {
+    headers: {
+      "X-Parse-Application-Id": PARSE_APP_ID,
+      "X-Parse-Session-Token": sessionToken,
+    },
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Parse REST ${response.status}: ${text.slice(0, 300)}`);
+  }
+  return JSON.parse(text);
+}
+
+async function fetchAll(sessionToken, urlPath, params) {
+  const out = [];
+  for (let skip = 0; ; skip += PAGE) {
+    const page = await restGet(sessionToken, urlPath, {
+      ...params,
+      limit: String(PAGE),
+      skip: String(skip),
+    });
+    out.push(...page.results);
+    if (page.results.length < PAGE) return out;
+  }
+}
+
+/** objectIds of users inside a named _Role. */
+async function roleUserIds(sessionToken, roleName) {
+  const roles = await restGet(sessionToken, "/roles", {
+    where: JSON.stringify({ name: roleName }),
+    limit: "1",
+  });
+  const role = roles.results[0];
+  if (!role) return null;
+
+  const users = await fetchAll(sessionToken, "/users", {
+    where: JSON.stringify({
+      $relatedTo: {
+        object: { __type: "Pointer", className: "_Role", objectId: role.id ?? role.objectId },
+        key: "users",
+      },
+    }),
+    keys: "objectId",
+  });
+  return new Set(users.map((u) => u.objectId));
+}
+
+/**
+ * Display names by user id, via the dashboard endpoint Paprwork's Team panel
+ * uses. Parse hides other users' fields from a normal session token; that route
+ * reads with the master key, so it is the only way to see the whole roster.
+ */
+async function dashboardUsers(sessionToken) {
+  const platform = (
+    process.env.PAPR_PLATFORM_URL || "https://dashboard.papr.ai"
+  ).replace(/\/$/, "");
+  const url = new URL(`${platform}/api/workspace/members`);
+  url.searchParams.set("workspaceId", WORKSPACE_ID);
+
+  const response = await fetch(url.toString(), {
+    headers: { "X-Parse-Session-Token": sessionToken },
+  });
+  if (!response.ok) {
+    console.log(`  (dashboard members endpoint returned ${response.status})`);
+    return new Map();
+  }
+  const body = await response.json();
+  const map = new Map();
+  for (const member of body.members ?? []) {
+    const user = member.user ?? {};
+    if (user.objectId) {
+      map.set(user.objectId, {
+        name: user.displayName ?? user.fullname ?? "",
+        role: user.role?.name ?? "",
+      });
+    }
+  }
+  return map;
+}
+
+function csvCell(value) {
+  const text = value === undefined || value === null ? "" : String(value);
+  return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+async function main() {
+  await app.whenReady();
+  const sessionToken = readSessionToken();
+
+  console.log(`Workspace ${WORKSPACE_ID} on ${PARSE_SERVER_URL}\n`);
+
+  const workspace = await restGet(
+    sessionToken,
+    `/classes/WorkSpace/${WORKSPACE_ID}`,
+    { keys: "objectId,workspace_name,workspace_url,memberCount,followerCount" },
+  );
+  console.log(
+    `${workspace.workspace_name} (${workspace.workspace_url})  ` +
+      `memberCount=${workspace.memberCount} followerCount=${workspace.followerCount}`,
+  );
+
+  const inMemberRole = await roleUserIds(sessionToken, `member-${WORKSPACE_ID}`);
+  console.log(
+    `member-${WORKSPACE_ID} role holds ${inMemberRole ? inMemberRole.size : "no role found"} users\n`,
+  );
+
+  const followers = await fetchAll(sessionToken, "/classes/workspace_follower", {
+    where: JSON.stringify({
+      workspace: {
+        __type: "Pointer",
+        className: "WorkSpace",
+        objectId: WORKSPACE_ID,
+      },
+      isMember: true,
+    }),
+    // Dot-notation keys are required for included pointers; without them Parse
+    // returns the user object stripped down to objectId.
+    keys:
+      "objectId,isMember,isFollower,isDeveloperUser,archive,createdAt,updatedAt," +
+      "user,user.objectId,user.username,user.displayName,user.fullname",
+    include: "user",
+    order: "createdAt",
+  });
+
+  console.log("Fetching display names from the dashboard members endpoint...");
+  const directory = await dashboardUsers(sessionToken);
+  console.log(`  resolved ${directory.size} names\n`);
+
+  const rows = followers.map((follower) => {
+    const user = follower.user ?? {};
+    const fromDashboard = directory.get(user.objectId) ?? {};
+    // Parse usernames are email addresses here, so they never reach the output.
+    // Only display names are reported.
+    const localPart = (user.username || "").split("@")[0];
+    return {
+      followerId: follower.objectId,
+      userId: user.objectId ?? "",
+      name: user.displayName || user.fullname || fromDashboard.name || localPart || "",
+      isAnon: localPart.toLowerCase().startsWith("anon"),
+      readable: Boolean(user.objectId),
+      workspaceRole: fromDashboard.role ?? "",
+      archive: follower.archive === true,
+      isDeveloperUser: follower.isDeveloperUser === true,
+      inRole: inMemberRole ? inMemberRole.has(user.objectId) : null,
+      createdAt: follower.createdAt,
+    };
+  });
+
+  const active = rows.filter((r) => !r.archive);
+  console.log(
+    `workspace_follower rows with isMember=true: ${rows.length} ` +
+      `(${active.length} not archived, ${rows.length - active.length} archived)`,
+  );
+  console.log(
+    `  in member role: ${active.filter((r) => r.inRole).length}   ` +
+      `missing role: ${active.filter((r) => r.inRole === false).length}`,
+  );
+
+  const readable = active.filter((row) => row.readable);
+  const hidden = active.filter((row) => !row.readable);
+  const anon = readable.filter((row) => row.isAnon);
+  const named = readable.filter((row) => !row.isAnon);
+
+  console.log(
+    `  identifiable: ${readable.length} (${named.length} named, ${anon.length} anonymous)`,
+  );
+  console.log(
+    `  hidden by ACL (user object unreadable with this session): ${hidden.length}\n`,
+  );
+
+  console.log(`Named accounts (${named.length}), oldest first:`);
+  console.log("role  created     display name");
+  for (const row of named) {
+    console.log(
+      `${row.inRole ? " ok " : "MISS"}  ${row.createdAt.slice(0, 10)}  ` +
+        `${row.name || `(no display name) ${row.userId}`}`,
+    );
+  }
+  console.log("");
+
+  const csvPath = path.join(process.cwd(), `papr-members-${WORKSPACE_ID}.csv`);
+  const header = [
+    "displayName",
+    "accountType",
+    "userId",
+    "followerId",
+    "inMemberRole",
+    "isDeveloperUser",
+    "createdAt",
+    "keepAsMember",
+  ];
+  const accountType = (row) => {
+    if (!row.readable) return "hidden";
+    return row.isAnon ? "anonymous" : "named";
+  };
+  const csv = [
+    header.join(","),
+    ...active.map((row) =>
+      [
+        row.name,
+        accountType(row),
+        row.userId,
+        row.followerId,
+        row.inRole,
+        row.isDeveloperUser,
+        row.createdAt,
+        "",
+      ]
+        .map(csvCell)
+        .join(","),
+    ),
+  ].join("\n");
+  fs.writeFileSync(csvPath, csv + "\n", "utf8");
+  console.log(`CSV written to ${csvPath}`);
+  console.log("Mark keepAsMember=no on the rows you want flipped to isMember=false.");
+}
+
+main()
+  .then(() => app.exit(0))
+  .catch((error) => {
+    console.error("\nFAILED:", error.message);
+    app.exit(1);
+  });

--- a/scripts/list-papr-workspaces.cjs
+++ b/scripts/list-papr-workspaces.cjs
@@ -1,0 +1,176 @@
+/**
+ * Read-only report of the signed-in Papr user's workspaces, straight from Parse.
+ *
+ * The desktop switcher shows workspaces after resolution and deduplication, so
+ * it cannot answer "which of these rows is the real one". This prints the raw
+ * membership rows with the fields that decide that: the slug, the member count,
+ * the archive flags, and whether the organization points back at the workspace.
+ *
+ * Runs as a real Electron main process because the session token is encrypted
+ * with safeStorage, which is unavailable under ELECTRON_RUN_AS_NODE.
+ *
+ *   node_modules/.bin/electron scripts/list-papr-workspaces.cjs
+ *
+ * Contains no mutations.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const electron = require("electron");
+
+const { app, safeStorage } = electron;
+
+// Must match the running app, or safeStorage looks at the wrong keychain entry
+// and userData points at the wrong directory.
+app.setName("Papr Work");
+
+const PARSE_GRAPHQL_URL =
+  process.env.PARSE_GRAPHQL_URL || "https://server.papr.ai/graphql";
+const PARSE_APP_ID =
+  process.env.PARSE_APP_ID || "671e705a-f735-4ec0-8474-15899a475440";
+
+function readSessionToken() {
+  const keysFile = path.join(
+    app.getPath("userData"),
+    "data",
+    "custom-keys.global.json",
+  );
+  if (!fs.existsSync(keysFile)) {
+    throw new Error(`No global keys file at ${keysFile} — sign in first.`);
+  }
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error("safeStorage unavailable (keychain locked?)");
+  }
+
+  const store = JSON.parse(fs.readFileSync(keysFile, "utf8"));
+  const entry = Object.values(store).find(
+    (k) => k && k.name === "PAPR_SESSION_TOKEN",
+  );
+  if (!entry?.encryptedValue) {
+    throw new Error("PAPR_SESSION_TOKEN not found in global keys");
+  }
+
+  return safeStorage.decryptString(Buffer.from(entry.encryptedValue, "base64"));
+}
+
+async function graphql(sessionToken, query, variables) {
+  const response = await fetch(PARSE_GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Parse-Application-Id": PARSE_APP_ID,
+      "X-Parse-Session-Token": sessionToken,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Parse GraphQL ${response.status}: ${text.slice(0, 400)}`);
+  }
+
+  const result = JSON.parse(text);
+  if (result.errors) {
+    throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
+  }
+  return result.data ?? {};
+}
+
+const ME = `
+  query Me {
+    viewer {
+      user {
+        objectId
+        organization_id
+      }
+    }
+  }
+`;
+
+const MY_FOLLOWERS = `
+  query MyFollowers($input: Workspace_followerWhereInput!) {
+    workspace_followers(where: $input, first: 200) {
+      edges {
+        node {
+          objectId
+          archive
+          isMember
+          isFollower
+          isSelected
+          workspace {
+            objectId
+            workspace_name
+            workspace_url
+            archive
+            memberCount
+            followerCount
+            createdAt
+            user { objectId }
+            organization {
+              objectId
+              name
+              plan_tier
+              workspace { objectId }
+              default_namespace { objectId name }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+async function main() {
+  await app.whenReady();
+
+  const sessionToken = readSessionToken();
+  const me = await graphql(sessionToken, ME, {});
+  const userId = me.viewer?.user?.objectId;
+  const developerOrgId = me.viewer?.user?.organization_id;
+  console.log(`user=${userId}  developerOrg=${developerOrgId ?? "(none)"}\n`);
+
+  const data = await graphql(sessionToken, MY_FOLLOWERS, {
+    input: {
+      user: { have: { objectId: { equalTo: userId } } },
+      isMember: { equalTo: true },
+    },
+  });
+
+  const rows = (data.workspace_followers?.edges ?? [])
+    .map((e) => e.node)
+    .filter((n) => n?.workspace?.objectId);
+
+  console.log(`${rows.length} membership rows:\n`);
+  for (const row of rows) {
+    const ws = row.workspace;
+    const org = ws.organization;
+    const isOrgPrimary = org?.workspace?.objectId === ws.objectId;
+    console.log(
+      [
+        `ws=${ws.objectId}`,
+        `follower=${row.objectId}`,
+        `slug=${String(ws.workspace_url ?? "-").padEnd(22)}`,
+        `name=${JSON.stringify(ws.workspace_name ?? null).padEnd(14)}`,
+        `members=${String(ws.memberCount ?? "?").padEnd(4)}`,
+        `wsArchive=${String(ws.archive).padEnd(5)}`,
+        `folArchive=${String(row.archive).padEnd(5)}`,
+        `selected=${String(row.isSelected).padEnd(5)}`,
+        `org=${org?.objectId}`,
+        `orgPrimary=${isOrgPrimary ? "YES" : "no "}`,
+        `ns=${org?.default_namespace?.objectId ?? "-"}`,
+      ].join("  "),
+    );
+  }
+
+  console.log(
+    "\norgPrimary=YES means the organization's own `workspace` pointer " +
+      "references this row — the authoritative workspace for that org.",
+  );
+}
+
+main()
+  .then(() => app.exit(0))
+  .catch((error) => {
+    console.error("\nFAILED:", error.message);
+    app.exit(1);
+  });

--- a/scripts/verify-papr-rest-pointer.cjs
+++ b/scripts/verify-papr-rest-pointer.cjs
@@ -1,0 +1,122 @@
+/**
+ * Read one WorkSpace and its claiming Organizations through the Parse REST API.
+ *
+ * A cross-check for the GraphQL reads: REST returns the stored pointer verbatim
+ * with no resolver in between, so if REST and GraphQL agree the value really is
+ * what is on the server rather than an artefact of how the query was written.
+ *
+ *   node_modules/.bin/electron scripts/verify-papr-rest-pointer.cjs [workspaceId]
+ *
+ * Contains no mutations.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const electron = require("electron");
+
+const { app, safeStorage } = electron;
+
+app.setName("Papr Work");
+
+const PARSE_SERVER_URL =
+  process.env.PARSE_SERVER_URL || "https://server.papr.ai/parse";
+const PARSE_APP_ID =
+  process.env.PARSE_APP_ID || "671e705a-f735-4ec0-8474-15899a475440";
+
+const WORKSPACE_ID =
+  process.argv.slice(2).find((a) => !a.startsWith("--")) || "qDgAdi2eMf";
+
+function readSessionToken() {
+  const keysFile = path.join(
+    app.getPath("userData"),
+    "data",
+    "custom-keys.global.json",
+  );
+  const store = JSON.parse(fs.readFileSync(keysFile, "utf8"));
+  const entry = Object.values(store).find(
+    (k) => k && k.name === "PAPR_SESSION_TOKEN",
+  );
+  if (!entry?.encryptedValue) throw new Error("PAPR_SESSION_TOKEN not found");
+  return safeStorage.decryptString(Buffer.from(entry.encryptedValue, "base64"));
+}
+
+async function restGet(sessionToken, urlPath, params) {
+  const url = new URL(`${PARSE_SERVER_URL}${urlPath}`);
+  for (const [key, value] of Object.entries(params ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  const response = await fetch(url.toString(), {
+    headers: {
+      "X-Parse-Application-Id": PARSE_APP_ID,
+      "X-Parse-Session-Token": sessionToken,
+    },
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Parse REST ${response.status}: ${text.slice(0, 300)}`);
+  }
+  return JSON.parse(text);
+}
+
+async function main() {
+  await app.whenReady();
+  const sessionToken = readSessionToken();
+
+  console.log(`REST: ${PARSE_SERVER_URL}\n`);
+
+  const ws = await restGet(sessionToken, `/classes/WorkSpace/${WORKSPACE_ID}`, {
+    keys: "objectId,workspace_name,workspace_url,memberCount,archive,organization,updatedAt",
+  });
+  console.log(`WorkSpace ${ws.objectId} (${ws.workspace_url})`);
+  console.log(`  memberCount   : ${ws.memberCount}`);
+  console.log(`  archive       : ${ws.archive}`);
+  console.log(`  organization  : ${JSON.stringify(ws.organization)}`);
+  console.log(`  updatedAt     : ${ws.updatedAt}`);
+
+  const orgs = await restGet(sessionToken, "/classes/Organization", {
+    where: JSON.stringify({
+      workspace: {
+        __type: "Pointer",
+        className: "WorkSpace",
+        objectId: WORKSPACE_ID,
+      },
+    }),
+    keys: "objectId,name,plan_tier,owner,owner_user_id,default_namespace,default_namespace_id,workspace,createdAt,updatedAt",
+    order: "-createdAt",
+    limit: "50",
+  });
+
+  console.log(
+    `\nOrganizations whose workspace pointer == ${WORKSPACE_ID}: ${orgs.results.length}`,
+  );
+  for (const org of orgs.results) {
+    console.log(
+      `  ${org.objectId}  name=${JSON.stringify(org.name).padEnd(24)} ` +
+        `tier=${String(org.plan_tier).padEnd(11)} owner=${String(org.owner_user_id)}`,
+    );
+    console.log(
+      `      default_namespace=${org.default_namespace?.objectId ?? org.default_namespace_id ?? "-"}  ` +
+        `created=${org.createdAt}  updated=${org.updatedAt}`,
+    );
+  }
+
+  console.log("\nSampling updatedAt twice, 3s apart, to detect live writes:");
+  for (let i = 0; i < 2; i++) {
+    const again = await restGet(
+      sessionToken,
+      `/classes/WorkSpace/${WORKSPACE_ID}`,
+      { keys: "objectId,organization,updatedAt" },
+    );
+    console.log(
+      `  t${i}: updatedAt=${again.updatedAt}  organization=${again.organization?.objectId}`,
+    );
+    if (i === 0) await new Promise((r) => setTimeout(r, 3000));
+  }
+}
+
+main()
+  .then(() => app.exit(0))
+  .catch((error) => {
+    console.error("\nFAILED:", error.message);
+    app.exit(1);
+  });

--- a/src/core/papr/paprLoginGraphql.ts
+++ b/src/core/papr/paprLoginGraphql.ts
@@ -13,6 +13,29 @@ export const GET_NAMESPACE_API_KEYS = `
   }
 `;
 
+/**
+ * Everything needed to decide whether a workspace may be claimed by a new org.
+ *
+ * memberCount is a plain field on WorkSpace, so it survives the ACL filtering
+ * that can null out the organization pointer for a member who is missing the
+ * workspace role. A shared workspace must never be repointed during one user's
+ * provisioning, even when its organization reads as null.
+ */
+export const GET_WORKSPACE_ORG_CLAIM_STATE = `
+  query GetWorkspaceOrgClaimState($workspaceId: ID!) {
+    workSpace(id: $workspaceId) {
+      objectId
+      workspace_name
+      memberCount
+      followerCount
+      organization {
+        objectId
+        name
+      }
+    }
+  }
+`;
+
 export const UPDATE_WORKSPACE_ORG = `
   mutation UpdateWorkspaceOrganization(
     $workspaceId: ID!,

--- a/src/core/papr/provisioningDefaults.ts
+++ b/src/core/papr/provisioningDefaults.ts
@@ -142,14 +142,27 @@ export function sanitizeProvisioningName(
 export type ProvisioningPlanKind =
   | "none"
   | "namespace_only"
-  | "org_and_namespace";
+  | "org_and_namespace"
+  | "deferred";
+
+/**
+ * Whether the selected workspace already belongs to an organization.
+ *
+ * "unknown" matters: a member whose role grant is missing gets the organization
+ * pointer stripped by ACL, which is indistinguishable from a workspace that
+ * genuinely has no org. Treating that as "absent" is what caused shared
+ * workspaces to be repointed at a brand new personal org.
+ */
+export type WorkspaceOrganizationState = "present" | "absent" | "unknown";
 
 export interface ProvisioningPlanInput {
   workspaceId?: string;
-  workspaceHasOrganization: boolean;
+  workspaceOrganization: WorkspaceOrganizationState;
   workspaceOrgHasDefaultNamespace: boolean;
   developerOrgId?: string;
   developerOrgHasDefaultNamespace: boolean;
+  /** True when the developer org lookup errored, so `developerOrgId` proves nothing. */
+  developerOrgLookupFailed?: boolean;
 }
 
 export interface ProvisioningPlan {
@@ -160,7 +173,13 @@ export interface ProvisioningPlan {
 
 /** Pure decision tree mirroring provisionOrGetApiKey — easy to unit test. */
 export function resolveProvisioningPlan(input: ProvisioningPlanInput): ProvisioningPlan {
-  if (input.workspaceId && input.workspaceHasOrganization) {
+  if (input.workspaceId && input.workspaceOrganization === "unknown") {
+    // Fail closed. Creating an org here would claim a workspace that may
+    // already belong to someone else's organization.
+    return { kind: "deferred", needsOrg: false, needsNamespace: false };
+  }
+
+  if (input.workspaceId && input.workspaceOrganization === "present") {
     if (input.workspaceOrgHasDefaultNamespace) {
       return { kind: "none", needsOrg: false, needsNamespace: false };
     }
@@ -174,9 +193,19 @@ export function resolveProvisioningPlan(input: ProvisioningPlanInput): Provision
     return { kind: "namespace_only", needsOrg: false, needsNamespace: true };
   }
 
+  if (input.developerOrgLookupFailed) {
+    // The user may already own an org we simply could not read.
+    return { kind: "deferred", needsOrg: false, needsNamespace: false };
+  }
+
   return { kind: "org_and_namespace", needsOrg: true, needsNamespace: true };
 }
 
 export function isProvisioningSetupRequired(plan: ProvisioningPlan): boolean {
-  return plan.kind !== "none";
+  return plan.kind !== "none" && plan.kind !== "deferred";
+}
+
+/** True when workspace state could not be read and provisioning must not run. */
+export function isProvisioningDeferred(plan: ProvisioningPlan): boolean {
+  return plan.kind === "deferred";
 }

--- a/src/electron/ipc/paprLogin.ts
+++ b/src/electron/ipc/paprLogin.ts
@@ -60,13 +60,18 @@ import {
 } from "../../core/telemetry/paprLoginSteps.js";
 import {
   deriveProvisioningDefaults,
+  isProvisioningDeferred,
   isProvisioningSetupRequired,
   resolveProvisioningPlan,
   sanitizeProvisioningName,
   DEFAULT_NAMESPACE_NAME,
   type ProvisioningNameDefaults,
+  type WorkspaceOrganizationState,
 } from "../../core/papr/provisioningDefaults.js";
-import { UPDATE_WORKSPACE_ORG } from "../../core/papr/paprLoginGraphql.js";
+import {
+  GET_WORKSPACE_ORG_CLAIM_STATE,
+  UPDATE_WORKSPACE_ORG,
+} from "../../core/papr/paprLoginGraphql.js";
 
 /**
  * Sync Papr profile fields to gateway settings file so the gateway process
@@ -1696,7 +1701,9 @@ async function assessProvisioningNeeds(
     workspaceId = await getSelectedWorkspaceId(sessionToken, userId);
   }
 
-  let workspaceHasOrganization = Boolean(workspaceInfo.organizationId);
+  let workspaceOrganization: WorkspaceOrganizationState = workspaceInfo.organizationId
+    ? "present"
+    : "absent";
   let workspaceOrgHasDefaultNamespace = false;
 
   if (workspaceId) {
@@ -1707,7 +1714,7 @@ async function assessProvisioningNeeds(
         workspaceId,
       );
       if (resolved) {
-        workspaceHasOrganization = true;
+        workspaceOrganization = "present";
         workspaceOrgHasDefaultNamespace = Boolean(resolved.defaultNamespaceId);
       } else if (workspaceInfo.organizationId) {
         const defaultNs = await resolveDefaultNamespaceForOrg(
@@ -1717,12 +1724,19 @@ async function assessProvisioningNeeds(
         workspaceOrgHasDefaultNamespace = Boolean(defaultNs);
       }
     } catch (error) {
-      console.warn("[PaprLogin] assessProvisioningNeeds workspace lookup failed:", error);
+      // A failed lookup is not evidence that the workspace has no org, and
+      // guessing "absent" here is what repointed shared workspaces at new orgs.
+      console.error(
+        "[PaprLogin] assessProvisioningNeeds workspace lookup failed, deferring provisioning:",
+        error,
+      );
+      workspaceOrganization = "unknown";
     }
   }
 
   let developerOrgId: string | undefined;
   let developerOrgHasDefaultNamespace = false;
+  let developerOrgLookupFailed = false;
   try {
     developerOrgId = await fetchUserDeveloperOrganizationId(sessionToken, userId);
     if (developerOrgId) {
@@ -1730,16 +1744,28 @@ async function assessProvisioningNeeds(
       developerOrgHasDefaultNamespace = Boolean(defaultNs);
     }
   } catch (error) {
-    console.warn("[PaprLogin] assessProvisioningNeeds developer org lookup failed:", error);
+    console.error(
+      "[PaprLogin] assessProvisioningNeeds developer org lookup failed, deferring provisioning:",
+      error,
+    );
+    developerOrgLookupFailed = true;
   }
 
   const plan = resolveProvisioningPlan({
     workspaceId,
-    workspaceHasOrganization,
+    workspaceOrganization,
     workspaceOrgHasDefaultNamespace,
     developerOrgId,
     developerOrgHasDefaultNamespace,
+    developerOrgLookupFailed,
   });
+
+  if (isProvisioningDeferred(plan)) {
+    console.warn(
+      `[PaprLogin] Provisioning deferred for workspace ${workspaceId ?? "(none)"}: ` +
+        `organization state could not be verified.`,
+    );
+  }
 
   const defaults = deriveProvisioningDefaults({
     email,
@@ -1773,76 +1799,93 @@ async function provisionOrGetApiKey(
 
   // 1. Resolve namespace org for selected workspace (team org or developer org)
   if (workspaceId) {
+    // Only the lookup is guarded: a failure here is not evidence that the
+    // workspace is unclaimed, so falling through would create a duplicate org
+    // and repoint a workspace that already belongs to someone.
+    let resolved: Awaited<ReturnType<typeof resolveNamespaceOrganizationForWorkspace>>;
     try {
-      const resolved = await resolveNamespaceOrganizationForWorkspace(
+      resolved = await resolveNamespaceOrganizationForWorkspace(
         sessionToken,
         userId,
         workspaceId,
       );
-      if (resolved) {
-        console.log(
-          `[PaprLogin] Workspace ${workspaceId} → namespace org "${resolved.organizationName}" (${resolved.organizationId})`,
-        );
-        if (resolved.defaultNamespaceId) {
-          return await resolveOrgApiKey(
-            sessionToken,
-            userId,
-            resolved.organizationId,
-            resolved.defaultNamespaceId,
-            "default",
-            workspaceId,
-          );
-        }
+    } catch (wsErr) {
+      console.error("[PaprLogin] Workspace org lookup failed:", wsErr);
+      throw new Error(
+        `Could not verify whether workspace ${workspaceId} already belongs to an organization. ` +
+          `Refusing to provision a new one. Please try signing in again.`,
+      );
+    }
 
-        console.log(
-          `[PaprLogin] Namespace org ${resolved.organizationId} has no default namespace — creating one`,
-        );
-        return await createNamespaceAndKey(
+    if (resolved) {
+      console.log(
+        `[PaprLogin] Workspace ${workspaceId} → namespace org "${resolved.organizationName}" (${resolved.organizationId})`,
+      );
+      if (resolved.defaultNamespaceId) {
+        return await resolveOrgApiKey(
           sessionToken,
           userId,
           resolved.organizationId,
-          orgName,
+          resolved.defaultNamespaceId,
+          "default",
           workspaceId,
-          namespaceName,
         );
       }
 
       console.log(
-        `[PaprLogin] Workspace ${workspaceId} has no organization — creating new org`,
+        `[PaprLogin] Namespace org ${resolved.organizationId} has no default namespace — creating one`,
       );
-    } catch (wsErr) {
-      console.warn("[PaprLogin] Workspace org lookup failed:", wsErr);
-    }
-  }
-
-  // 2. Fallback: user.organization_id (developer org without a linked workspace)
-  try {
-    const developerOrgId = await fetchUserDeveloperOrganizationId(sessionToken, userId);
-    if (developerOrgId) {
-      console.log(`[PaprLogin] User developer org: ${developerOrgId}`);
-      const defaultNs = await resolveDefaultNamespaceForOrg(sessionToken, developerOrgId);
-      if (defaultNs) {
-        return await resolveOrgApiKey(
-          sessionToken,
-          userId,
-          developerOrgId,
-          defaultNs.namespaceId,
-          defaultNs.namespaceName,
-          workspaceId ?? "",
-        );
-      }
-      console.log("[PaprLogin] Developer org has no default namespace — creating one");
       return await createNamespaceAndKey(
         sessionToken,
         userId,
-        developerOrgId,
+        resolved.organizationId,
         orgName,
-        workspaceId ?? "",
+        workspaceId,
         namespaceName,
       );
     }
+
+    console.log(
+      `[PaprLogin] Workspace ${workspaceId} has no organization — creating new org`,
+    );
+  }
+
+  // 2. Fallback: user.organization_id (developer org without a linked workspace)
+  let developerOrgId: string | undefined;
+  try {
+    developerOrgId = await fetchUserDeveloperOrganizationId(sessionToken, userId);
   } catch (devOrgErr) {
-    console.warn("[PaprLogin] Developer org lookup failed:", devOrgErr);
+    // Same reasoning as the workspace lookup: an unreadable developer org must
+    // not turn into a second org for the same user.
+    console.error("[PaprLogin] Developer org lookup failed:", devOrgErr);
+    throw new Error(
+      "Could not verify whether you already have an organization. " +
+        "Refusing to provision a new one. Please try signing in again.",
+    );
+  }
+
+  if (developerOrgId) {
+    console.log(`[PaprLogin] User developer org: ${developerOrgId}`);
+    const defaultNs = await resolveDefaultNamespaceForOrg(sessionToken, developerOrgId);
+    if (defaultNs) {
+      return await resolveOrgApiKey(
+        sessionToken,
+        userId,
+        developerOrgId,
+        defaultNs.namespaceId,
+        defaultNs.namespaceName,
+        workspaceId ?? "",
+      );
+    }
+    console.log("[PaprLogin] Developer org has no default namespace — creating one");
+    return await createNamespaceAndKey(
+      sessionToken,
+      userId,
+      developerOrgId,
+      orgName,
+      workspaceId ?? "",
+      namespaceName,
+    );
   }
 
   // 3. No org on workspace — full provisioning (new org + namespace + key)
@@ -1855,6 +1898,74 @@ async function provisionOrGetApiKey(
   );
 }
 
+/**
+ * Refuse to claim a workspace that already belongs to someone.
+ *
+ * Called before the org is created, so a claimed workspace leaves no orphan org
+ * behind. Three signals, any of which blocks the claim:
+ *   - the workspace already points at an organization
+ *   - another organization points back at the workspace
+ *   - the workspace has more than one member, so it is shared
+ */
+async function assertWorkspaceClaimable(
+  sessionToken: string,
+  workspaceId: string,
+): Promise<void> {
+  const data = (await parseGraphQL(sessionToken, GET_WORKSPACE_ORG_CLAIM_STATE, {
+    workspaceId,
+  })) as {
+    workSpace?: {
+      workspace_name?: string;
+      memberCount?: number;
+      followerCount?: number;
+      organization?: { objectId?: string; name?: string };
+    };
+  };
+
+  const workspace = data.workSpace;
+  const existingOrgId = workspace?.organization?.objectId;
+
+  if (existingOrgId) {
+    throw new Error(
+      `Workspace ${workspaceId} already belongs to organization ${existingOrgId}. ` +
+        `Refusing to repoint it.`,
+    );
+  }
+
+  const memberCount = workspace?.memberCount ?? 0;
+  if (memberCount > 1) {
+    throw new Error(
+      `Workspace ${workspaceId} has ${memberCount} members, so it is shared. ` +
+        `Its organization reads as empty, which usually means this account is ` +
+        `missing the workspace role rather than that the workspace is unclaimed. ` +
+        `Refusing to claim it.`,
+    );
+  }
+
+  const claimingOrgs = await fetchWorkspaceOrganizationsWithSession(sessionToken, workspaceId);
+  if (claimingOrgs.length > 0) {
+    throw new Error(
+      `Workspace ${workspaceId} is already claimed by ${claimingOrgs.length} organization(s): ` +
+        `${claimingOrgs.map((org) => org.id).join(", ")}. Refusing to create another.`,
+    );
+  }
+}
+
+async function fetchWorkspaceOrganizationsWithSession(
+  sessionToken: string,
+  workspaceId: string,
+): Promise<Array<{ id: string; name: string }>> {
+  const data = (await parseGraphQL(sessionToken, GET_WORKSPACE_ORGANIZATIONS, {
+    workspaceId,
+  })) as {
+    organizations?: { edges?: Array<{ node: { objectId: string; name?: string } }> };
+  };
+
+  return (data.organizations?.edges ?? [])
+    .map((edge) => ({ id: edge.node.objectId, name: edge.node.name?.trim() || "" }))
+    .filter((org) => org.id);
+}
+
 async function provisionNewOrgNamespace(
   sessionToken: string,
   userId: string,
@@ -1863,6 +1974,10 @@ async function provisionNewOrgNamespace(
   namespaceName: string,
 ): Promise<ProvisionResult> {
   console.log("[PaprLogin] Full provisioning: org + namespace + API key...");
+
+  if (workspaceId) {
+    await assertWorkspaceClaimable(sessionToken, workspaceId);
+  }
 
   if (!workspaceId) {
     try {
@@ -1917,10 +2032,24 @@ async function provisionNewOrgNamespace(
   console.log(`[PaprLogin] Created organization: ${orgId}`);
 
   if (workspaceId) {
-    await parseGraphQL(sessionToken, UPDATE_WORKSPACE_ORG, {
+    // Re-read between the claim check and the write: another client may have
+    // linked an org in between, and losing that pointer is unrecoverable.
+    const claimState = (await parseGraphQL(sessionToken, GET_WORKSPACE_ORG_CLAIM_STATE, {
       workspaceId,
-      organizationId: orgId,
-    });
+    })) as { workSpace?: { organization?: { objectId?: string } } };
+    const currentOrgId = claimState.workSpace?.organization?.objectId;
+
+    if (currentOrgId && currentOrgId !== orgId) {
+      console.error(
+        `[PaprLogin] Workspace ${workspaceId} was linked to organization ${currentOrgId} ` +
+          `while provisioning ${orgId} — leaving the existing pointer untouched.`,
+      );
+    } else {
+      await parseGraphQL(sessionToken, UPDATE_WORKSPACE_ORG, {
+        workspaceId,
+        organizationId: orgId,
+      });
+    }
   }
 
   return await createNamespaceAndKey(

--- a/tests/papr-provisioning-defaults.test.ts
+++ b/tests/papr-provisioning-defaults.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_NAMESPACE_NAME,
   deriveDefaultOrgName,
   deriveProvisioningDefaults,
+  isProvisioningDeferred,
   isProvisioningSetupRequired,
   resolveProvisioningPlan,
   sanitizeProvisioningName,
@@ -73,7 +74,7 @@ describe("resolveProvisioningPlan", () => {
   it("skips setup when workspace org already has a default namespace", () => {
     const plan = resolveProvisioningPlan({
       workspaceId: "ws-1",
-      workspaceHasOrganization: true,
+      workspaceOrganization: "present",
       workspaceOrgHasDefaultNamespace: true,
       developerOrgId: "dev-org",
       developerOrgHasDefaultNamespace: false,
@@ -86,7 +87,7 @@ describe("resolveProvisioningPlan", () => {
   it("requires namespace setup when workspace org exists without a namespace", () => {
     const plan = resolveProvisioningPlan({
       workspaceId: "ws-1",
-      workspaceHasOrganization: true,
+      workspaceOrganization: "present",
       workspaceOrgHasDefaultNamespace: false,
       developerOrgId: "dev-org",
       developerOrgHasDefaultNamespace: true,
@@ -102,8 +103,9 @@ describe("resolveProvisioningPlan", () => {
   it("requires org and namespace for brand-new users", () => {
     const plan = resolveProvisioningPlan({
       workspaceId: "ws-1",
-      workspaceHasOrganization: false,
+      workspaceOrganization: "absent",
       workspaceOrgHasDefaultNamespace: false,
+      developerOrgHasDefaultNamespace: false,
     });
 
     expect(plan).toEqual({
@@ -111,6 +113,35 @@ describe("resolveProvisioningPlan", () => {
       needsOrg: true,
       needsNamespace: true,
     });
+  });
+
+  it("defers when the workspace organization could not be read", () => {
+    const plan = resolveProvisioningPlan({
+      workspaceId: "ws-1",
+      workspaceOrganization: "unknown",
+      workspaceOrgHasDefaultNamespace: false,
+      developerOrgHasDefaultNamespace: false,
+    });
+
+    expect(plan).toEqual({
+      kind: "deferred",
+      needsOrg: false,
+      needsNamespace: false,
+    });
+    expect(isProvisioningSetupRequired(plan)).toBe(false);
+    expect(isProvisioningDeferred(plan)).toBe(true);
+  });
+
+  it("defers rather than creating a second org when the developer org lookup fails", () => {
+    const plan = resolveProvisioningPlan({
+      workspaceOrganization: "absent",
+      workspaceOrgHasDefaultNamespace: false,
+      developerOrgHasDefaultNamespace: false,
+      developerOrgLookupFailed: true,
+    });
+
+    expect(plan.kind).toBe("deferred");
+    expect(isProvisioningDeferred(plan)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Follow-up to #86. Same investigation, different root cause.

## The bug

When a user is added to a workspace, Parse creates a `workspace_follower` row but does not always add them to the `member-<workspaceId>` role. The Organization's ACL grants read access to that role, so a member without the grant gets `workSpace.organization` silently returned as `null`.

Login could not tell that apart from a workspace that genuinely has no organization, so it took the "brand new user" path: create a personal org, then repoint `workSpace.organization` at it. On `papr-ai` that moved a 601-member workspace onto a nearly empty org, which is why org usage metrics read zero and Stripe returned `Forbidden - You do not have access to this workspace`.

Measured on the live workspace: 596 `isMember=true` follower rows, 301 in the role, **295 missing it**. Every row missing the role is also unreadable by a normal session token, which is the same ACL effect one level down.

## What changed

- `resolveProvisioningPlan` takes a tri-state `workspaceOrganization` (`"present" | "absent" | "unknown"`) instead of a boolean, and returns a new `deferred` plan when the state cannot be verified. A failed developer-org lookup defers as well, so an org we simply could not read cannot turn into a second org for the same user.
- The two `catch` blocks in `provisionOrGetApiKey` that logged a warning and fell through to org creation now throw. I also narrowed both `try` blocks to wrap only the lookup — they previously wrapped the API-key creation calls too, so a key failure would have been reported as a lookup failure.
- `assertWorkspaceClaimable` runs **before** `CREATE_ORGANIZATION`, so a claimed workspace leaves no orphan org behind. It blocks on any of three signals:
  1. the workspace already points at an organization,
  2. another organization points back at the workspace,
  3. `memberCount > 1`.

  The third is the load-bearing one. `memberCount` is a plain field on `WorkSpace`, so unlike the organization pointer it survives ACL filtering — a 601-member workspace can never be claimed even when its org reads as null.
- `UPDATE_WORKSPACE_ORG` re-reads the pointer immediately before writing and skips the write if another client linked an org in between. Losing that pointer is unrecoverable.
- `papr-members-*.csv` added to `.gitignore` so member exports can't be committed.

There is exactly one `CREATE_ORGANIZATION` call site, and it is now behind the guard.

## Server-side companions (separate repos, not in this PR)

This PR stops the desktop app from *reacting* badly to the missing grant. The grant itself is fixed in:
- `parseServer`: idempotent `ensureWorkspaceRoles` helper plus an `ensureWorkspaceRoleMembership` cloud function, called from both the create and update paths of `addPeopleToWorkspace` / `addPeopleToDeveloperWorkspace`. Role grants were previously only issued inside `if (workspace_follower.isNew())`.
- `papr-dev-platform`: `addUserToWorkspace` no longer returns early on `alreadyMember` — it reconciles role membership instead. `api/workspace/members` now pages through results (it was capping at 100 of 601).

## Diagnostics included

Read-only scripts used to find this, each taking an optional workspace id (defaults to `papr-ai`):

```bash
env -u ELECTRON_RUN_AS_NODE npx electron scripts/check-papr-role-membership.cjs
env -u ELECTRON_RUN_AS_NODE npx electron scripts/inspect-papr-org-pointers.cjs
env -u ELECTRON_RUN_AS_NODE npx electron scripts/verify-papr-rest-pointer.cjs
env -u ELECTRON_RUN_AS_NODE npx electron scripts/list-papr-workspaces.cjs
env -u ELECTRON_RUN_AS_NODE npx electron scripts/list-papr-workspace-members.cjs
```

`list-papr-workspace-members.cjs` reports display names only — Parse usernames are email addresses, so that column is deliberately absent.

## Test plan

- [x] `npx vitest run tests/papr-provisioning-defaults.test.ts` — 12 pass, including two new cases covering the deferred plan for an unknown workspace org and a failed developer-org lookup
- [x] Full Papr login/provisioning suite green: `papr-login-graphql`, `papr-namespace-org-resolution`, `papr-workspace-cache-store`, `papr-workspace-cache-dedupe`, `parse-transport`, `papr-login-funnel`, `papr-api-key` — 81 tests
- [x] `npm run type-check` clean for touched files
- [ ] Sign in as an existing member of `papr-ai` and confirm no new org is created and `workSpace.organization` still reads `Y8D4H7Yp3Z`
- [ ] Sign up a brand-new account and confirm normal provisioning still completes

Made with [Cursor](https://cursor.com)