### PR TITLE
refactor(memory): read searchId from response headers via withResponse()

### DIFF
--- a/src/core/tools/paprMemory.ts
+++ b/src/core/tools/paprMemory.ts
@@ -719,30 +719,41 @@ export const searchAgentMemoryTool = createTool({
       const chosenProvider = args.rerankingProvider ?? "cohere";
       const chosenModel = args.rerankingModel ?? (chosenProvider === "cohere" ? "rerank-v3.5" : undefined);
 
-      const response = await client.memory.search({
-        query: args.query!,
-        ...(memorySearchScope.external_user_id
-          ? { external_user_id: memorySearchScope.external_user_id }
-          : {}),
-        ...(memorySearchScope.search_acl
-          ? { search_acl: memorySearchScope.search_acl }
-          : {}),
-        max_memories: args.maxMemories ?? 20,
-        max_nodes: 20,
-        enable_agentic_graph: true,
-        reranking_config: {
-          reranking_enabled: chosenProvider !== "none",
-          reranking_provider: chosenProvider,
-          ...(chosenModel ? { reranking_model: chosenModel } : {}),
-          ...(args.rerankingDomainId ? { domain_id: args.rerankingDomainId } : {}),
-        },
-        response_format: "toon",
-        ...(searchPolicy ? { policy: searchPolicy } : {}),
-        ...(Object.keys(searchMetadata).length > 0
-          ? { metadata: searchMetadata }
-          : {}),
-      });
-      const formatted = formatSearchMemoryResponse(response);
+      // withResponse() exposes the raw Response so we can read the server's
+      // X-Search-Id / X-Memory-Count / X-Node-Count headers. That is more robust
+      // than regex-parsing the TOON body, which stays as a fallback for servers
+      // that predate those headers.
+      const { data: response, response: httpResponse } = await client.memory
+        .search({
+          query: args.query!,
+          ...(memorySearchScope.external_user_id
+            ? { external_user_id: memorySearchScope.external_user_id }
+            : {}),
+          ...(memorySearchScope.search_acl
+            ? { search_acl: memorySearchScope.search_acl }
+            : {}),
+          max_memories: args.maxMemories ?? 20,
+          max_nodes: 20,
+          enable_agentic_graph: true,
+          reranking_config: {
+            reranking_enabled: chosenProvider !== "none",
+            reranking_provider: chosenProvider,
+            ...(chosenModel ? { reranking_model: chosenModel } : {}),
+            ...(args.rerankingDomainId
+              ? { domain_id: args.rerankingDomainId }
+              : {}),
+          },
+          response_format: "toon",
+          ...(searchPolicy ? { policy: searchPolicy } : {}),
+          ...(Object.keys(searchMetadata).length > 0
+            ? { metadata: searchMetadata }
+            : {}),
+        })
+        .withResponse();
+      const formatted = formatSearchMemoryResponse(
+        response,
+        httpResponse.headers,
+      );
       // Only auto-submit low-relevance feedback when the server genuinely returned
       // nothing. memoryCount is now recovered from the TOON envelope, so a parse
       // failure must NOT be mistaken for a zero-result search — that would train

--- a/tests/papr-memory-feedback.test.ts
+++ b/tests/papr-memory-feedback.test.ts
@@ -23,6 +23,23 @@ vi.mock("../src/gateway/utils/paprUserId.js", () => ({
   invalidatePaprUserIdCache: vi.fn(),
 }));
 
+/**
+ * The SDK returns an APIPromise: awaitable AND carrying withResponse(), which
+ * resolves to { data, response }. search_agent_memory calls withResponse() to
+ * read the X-Search-Id / X-Memory-Count / X-Node-Count headers, so the mock has
+ * to model both shapes — a plain resolved value would not catch a regression.
+ */
+function mockApiPromise(data: unknown, headers: Record<string, string> = {}) {
+  const promise = Promise.resolve(data) as Promise<unknown> & {
+    withResponse: () => Promise<{ data: unknown; response: { headers: Headers } }>;
+  };
+  promise.withResponse = async () => ({
+    data,
+    response: { headers: new Headers(headers) },
+  });
+  return promise;
+}
+
 describe("papr memory feedback", () => {
   const mockSearch = vi.fn();
   const mockFeedbackSubmit = vi.fn();
@@ -58,12 +75,57 @@ describe("papr memory feedback", () => {
     expect(formatted._memoryFeedbackReminder).toContain("submit_memory_feedback");
   });
 
-  it("search_agent_memory returns searchId and auto-submits empty-search feedback", async () => {
-    mockSearch.mockResolvedValue({
-      search_id: "search-empty",
-      status: "success",
-      data: { memories: [], nodes: [] },
+  it("search_agent_memory reads searchId and counts from response headers", async () => {
+    // TOON body: data is a plain string, so counters must come from headers.
+    mockSearch.mockReturnValue(
+      mockApiPromise(
+        "code: 200\nstatus: success\ndata:\n  memories[#10]:\nsearch_id: header-search-1",
+        {
+          "X-Content-Format": "toon",
+          "X-Search-Id": "header-search-1",
+          "X-Memory-Count": "10",
+          "X-Node-Count": "3",
+        },
+      ),
+    );
+
+    const result = await searchAgentMemoryTool.execute({
+      query: "Find fundraising commitments and investor diligence status this month.",
     });
+
+    expect(result.searchId).toBe("header-search-1");
+    expect(result.memoryCount).toBe(10);
+    expect(result.nodeCount).toBe(3);
+    // Results were returned, so no low-relevance feedback should be auto-submitted.
+    expect(mockFeedbackSubmit).not.toHaveBeenCalled();
+  });
+
+  it("search_agent_memory falls back to TOON body when headers are absent", async () => {
+    // Older server without X-Search-Id headers — parser must still recover both.
+    mockSearch.mockReturnValue(
+      mockApiPromise(
+        "code: 200\nstatus: success\ndata:\n  memories[#7]:\n  nodes[#2]:\nsearch_id: 1aaafbd9-ec56-4345-8be2-9d603542e802",
+      ),
+    );
+
+    const result = await searchAgentMemoryTool.execute({
+      query: "Find architecture notes about graph embeddings and routing tiers.",
+    });
+
+    expect(result.searchId).toBe("1aaafbd9-ec56-4345-8be2-9d603542e802");
+    expect(result.memoryCount).toBe(7);
+    expect(result.nodeCount).toBe(2);
+    expect(mockFeedbackSubmit).not.toHaveBeenCalled();
+  });
+
+  it("search_agent_memory returns searchId and auto-submits empty-search feedback", async () => {
+    mockSearch.mockReturnValue(
+      mockApiPromise({
+        search_id: "search-empty",
+        status: "success",
+        data: { memories: [], nodes: [] },
+      }),
+    );
 
     const result = await searchAgentMemoryTool.execute({
       query: "Find architecture notes about graph embeddings and routing tiers.",


### PR DESCRIPTION
Follow-up to #93. This commit was pushed to the `fix/memory-toon-searchid-crud-tools` branch **after** that PR had already merged, so GitHub never picked it up — `withResponse()` is not on master.

Verified:
```
$ git merge-base --is-ancestor c4c86b8 origin/master  →  NO_NOT_IN_MASTER
$ git show origin/master:src/core/tools/paprMemory.ts | grep -c withResponse  →  0
```

## Change

`search_agent_memory` now calls `.withResponse()` so it can read the server's `X-Search-Id` / `X-Memory-Count` / `X-Node-Count` headers directly:

```ts
const { data: response, response: httpResponse } = await client.memory
  .search({ ... })
  .withResponse();
const formatted = formatSearchMemoryResponse(response, httpResponse.headers);
```

`formatSearchMemoryResponse` already accepted a `headers` argument from #93 — it was simply never passed any. Header values now take precedence; TOON body parsing remains the fallback for servers that predate those headers, so this is **backward compatible**.

### Correction to an assumption in #93

#93 justified regex-parsing the TOON body on the basis that the SDK had no `withResponse()`. That was wrong — it exists in `@papr/memory` 2.7.0 at `core/api-promise.d.ts`:

```ts
withResponse(): Promise<{ data: T; response: Response }>;
```

The original grep only covered top-level `*.d.ts` files and missed it. Reading a documented header is more robust than pattern-matching a text body.

## Testing

**31/31 passing** on top of current master (includes `caaeeb1`), `tsc --noEmit` clean.

The existing test caught this change immediately:

```
× search_agent_memory returns searchId and auto-submits empty-search feedback
  → client.memory.search(...).withResponse is not a function
```

The mock returned a plain resolved value, but the SDK returns an `APIPromise` — awaitable **and** carrying `withResponse()`. The mock now models both shapes; a plain-promise mock would not catch a regression here.

Two new cases:
- **headers present** → `searchId` / `memoryCount` / `nodeCount` read from headers
- **headers absent** → falls back to parsing the TOON body

Both assert that no auto-feedback fires when results were actually returned — guarding the `feedbackScore: 1` landmine described in #93.

## Note on CI

`Vitest + CI sequential tier` is currently red on master with 15 × `quoteIdent is not a function`, across `tursoDeltaPull.ts` / `tursoBulkInsert.ts` / `convergenceHash.ts` / `tursoSyncIndex.ts`. **Unrelated to this PR** — zero occurrences of `quoteIdent` in `paprMemory.ts`. Pre-existing on master and worth a separate fix; expect it to show red here too.

## Related

- memory#86 (merged) — added the headers server-side
- memory#90 (open) — QueryLog `searchId` fallback; the fix that actually stops feedback 404ing
- memory#94 (open) — documents these headers in the OpenAPI spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)
