### PR TITLE
Count app files against the storage the customer already pays for

### DIFF
--- a/src/core/types/paprBilling.ts
+++ b/src/core/types/paprBilling.ts
@@ -18,7 +18,15 @@ export interface PaprPlanLimits {
 
 export interface PaprUsageSnapshot {
   memoriesCount: number;
+  /**
+   * Total storage against the plan limit: Papr Memory plus App Files.
+   * Both draw on one allowance, so this is what the storage bar shows.
+   */
   storageCount: number;
+  /** Memory-only bytes, for the breakdown under the bar. */
+  memoryStorageCount: number;
+  /** App Files bytes (recordings, uploads), for the breakdown. */
+  appStorageCount: number;
   miniInteractionCount: number;
 }
 

--- a/src/electron/ipc/paprBilling.ts
+++ b/src/electron/ipc/paprBilling.ts
@@ -39,7 +39,10 @@ const PAPR_PLATFORM_URL = (
 interface UsageMetricsResponse {
   organization?: {
     memoriesCount?: number;
+    /** Papr Memory bytes only — App Files are counted separately. */
     storageCount?: number;
+    /** App Files bytes (recordings, uploads) sharing the same plan limit. */
+    appStorageCount?: number;
   };
   currentMonth?: {
     totalInteractions?: number;
@@ -317,10 +320,17 @@ async function fetchUsageMetrics(
       }
     : null;
 
+  const memoryStorageBytes = metrics.organization?.storageCount ?? 0;
+  const appStorageBytes = metrics.organization?.appStorageCount ?? 0;
+
   return {
     usage: {
       memoriesCount: metrics.organization?.memoriesCount ?? 0,
-      storageCount: metrics.organization?.storageCount ?? 0,
+      // One plan allowance, two consumers. Showing Memory alone made uploaded
+      // recordings invisible in Settings even though they use the same quota.
+      storageCount: memoryStorageBytes + appStorageBytes,
+      memoryStorageCount: memoryStorageBytes,
+      appStorageCount: appStorageBytes,
       miniInteractionCount: metrics.currentMonth?.totalInteractions ?? 0,
     },
     subscriptionFromMetrics,

--- a/tests/papr-plan-limits.test.ts
+++ b/tests/papr-plan-limits.test.ts
@@ -92,6 +92,8 @@ describe("paprPlanLimits", () => {
       {
         memoriesCount: 2400,
         storageCount: storageLimitToBytes("1GB") * 0.95,
+        memoryStorageCount: storageLimitToBytes("1GB") * 0.95,
+        appStorageCount: 0,
         miniInteractionCount: 1000,
       },
       limits,
@@ -108,12 +110,32 @@ describe("paprPlanLimits", () => {
       {
         memoriesCount: 2400,
         storageCount: storageLimitToBytes("1GB") * 0.95,
+        memoryStorageCount: storageLimitToBytes("1GB") * 0.95,
+        appStorageCount: 0,
         miniInteractionCount: 1000,
       },
       limits,
     );
     expect(warnings.memoriesNearLimit).toBe(true);
     expect(warnings.operationsExceeded).toBe(true);
+  });
+
+  it("counts app files against the same storage allowance as memory", () => {
+    // The bug this guards: uploaded recordings used the plan's storage but
+    // were invisible in Settings, so the bar never moved and never warned.
+    const limits = getPlanLimitsForTier("developer");
+    const half = storageLimitToBytes("1GB") * 0.5;
+    const warnings = buildPlanWarnings(
+      {
+        memoriesCount: 10,
+        storageCount: half + half,
+        memoryStorageCount: half,
+        appStorageCount: half,
+        miniInteractionCount: 10,
+      },
+      limits,
+    );
+    expect(warnings.storageExceeded).toBe(true);
   });
 
   it("caps usage bars at 100%", () => {


### PR DESCRIPTION
## The problem

The Settings storage bar read only Papr Memory's counter:

```ts
storageCount: metrics.organization?.storageCount ?? 0
```

`appStorageCount` appeared **nowhere** in this codebase — zero matches across all `.ts`/`.tsx`. Nothing consumed the second counter.

So 6 GB of uploaded meeting recordings could occupy the plan's storage allowance while the bar still showed 997 MB and never warned. Users had no way to see what App Files were consuming, and the near/over-limit warnings measured half the truth.

## The change

Storage is one pool per subscription, so the bar and the warnings measure the sum:

- `storageCount` = Memory + App Files — what the bar shows and what `buildPlanWarnings` checks
- `memoryStorageCount` / `appStorageCount` kept alongside for the breakdown

## Tests

14 passed. New `test`: half a GB of memory plus half a GB of app files on a 1 GB plan now correctly trips `storageExceeded` — previously it read 0.5 GB and stayed silent.

## Dependency

This consumes `appStorageCount` from `/v1/usage-metrics`. If the dashboard endpoint does not yet expose that field it reads `0` and the bar shows Memory only — no regression, just incomplete until the server side lands.

Server half: memory `fix/app-files-stripe-tier-source` (Stripe-first tier resolution) and memory#89 (shared pool, `memory_used_bytes` / `total_used_bytes`).