### PR TITLE
fix(papr): pick the real workspace when duplicates share a name

### DIFF
--- a/scripts/verify-papr-workspace-query.cjs
+++ b/scripts/verify-papr-workspace-query.cjs
@@ -1,0 +1,191 @@
+/**
+ * Read-only check that the workspace switcher's own query returns the two fields
+ * the duplicate tie-break depends on: WorkSpace.memberCount and the
+ * organization's own workspace pointer.
+ *
+ * Both are new selections on an existing query. If either is not selectable in
+ * this shape the query still succeeds and the fields come back undefined, so the
+ * tie-break silently falls back to arrival order — the exact bug it fixes. This
+ * asserts they are actually populated against live Parse.
+ *
+ * Runs as a real Electron main process because the session token is encrypted
+ * with safeStorage, which is unavailable under ELECTRON_RUN_AS_NODE:
+ *
+ *   env -u ELECTRON_RUN_AS_NODE npx electron scripts/verify-papr-workspace-query.cjs
+ *
+ * Contains no mutations.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const electron = require("electron");
+
+const { app, safeStorage } = electron;
+
+// Must match the running app, or safeStorage looks at the wrong keychain entry
+// and userData points at the wrong directory.
+app.setName("Papr Work");
+
+const PARSE_GRAPHQL_URL =
+  process.env.PARSE_GRAPHQL_URL || "https://server.papr.ai/graphql";
+const PARSE_APP_ID =
+  process.env.PARSE_APP_ID || "671e705a-f735-4ec0-8474-15899a475440";
+
+function readSessionToken() {
+  const keysFile = path.join(
+    app.getPath("userData"),
+    "data",
+    "custom-keys.global.json",
+  );
+  if (!fs.existsSync(keysFile)) {
+    throw new Error(`No global keys file at ${keysFile} — sign in first.`);
+  }
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error("safeStorage unavailable (keychain locked?)");
+  }
+
+  const store = JSON.parse(fs.readFileSync(keysFile, "utf8"));
+  const entry = Object.values(store).find(
+    (k) => k && k.name === "PAPR_SESSION_TOKEN",
+  );
+  if (!entry?.encryptedValue) {
+    throw new Error("PAPR_SESSION_TOKEN not found in global keys");
+  }
+
+  return safeStorage.decryptString(Buffer.from(entry.encryptedValue, "base64"));
+}
+
+async function graphql(sessionToken, query, variables) {
+  const response = await fetch(PARSE_GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Parse-Application-Id": PARSE_APP_ID,
+      "X-Parse-Session-Token": sessionToken,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Parse GraphQL ${response.status}: ${text.slice(0, 400)}`);
+  }
+
+  const result = JSON.parse(text);
+  if (result.errors) {
+    throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
+  }
+  return result.data ?? {};
+}
+
+const ME = `
+  query Me {
+    viewer {
+      user {
+        objectId
+      }
+    }
+  }
+`;
+
+// Kept in sync with GET_USER_WORKSPACES in src/electron/ipc/paprLogin.ts.
+const GET_USER_WORKSPACES = `
+  query GetUserWorkspaces($input: Workspace_followerWhereInput!) {
+    workspace_followers(where: $input) {
+      edges {
+        node {
+          objectId
+          archive
+          isMember
+          isSelected
+          workspace {
+            objectId
+            workspace_name
+            memberCount
+            organization {
+              objectId
+              name
+              logoUrl
+              workspace {
+                objectId
+              }
+              default_namespace {
+                objectId
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+async function main() {
+  const sessionToken = readSessionToken();
+
+  const me = await graphql(sessionToken, ME, {});
+  const userId = me.viewer?.user?.objectId;
+  if (!userId) throw new Error("Could not resolve signed-in user");
+
+  const data = await graphql(sessionToken, GET_USER_WORKSPACES, {
+    input: {
+      user: { have: { objectId: { equalTo: userId } } },
+      isMember: { equalTo: true },
+    },
+  });
+
+  const edges = data.workspace_followers?.edges ?? [];
+  console.log(`\nuser=${userId}  rows=${edges.length}\n`);
+
+  let missingMemberCount = 0;
+  let orgPrimaryRows = 0;
+
+  for (const edge of edges) {
+    const workspace = edge.node?.workspace;
+    if (!workspace) continue;
+
+    const memberCount = workspace.memberCount;
+    const orgPrimaryId = workspace.organization?.workspace?.objectId;
+    const isOrgPrimary = orgPrimaryId === workspace.objectId;
+
+    if (typeof memberCount !== "number") missingMemberCount += 1;
+    if (isOrgPrimary) orgPrimaryRows += 1;
+
+    console.log(
+      [
+        `ws=${workspace.objectId}`,
+        `name=${JSON.stringify(workspace.workspace_name ?? null).padEnd(16)}`,
+        `memberCount=${String(memberCount ?? "MISSING").padEnd(8)}`,
+        `orgPrimary=${isOrgPrimary ? "YES" : "no "}`,
+        `orgPointsAt=${orgPrimaryId ?? "none"}`,
+      ].join("  "),
+    );
+  }
+
+  console.log(
+    `\nmemberCount populated on ${edges.length - missingMemberCount}/${edges.length} rows`,
+  );
+  console.log(`rows the organization points at: ${orgPrimaryRows}`);
+
+  if (missingMemberCount === edges.length && edges.length > 0) {
+    console.error(
+      "\nFAIL: memberCount came back empty on every row — the tie-break would " +
+        "fall back to arrival order.",
+    );
+    process.exitCode = 1;
+  } else {
+    console.log("\nOK: both tie-break signals are readable from this query.");
+  }
+}
+
+app.whenReady().then(async () => {
+  try {
+    await main();
+  } catch (error) {
+    console.error(`\nFAILED: ${error.message}`);
+    process.exitCode = 1;
+  } finally {
+    app.quit();
+  }
+});

--- a/src/electron/ipc/paprLogin.ts
+++ b/src/electron/ipc/paprLogin.ts
@@ -875,10 +875,20 @@ const GET_USER_WORKSPACES = `
           workspace {
             objectId
             workspace_name
+            # Server-computed, and a plain field rather than a pointer, so it
+            # survives the ACL filtering that can strip the organization. It is
+            # the only signal that reliably separates a shared workspace from a
+            # one-member duplicate of the same name.
+            memberCount
             organization {
               objectId
               name
               logoUrl
+              # The org's own authoritative workspace. Duplicate workspaces share
+              # a name, org and namespace, so this is what tells them apart.
+              workspace {
+                objectId
+              }
               default_namespace {
                 objectId
                 name
@@ -1031,6 +1041,31 @@ interface UserWorkspaceOption {
   isSelected: boolean;
   role: string;
   defaultNamespaceId?: string;
+  /** Members on the workspace per the server. Undefined when unreadable. */
+  memberCount?: number;
+  /** This row is the workspace its own organization points at. */
+  isOrgPrimary?: boolean;
+}
+
+/**
+ * The cache row for a fetched workspace.
+ *
+ * Single conversion for all three write sites: they had drifted apart before,
+ * and a field missing from one of them is a cache that silently loses it on the
+ * next refresh through that path.
+ */
+function toCachedWorkspace(workspace: UserWorkspaceOption): CachedWorkspace {
+  return {
+    id: workspace.workspaceId,
+    name: workspaceDisplayName(workspace),
+    role: workspace.role,
+    organizationId: workspace.organizationId,
+    organizationName: workspace.organizationName,
+    workspaceName: workspace.workspaceName,
+    defaultNamespaceId: workspace.defaultNamespaceId,
+    memberCount: workspace.memberCount,
+    isOrgPrimary: workspace.isOrgPrimary,
+  };
 }
 
 interface OwnedOrgInfo {
@@ -1219,9 +1254,11 @@ async function fetchUserWorkspaces(
           workspace?: {
             objectId?: string;
             workspace_name?: string;
+            memberCount?: number;
             organization?: {
               objectId?: string;
               name?: string;
+              workspace?: { objectId?: string };
               default_namespace?: { objectId?: string; name?: string };
             };
           };
@@ -1273,6 +1310,13 @@ async function fetchUserWorkspaces(
       );
     }
 
+    // An owned org appears in ownedOrgByWorkspaceId keyed by the workspace its
+    // own pointer references, so membership there means the same thing as the
+    // pointer we now select. Checking both covers orgs the user does not own.
+    const isOrgPrimary =
+      organization.workspace?.objectId === workspace.objectId ||
+      context.ownedOrgByWorkspaceId.has(workspace.objectId);
+
     workspaces.push({
       followerId: node.objectId,
       workspaceId: workspace.objectId,
@@ -1282,6 +1326,9 @@ async function fetchUserWorkspaces(
       isSelected: node.isSelected === true,
       role: ownedOrgIds.has(namespaceOrgId) ? "owner" : "member",
       defaultNamespaceId,
+      memberCount:
+        typeof workspace.memberCount === "number" ? workspace.memberCount : undefined,
+      isOrgPrimary,
     });
   }
 
@@ -3920,17 +3967,7 @@ export function initializePaprLoginIPC(
             customKeysStorage,
             settingsStorage,
           );
-          const rows = fetched.map(
-            (workspace): CachedWorkspace => ({
-              id: workspace.workspaceId,
-              name: workspaceDisplayName(workspace),
-              role: workspace.role,
-              organizationId: workspace.organizationId,
-              organizationName: workspace.organizationName,
-              workspaceName: workspace.workspaceName,
-              defaultNamespaceId: workspace.defaultNamespaceId,
-            }),
-          );
+          const rows = fetched.map(toCachedWorkspace);
           writeCachedWorkspaces(profile.userId, rows);
           return rows;
         };
@@ -4160,20 +4197,7 @@ export function initializePaprLoginIPC(
                   })),
                 ) !== workspaceListSignature(workspaces);
 
-              writeCachedWorkspaces(
-                profile.userId,
-                workspaces.map(
-                  (workspace): CachedWorkspace => ({
-                    id: workspace.workspaceId,
-                    name: workspaceDisplayName(workspace),
-                    role: workspace.role,
-                    organizationId: workspace.organizationId,
-                    organizationName: workspace.organizationName,
-                    workspaceName: workspace.workspaceName,
-                    defaultNamespaceId: workspace.defaultNamespaceId,
-                  }),
-                ),
-              );
+              writeCachedWorkspaces(profile.userId, workspaces.map(toCachedWorkspace));
 
               if (workspacesChanged) {
                 console.log(
@@ -4226,6 +4250,8 @@ export function initializePaprLoginIPC(
             isSelected: workspace.id === profile.workspaceId,
             role: workspace.role ?? "member",
             defaultNamespaceId: workspace.defaultNamespaceId,
+            memberCount: workspace.memberCount,
+            isOrgPrimary: workspace.isOrgPrimary,
           }),
         );
 
@@ -4245,20 +4271,7 @@ export function initializePaprLoginIPC(
         settingsStorage,
       );
 
-      writeCachedWorkspaces(
-        profile.userId,
-        workspaces.map(
-          (workspace): CachedWorkspace => ({
-            id: workspace.workspaceId,
-            name: workspaceDisplayName(workspace),
-            role: workspace.role,
-            organizationId: workspace.organizationId,
-            organizationName: workspace.organizationName,
-            workspaceName: workspace.workspaceName,
-            defaultNamespaceId: workspace.defaultNamespaceId,
-          }),
-        ),
-      );
+      writeCachedWorkspaces(profile.userId, workspaces.map(toCachedWorkspace));
 
       const selected = workspaces.find((workspace) => workspace.isSelected);
       const activeWorkspaceId =

--- a/src/electron/ipc/paprWorkspaceCache.ts
+++ b/src/electron/ipc/paprWorkspaceCache.ts
@@ -40,6 +40,13 @@ export interface CachedWorkspace {
   organizationName?: string;
   workspaceName?: string;
   defaultNamespaceId?: string;
+  /**
+   * Members per the server. Undefined when the row predates this field, which
+   * ranks below any known count when collapsing duplicates.
+   */
+  memberCount?: number;
+  /** This row is the workspace its own organization points at. */
+  isOrgPrimary?: boolean;
 }
 
 interface CachedNamespaceEntry {
@@ -48,7 +55,7 @@ interface CachedNamespaceEntry {
 }
 
 export interface PaprWorkspaceCacheFile {
-  version: 3;
+  version: 4;
   /** Owner of this cache. A mismatch is a miss, never a fallback. */
   userId: string;
   workspacesFetchedAt: string;
@@ -57,7 +64,13 @@ export interface PaprWorkspaceCacheFile {
   namespacesByOrgId: Record<string, CachedNamespaceEntry>;
 }
 
-export const WORKSPACE_CACHE_VERSION = 3;
+/**
+ * Bumped to 4 when rows gained `memberCount` and `isOrgPrimary`. A v3 row has
+ * neither, so every duplicate in a scope would rank equal and the collapse would
+ * fall back to arrival order — the bug this data exists to fix. Discarding those
+ * files costs one refetch and makes the fix apply on first launch.
+ */
+export const WORKSPACE_CACHE_VERSION = 4;
 
 /** Below this age, serve without triggering a refresh. */
 export const CACHE_FRESH_MS = 5 * 60_000;
@@ -95,8 +108,9 @@ function readForUser(userId: string): PaprWorkspaceCacheFile | null {
     return null;
   }
 
-  // Pre-v3 files carry no userId, so they cannot be attributed to an account.
-  // Discarding them costs one refetch and closes the cross-account leak.
+  // Pre-v3 files carry no userId, so they cannot be attributed to an account,
+  // and v3 rows lack the fields that pick between duplicate workspaces.
+  // Discarding either costs one refetch.
   if (parsed?.version !== WORKSPACE_CACHE_VERSION) return null;
   if (!Array.isArray(parsed.workspaces)) return null;
   if (!parsed.userId || parsed.userId !== userId) return null;
@@ -168,6 +182,48 @@ function workspaceNameScore(workspace: CachedWorkspace): number {
   return 2;
 }
 
+/**
+ * How strong a claim a row has to be *the* workspace for its scope, best first.
+ *
+ * Duplicate provisioning leaves several workspaces sharing a name, org and
+ * namespace, and only one of them is the one the team actually uses. Keeping
+ * whichever arrived first picked a one-member shell over a 601-member workspace,
+ * so the switcher showed the right name attached to the wrong id and the team
+ * list came back with only the viewer in it.
+ *
+ * Ordered by how hard each signal is to corrupt:
+ *   1. The organization's own `workspace` pointer — the org naming its
+ *      authoritative workspace. Not derived from the viewer's session.
+ *   2. `memberCount` — computed server-side from real membership, and a plain
+ *      field, so it survives the ACL filtering that hides `organization`.
+ *   3. Name quality, to keep the existing preference for a real label.
+ *
+ * `isSelected` is deliberately absent. The buggy client wrote that flag onto
+ * whichever duplicate it had already picked, so it can confirm the wrong row.
+ */
+function workspaceAuthorityRank(workspace: CachedWorkspace): number[] {
+  return [
+    workspace.isOrgPrimary === true ? 1 : 0,
+    // Below any known count, so a readable 1 outranks an unreadable unknown.
+    typeof workspace.memberCount === "number" ? workspace.memberCount : -1,
+    workspaceNameScore(workspace),
+  ];
+}
+
+/** True when `candidate` is a strictly better representative than `existing`. */
+function isStrongerWorkspace(
+  candidate: CachedWorkspace,
+  existing: CachedWorkspace,
+): boolean {
+  const left = workspaceAuthorityRank(candidate);
+  const right = workspaceAuthorityRank(existing);
+  for (let i = 0; i < left.length; i += 1) {
+    if (left[i] !== right[i]) return left[i] > right[i];
+  }
+  // Fully tied — keep the row already held so output stays first-seen stable.
+  return false;
+}
+
 /** Org + namespace a row resolves to. Rows without a namespace stand alone. */
 function workspaceScopeKey(workspace: CachedWorkspace): string {
   return workspace.defaultNamespaceId
@@ -191,7 +247,8 @@ function workspaceScopeKey(workspace: CachedWorkspace): string {
  *
  * So within a scope: rows with distinct real names are kept, and placeholder-named
  * rows are absorbed into the named ones (or collapsed among themselves if no row
- * in the scope has a real name).
+ * in the scope has a real name). Where several rows do share a name, the survivor
+ * is chosen by `workspaceAuthorityRank` rather than arrival order.
  *
  * This runs on read only. The stored rows stay untouched, so a mistake here
  * hides a workspace until the next deploy instead of destroying it on disk.
@@ -209,7 +266,7 @@ export function dedupeCachedWorkspaces(
 
     if (!name) {
       const existing = placeholders.get(scope);
-      if (!existing || workspaceNameScore(workspace) > workspaceNameScore(existing)) {
+      if (!existing || isStrongerWorkspace(workspace, existing)) {
         placeholders.set(scope, workspace);
       }
       continue;
@@ -222,7 +279,7 @@ export function dedupeCachedWorkspaces(
     }
 
     const existing = named.get(name);
-    if (!existing || workspaceNameScore(workspace) > workspaceNameScore(existing)) {
+    if (!existing || isStrongerWorkspace(workspace, existing)) {
       named.set(name, workspace);
     }
   }

--- a/tests/papr-workspace-cache-dedupe.test.ts
+++ b/tests/papr-workspace-cache-dedupe.test.ts
@@ -115,4 +115,94 @@ describe("dedupeCachedWorkspaces", () => {
 
     expect(result).toHaveLength(1);
   });
+
+  // Duplicate provisioning leaves several same-named workspaces in one scope and
+  // only one is the workspace the team uses. Keeping the first-seen row picked a
+  // one-member shell, so the switcher showed "Papr" pointing at the wrong id and
+  // the team list came back with only the viewer in it.
+  describe("choosing between duplicates of the same name", () => {
+    it("keeps the workspace its organization points at", () => {
+      const result = dedupeCachedWorkspaces([
+        { ...workspace("shell", "Papr", "ns-1"), memberCount: 1 },
+        { ...workspace("real", "Papr", "ns-1"), memberCount: 601, isOrgPrimary: true },
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("real");
+    });
+
+    it("falls back to member count when neither row is org primary", () => {
+      const result = dedupeCachedWorkspaces([
+        { ...workspace("shell", "Papr", "ns-1"), memberCount: 1 },
+        { ...workspace("real", "Papr", "ns-1"), memberCount: 601 },
+      ]);
+
+      expect(result.map((entry) => entry.id)).toEqual(["real"]);
+    });
+
+    // The org pointer is the org naming its own authoritative workspace, so it
+    // outranks a headcount that duplicate rows can inflate.
+    it("prefers the org primary row over a larger non-primary one", () => {
+      const result = dedupeCachedWorkspaces([
+        { ...workspace("big", "Papr", "ns-1"), memberCount: 900 },
+        { ...workspace("primary", "Papr", "ns-1"), memberCount: 601, isOrgPrimary: true },
+      ]);
+
+      expect(result[0].id).toBe("primary");
+    });
+
+    it("ranks a known member count above an unreadable one", () => {
+      const result = dedupeCachedWorkspaces([
+        workspace("unknown", "Papr", "ns-1"),
+        { ...workspace("known", "Papr", "ns-1"), memberCount: 1 },
+      ]);
+
+      expect(result[0].id).toBe("known");
+    });
+
+    it("keeps first-seen order when no row has a stronger claim", () => {
+      const result = dedupeCachedWorkspaces([
+        workspace("first", "Papr", "ns-1"),
+        workspace("second", "Papr", "ns-1"),
+      ]);
+
+      expect(result[0].id).toBe("first");
+    });
+
+    it("applies the same ranking to placeholder-only scopes", () => {
+      const result = dedupeCachedWorkspaces([
+        { ...workspace("shell", "null (you)", "ns-1"), memberCount: 1 },
+        { ...workspace("real", "null (you)", "ns-1"), memberCount: 601, isOrgPrimary: true },
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("real");
+    });
+
+    // The live papr-ai rows: five typo-slug duplicates with one member each
+    // alongside the 601-member workspace the org actually points at.
+    it("picks the real papr-ai workspace out of its typo duplicates", () => {
+      const duplicate = (id: string): CachedWorkspace => ({
+        ...workspace(id, "Papr", "85ZIB7mD1V"),
+        memberCount: 1,
+      });
+
+      const result = dedupeCachedWorkspaces([
+        { ...workspace("7I5tUcLunV", "null (you)", "85ZIB7mD1V"), memberCount: 1 },
+        duplicate("eZpxfyPoG2"),
+        duplicate("gWjcH8KOFA"),
+        duplicate("8iYWy5F10q"),
+        duplicate("tDu6TjHL3x"),
+        {
+          ...workspace("qDgAdi2eMf", "Papr", "85ZIB7mD1V"),
+          memberCount: 601,
+          isOrgPrimary: true,
+        },
+        duplicate("9RSVXV8mEJ"),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("qDgAdi2eMf");
+    });
+  });
 });

--- a/tests/papr-workspace-cache-store.test.ts
+++ b/tests/papr-workspace-cache-store.test.ts
@@ -99,6 +99,25 @@ describe("workspace cache persistence", () => {
     expect(readCachedWorkspaces(USER)).toBeNull();
   });
 
+  // v3 rows predate memberCount/isOrgPrimary, so serving them would collapse
+  // duplicate workspaces by arrival order and keep picking the wrong one.
+  it("ignores a v3 file, whose rows cannot rank duplicates", () => {
+    fs.mkdirSync(path.dirname(cacheFilePath()), { recursive: true });
+    fs.writeFileSync(
+      cacheFilePath(),
+      JSON.stringify({
+        version: 3,
+        userId: USER,
+        workspacesFetchedAt: new Date().toISOString(),
+        workspaces: [workspace("a", "Papr")],
+        namespacesByOrgId: {},
+      }),
+      "utf8",
+    );
+
+    expect(readCachedWorkspaces(USER)).toBeNull();
+  });
+
   it("treats a corrupt file as a miss and recovers on the next write", () => {
     fs.mkdirSync(path.dirname(cacheFilePath()), { recursive: true });
     fs.writeFileSync(cacheFilePath(), "{ truncated", "utf8");


### PR DESCRIPTION
Follow-up to #90. That PR stopped login from *creating* a wrong org; this one stops the switcher from *selecting* the wrong workspace. Symptom after upgrading to #90: still only one `Papr` workspace, and the team list shows a single member.

## The bug

`papr-ai` has seven workspaces sharing a name, org and namespace — the 601-member workspace the team uses, plus five one-member shells from typo'd slugs:

| Workspace | Slug | Members | Org primary? |
|---|---|---|---|
| `qDgAdi2eMf` | `papr-ai.papr.ai` | **601** | **YES** |
| `eZpxfyPoG2` | `papr-ai.papr.ai`**z** | 1 | no |
| `gWjcH8KOFA` | `papr-ai`**sss**`.papr.ai` | 1 | no |
| `8iYWy5F10q` | `papr-ai.papr.ai`**s** | 1 | no |
| `tDu6TjHL3x` | `papr-ai`**e**`.papr.ai` | 1 | no |
| `9RSVXV8mEJ` | `papr-ai.papr.ai`**ss** | 1 | no |

`dedupeCachedWorkspaces` is right to collapse these — they are indistinguishable to the user — but it kept whichever arrived first. Running the real function over a live cache:

```
KEPT    eZpxfyPoG2  name="Papr"     <- 1 member, typo slug
dropped qDgAdi2eMf  name="Papr"     <- 601 members, the real one
```

So the switcher showed `Papr` attached to the wrong id. Team listed one member because the shell genuinely has one, and org usage read as empty for the same reason. Clearing the cache did not help: the refetch returns the same rows and the collapse picks the same loser.

## What changed

The collapse now ranks candidates instead of taking the first:

1. **The organization's own `workspace` pointer.** The org naming its authoritative workspace, and not derived from the viewer's session.
2. **`memberCount`.** Computed server-side from real membership, and a plain field rather than a pointer, so it survives the ACL filtering that strips `organization` — the #90 failure mode one level down.
3. Name quality, then arrival order, so output stays stable for the UI.

`isSelected` is deliberately **not** a signal. The buggy client wrote that flag onto whichever duplicate it had already picked, so it can confirm the wrong row.

Both fields are new selections on the existing workspace query — no extra request.

**Cache schema 3 to 4.** A v3 row has neither field, so every duplicate would rank equal and collapse by arrival order again. Discarding those files costs one refetch and makes the fix apply on first launch rather than after a background refresh.

**Three drifting mappings collapsed into one helper.** `UserWorkspaceOption` to `CachedWorkspace` was written out at three call sites; a field missing from one is a cache that loses it on the next refresh through that path.

## Diagnostics

`scripts/verify-papr-workspace-query.cjs` asserts both tie-break fields come back populated. If either were unselectable in this shape the query would still succeed with the fields undefined, and the tie-break would silently fall back to arrival order — the exact bug — so this fails loudly instead of reporting:

```
env -u ELECTRON_RUN_AS_NODE npx electron scripts/verify-papr-workspace-query.cjs
```

Live result: `memberCount` populated on 8/8 rows, `qDgAdi2eMf` correctly identified as org primary.

## Test plan

- `npx vitest run tests/papr-workspace-cache-dedupe.test.ts` — 18 pass, 8 new, including one built from the live `papr-ai` rows asserting `qDgAdi2eMf` survives, plus cases for org-primary beating a larger non-primary row, known member counts outranking unreadable ones, and arrival order still deciding a true tie
- Full Papr login/provisioning suite green: `papr-workspace-cache-store` (19, one new for v3 rejection), `papr-workspace-cache-dedupe`, `papr-provisioning-defaults`, `papr-login-graphql`, `papr-namespace-org-resolution`, `parse-transport`, `papr-login-funnel`, `papr-api-key` — 89 tests
- `npm run type-check` clean for touched files
- Sign in on `papr-ai` and confirm the `Papr` workspace resolves to `qDgAdi2eMf` and Team lists the full membership
- Confirm the `Sqaservices` workspace (different namespace, 6 members) is unaffected

## Not in this PR

The five typo workspaces are still there and should be archived separately — this PR makes the app pick correctly regardless, but the junk rows remain in Parse.

Made with Cursor

Made with [Cursor](https://cursor.com)