### PR TITLE
fix(papr): point the active workspace at the surviving duplicate

### DIFF
--- a/src/electron/ipc/paprLogin.ts
+++ b/src/electron/ipc/paprLogin.ts
@@ -30,6 +30,7 @@ import {
   clearPaprWorkspaceCache,
   readCachedNamespaces,
   readCachedWorkspaces,
+  resolveAuthoritativeWorkspaceId,
   writeCachedNamespaces,
   writeCachedWorkspaces,
   type CachedWorkspace,
@@ -1357,12 +1358,26 @@ async function syncActiveWorkspaceOrganization(
   settingsStorage: SettingsStorage,
   customKeysStorage: CustomKeysStorage,
 ): Promise<UserWorkspaceOption | undefined> {
-  const activeWorkspaceId =
+  const requestedWorkspaceId =
     profile.workspaceId ||
     workspaces.find((workspace) => workspace.isSelected)?.workspaceId ||
     workspaces[0]?.workspaceId;
-  if (!activeWorkspaceId) {
+  if (!requestedWorkspaceId) {
     return undefined;
+  }
+
+  // The stored pointer can name a duplicate the switcher no longer shows, which
+  // leaves billing and the team list on a one-member shell while the list shows
+  // the real workspace. Route it through the same ranking so both agree, and so
+  // the write below heals the stored value.
+  const activeWorkspaceId = resolveAuthoritativeWorkspaceId(
+    workspaces.map(toCachedWorkspace),
+    requestedWorkspaceId,
+  );
+  if (activeWorkspaceId !== requestedWorkspaceId) {
+    console.log(
+      `[PaprLogin] Remapped active workspace ${requestedWorkspaceId} → ${activeWorkspaceId} (duplicate of the same org + namespace)`,
+    );
   }
 
   const active = workspaces.find((workspace) => workspace.workspaceId === activeWorkspaceId);

--- a/src/electron/ipc/paprWorkspaceCache.ts
+++ b/src/electron/ipc/paprWorkspaceCache.ts
@@ -316,6 +316,54 @@ export function dedupeCachedWorkspaces(
   return result;
 }
 
+/**
+ * The id the switcher will actually show for whichever duplicate group
+ * `workspaceId` falls into.
+ *
+ * The switcher renders deduped rows, but the *active* workspace is resolved
+ * separately from the raw list — `profile.workspaceId` first, then the selected
+ * row. A profile written by an older build points at whichever duplicate that
+ * build happened to pick, so it can name a row that dedupe now discards. The
+ * list then shows the 601-member workspace while billing and the team list stay
+ * on a one-member shell, which reads as "we're pointing at the wrong org".
+ *
+ * Mapping the stored pointer through the same ranking keeps the two in step and
+ * lets the stale value heal itself on next load. Ids that survive dedupe, and
+ * ids absent from the list, are returned unchanged.
+ */
+export function resolveAuthoritativeWorkspaceId(
+  workspaces: CachedWorkspace[],
+  workspaceId: string,
+): string {
+  const target = workspaces.find((workspace) => workspace.id === workspaceId);
+  if (!target) return workspaceId;
+
+  const survivors = dedupeCachedWorkspaces(workspaces);
+  if (survivors.some((workspace) => workspace.id === workspaceId)) {
+    return workspaceId;
+  }
+
+  const scope = workspaceScopeKey(target);
+  const inScope = survivors.filter(
+    (workspace) => workspaceScopeKey(workspace) === scope,
+  );
+  if (inScope.length === 0) return workspaceId;
+
+  // A placeholder row is absorbed without naming an absorber, so fall back to
+  // the whole scope when no survivor shares its name.
+  const name = meaningfulWorkspaceName(target);
+  const sameName = name
+    ? inScope.filter((workspace) => meaningfulWorkspaceName(workspace) === name)
+    : [];
+  const candidates = sameName.length > 0 ? sameName : inScope;
+
+  let best = candidates[0]!;
+  for (const candidate of candidates) {
+    if (isStrongerWorkspace(candidate, best)) best = candidate;
+  }
+  return best.id;
+}
+
 export interface CachedRead<T> {
   data: T;
   ageMs: number;

--- a/tests/papr-workspace-cache-dedupe.test.ts
+++ b/tests/papr-workspace-cache-dedupe.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   dedupeCachedWorkspaces,
+  resolveAuthoritativeWorkspaceId,
   type CachedWorkspace,
 } from "../src/electron/ipc/paprWorkspaceCache.js";
 
@@ -204,5 +205,56 @@ describe("dedupeCachedWorkspaces", () => {
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe("qDgAdi2eMf");
     });
+  });
+});
+
+describe("resolveAuthoritativeWorkspaceId", () => {
+  /** The live papr-ai shape: typo duplicates plus the real 601-member row. */
+  function paprAiRows(): CachedWorkspace[] {
+    const duplicate = (id: string): CachedWorkspace => ({
+      ...workspace(id, "Papr", "85ZIB7mD1V"),
+      memberCount: 1,
+    });
+    return [
+      { ...workspace("7I5tUcLunV", "null (you)", "85ZIB7mD1V"), memberCount: 1 },
+      duplicate("eZpxfyPoG2"),
+      duplicate("gWjcH8KOFA"),
+      {
+        ...workspace("qDgAdi2eMf", "Papr", "85ZIB7mD1V"),
+        memberCount: 601,
+        isOrgPrimary: true,
+      },
+      { ...workspace("3UsTzFx1oe", "Sqaservices", "HyQU6FnQW3", "rrM3uysMYw"), memberCount: 6 },
+    ];
+  }
+
+  it("remaps a stale pointer at a discarded duplicate onto the real workspace", () => {
+    expect(resolveAuthoritativeWorkspaceId(paprAiRows(), "eZpxfyPoG2")).toBe(
+      "qDgAdi2eMf",
+    );
+  });
+
+  it("leaves a pointer that already names the surviving row alone", () => {
+    expect(resolveAuthoritativeWorkspaceId(paprAiRows(), "qDgAdi2eMf")).toBe(
+      "qDgAdi2eMf",
+    );
+  });
+
+  it("remaps an absorbed placeholder row onto the named survivor", () => {
+    expect(resolveAuthoritativeWorkspaceId(paprAiRows(), "7I5tUcLunV")).toBe(
+      "qDgAdi2eMf",
+    );
+  });
+
+  it("does not move a pointer across org + namespace scopes", () => {
+    expect(resolveAuthoritativeWorkspaceId(paprAiRows(), "3UsTzFx1oe")).toBe(
+      "3UsTzFx1oe",
+    );
+  });
+
+  it("returns ids absent from the list unchanged", () => {
+    expect(resolveAuthoritativeWorkspaceId(paprAiRows(), "notInList")).toBe(
+      "notInList",
+    );
   });
 });


### PR DESCRIPTION
Follow-up to #91. That PR merged with only its first commit — this one was pushed to the branch minutes after the merge, so it never reached master.

## Why #91 alone wasn't enough

#91 fixed which duplicate the **switcher list** shows. But the **active** workspace is resolved on a separate path, from the raw un-deduped list, and `profile.workspaceId` wins that chain:

```ts
const requestedWorkspaceId =
  profile.workspaceId ||
  workspaces.find((workspace) => workspace.isSelected)?.workspaceId ||
  workspaces[0]?.workspaceId;
```

A profile written by an older build keeps naming whichever duplicate that build picked. The list then shows the real workspace while billing and the team list stay on a one-member shell — the org name looks right but reports a single member and resolves the wrong plan tier and Stripe customer.

Note Parse itself was correct: `isSelected=true` sits on the real workspace. The stale profile value simply takes priority, so that correct signal never got a chance.

## Fix

Routes the stored pointer through the same authority ranking used for dedupe (org-primary → `memberCount` → name quality), so both paths agree and the stale value is rewritten on next load. Ids that already name the surviving row, and ids absent from the list, pass through unchanged. Scope is respected, so a pointer never moves across org + namespace.

## Verified against live papr-ai data

Single startup, before and after the remap fires:

```
  workspaceId: 'eZpxfyPoG2',
[PaprLogin] Parse returned 8 workspace membership rows, kept 8: ...
[PaprLogin] Remapped active workspace eZpxfyPoG2 → qDgAdi2eMf (duplicate of the same org + namespace)
  workspaceId: 'qDgAdi2eMf',
```

| | Before | After |
|---|---|---|
| workspaceId | `eZpxfyPoG2` (1 member) | `qDgAdi2eMf` (601 members) |
| plan tier | starter | **enterprise** |
| Stripe customer | `cus_RbIAWsua…` | `cus_RbIAQMbs…` |

The pointer healed on first launch and persisted across restarts.

## Test plan

- [x] 42 cache tests pass on the merged master base
- [x] 5 new `resolveAuthoritativeWorkspaceId` cases: remaps a stale duplicate, leaves the survivor alone, remaps an absorbed placeholder, does not cross org/namespace scopes, passes unknown ids through
- [x] Typecheck clean for both touched files
- [x] End-to-end against live Parse (log above)

## Not fixed here

`[PaprBilling] Stripe subscription lookup failed: Failed to fetch subscription` appears identically before and after, so it is a separate issue from the workspace pointer. The earlier `Forbidden - You do not have access to this workspace` is gone.

Made with [Cursor](https://cursor.com)