### PR TITLE
Make the OAuth/API key switch actually route the agent

### DIFF
--- a/src/core/storage/SettingsStorage.ts
+++ b/src/core/storage/SettingsStorage.ts
@@ -178,6 +178,29 @@ export class SettingsStorage {
   }
 
   /**
+   * Which credential the user picked for a provider that has both OAuth and an
+   * API key. Defaults to "oauth" because key resolution has always preferred it.
+   */
+  getProviderAuthPreference(
+    provider: "openai" | "anthropic",
+  ): "oauth" | "apiKey" {
+    return this.store.get(
+      `preferences.providerAuthPreference.${provider}`,
+      "oauth",
+    ) as "oauth" | "apiKey";
+  }
+
+  setProviderAuthPreference(
+    provider: "openai" | "anthropic",
+    preference: "oauth" | "apiKey",
+  ): void {
+    this.store.set(
+      `preferences.providerAuthPreference.${provider}`,
+      preference,
+    );
+  }
+
+  /**
    * Stable random id per install for anonymous DAU-style metrics only.
    */
   getOrCreateTelemetryInstallId(): string {

--- a/src/core/types/agents.ts
+++ b/src/core/types/agents.ts
@@ -75,6 +75,12 @@ export interface AgentConfigInternal extends AgentConfig {
   apiKey: string; // Fetched internally via IPC, never sent over network
   /** When OAuth is used for openai/anthropic; used to route to pi-ai vs AI SDK */
   authType?: "oauth" | "apiKey";
+  /**
+   * Credential generation `apiKey` was resolved under. Sessions reuse a resolved
+   * credential for their lifetime, so this lets them detect that the user changed
+   * auth mode or keys and re-resolve instead of using the old one.
+   */
+  authEpoch?: number;
 }
 
 /**

--- a/src/core/types/storage.ts
+++ b/src/core/types/storage.ts
@@ -87,6 +87,15 @@ export interface AppSettings {
      * "user" = private, "namespace" = workspace team, "org" = organization.
      */
     defaultMemoryScope?: "user" | "namespace" | "org";
+    /**
+     * Which credential to use when a provider has both OAuth and an API key.
+     * Key resolution prefers OAuth by default, so this is the only way to reach
+     * a Platform API key (and its separate rate limits) without disconnecting
+     * the subscription. Unset means OAuth, matching the historical default.
+     */
+    providerAuthPreference?: Partial<
+      Record<"openai" | "anthropic", "oauth" | "apiKey">
+    >;
   };
   /** Anonymous install id for telemetry correlation only; not derived from user data. */
   telemetry: {

--- a/src/electron/index.cjs
+++ b/src/electron/index.cjs
@@ -1275,8 +1275,18 @@ class GatewayProcessSupervisor {
           const oauthStorage = getOAuthTokenStorage();
 
           if (oauthStorage) {
+            // The gateway prefers OAuth whenever a token is present, so honouring
+            // an "API key" choice means withholding the token here. Sending it and
+            // filtering downstream would silently lose to that precedence.
+            const prefersApiKey = (provider) =>
+              settings?.getProviderAuthPreference?.(provider) === "apiKey";
+
             const openaiToken = oauthStorage.getTokenByProvider("openai");
-            if (openaiToken && !oauthStorage.isTokenExpired(openaiToken)) {
+            if (prefersApiKey("openai")) {
+              console.log(
+                "[Electron]   ↷ OpenAI OAuth withheld — user chose API key",
+              );
+            } else if (openaiToken && !oauthStorage.isTokenExpired(openaiToken)) {
               oauthTokens.openai = {
                 accessToken: openaiToken.accessToken,
                 expiresAt: openaiToken.expiresAt,
@@ -1285,7 +1295,11 @@ class GatewayProcessSupervisor {
             }
 
             const claudeToken = oauthStorage.getTokenByProvider("anthropic");
-            if (claudeToken && !oauthStorage.isTokenExpired(claudeToken)) {
+            if (prefersApiKey("anthropic")) {
+              console.log(
+                "[Electron]   ↷ Claude OAuth withheld — user chose API key",
+              );
+            } else if (claudeToken && !oauthStorage.isTokenExpired(claudeToken)) {
               console.log(`[Electron]   Claude OAuth token details: length=${claudeToken.accessToken.length}, prefix=${claudeToken.accessToken.substring(0, 30)}...`);
               oauthTokens.anthropic = {
                 accessToken: claudeToken.accessToken,
@@ -2206,6 +2220,47 @@ app.whenReady().then(async () => {
   }
 
   ipcMain.handle("app:get-version", () => app.getVersion());
+
+  // Which credential to use when a provider has both OAuth and an API key.
+  // Lives in main because main decides which tokens the gateway ever sees.
+  ipcMain.handle("provider-auth:get-preference", (_event, provider) => {
+    if (provider !== "openai" && provider !== "anthropic") {
+      throw new TypeError(`Unsupported provider: ${provider}`);
+    }
+    return { preference: settingsStorage.getProviderAuthPreference(provider) };
+  });
+
+  ipcMain.handle(
+    "provider-auth:set-preference",
+    (_event, provider, preference) => {
+      if (provider !== "openai" && provider !== "anthropic") {
+        throw new TypeError(`Unsupported provider: ${provider}`);
+      }
+      if (preference !== "oauth" && preference !== "apiKey") {
+        throw new TypeError(`Unsupported preference: ${preference}`);
+      }
+      settingsStorage.setProviderAuthPreference(provider, preference);
+      // The gateway caches keys and OAuth tokens per provider, so drop the stale
+      // entry or it keeps using the credential the user just switched away from.
+      if (supervisor?.getProcess() && !supervisor.getProcess().killed) {
+        try {
+          supervisor.getProcess().send({
+            type: "INVALIDATE_KEY_CACHE",
+            keyName:
+              provider === "anthropic"
+                ? "ANTHROPIC_API_KEY"
+                : "OPENAI_API_KEY",
+          });
+        } catch (error) {
+          console.warn(
+            "[Electron] Could not invalidate gateway key cache:",
+            error.message,
+          );
+        }
+      }
+      return { success: true, preference };
+    },
+  );
 
   // Backfill gateway settings with Papr user id before telemetry + gateway spawn
   const paprProfile = settingsStorage.getPaprProfile();

--- a/src/electron/preload.cjs
+++ b/src/electron/preload.cjs
@@ -318,6 +318,13 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.invoke("telemetry:set-enabled", enabled),
   },
 
+  providerAuth: {
+    getPreference: (provider) =>
+      ipcRenderer.invoke("provider-auth:get-preference", provider),
+    setPreference: (provider, preference) =>
+      ipcRenderer.invoke("provider-auth:set-preference", provider, preference),
+  },
+
   chatAttachments: {
     save: (input) => ipcRenderer.invoke("chat:save-attachment", input),
     readPreview: (input) =>

--- a/src/gateway/services/AgentService.ts
+++ b/src/gateway/services/AgentService.ts
@@ -1361,6 +1361,11 @@ export class AgentService {
                 await import("../utils/resolveJobProviderModel.js")
               ).normalizeChatGptOAuthToken(token)
             : token;
+        // This env var doubles as the Platform API key, so keep the real one
+        // recoverable for when the user switches this provider to API key mode.
+        (
+          await import("../utils/keyResolver.js")
+        ).preserveEnvKeyBeforeOverwrite(envKey);
         process.env[envKey] = piToken;
         console.log(`[AgentService] Set ${envKey} in process.env (length: ${piToken.length})`);
 

--- a/src/gateway/utils/keyResolver.ts
+++ b/src/gateway/utils/keyResolver.ts
@@ -40,6 +40,35 @@ interface IpcProcessLike {
 const IPC_KEY_RESOLVE_TIMEOUT_MS = 15_000;
 const PAPR_API_KEY_RETRY_COOLDOWN_MS = 3_000;
 
+/**
+ * Real Platform keys that the OAuth path overwrote in process.env.
+ *
+ * pi-ai reads its credential from process.env, so an OAuth turn assigns the
+ * OAuth token to ANTHROPIC_API_KEY / OPENAI_API_KEY for the rest of the process.
+ * Without the original stashed here, switching a provider back to its API key
+ * would resolve that OAuth token instead of the user's real key.
+ */
+const overwrittenEnvKeys: Record<string, string> = {};
+
+/**
+ * OAuth access tokens are not Platform API keys — sending one to the Platform
+ * API fails or bills against the wrong quota, so never resolve one as a key.
+ */
+function isOAuthShapedToken(value: string): boolean {
+  return value.startsWith("sk-ant-oat") || value.startsWith("sk-ant-ort");
+}
+
+/**
+ * Call before assigning an OAuth token to a provider's API-key env var so the
+ * real key stays resolvable. No-op unless it would discard a genuine key.
+ */
+export function preserveEnvKeyBeforeOverwrite(keyName: string): void {
+  const current = process.env[keyName];
+  if (!current || isOAuthShapedToken(current)) return;
+  if (overwrittenEnvKeys[keyName]) return;
+  overwrittenEnvKeys[keyName] = current;
+}
+
 let paprApiKeyIpcInFlight: Promise<string | undefined> | null = null;
 let paprApiKeyUnavailableUntil = 0;
 
@@ -148,11 +177,16 @@ export async function getApiKeys(
     // Development: use process.env (from .env.local)
     console.log("[KeyResolver] Development mode - using process.env");
     for (const keyName of keyNames) {
-      const value = process.env[keyName];
-      if (value) {
-        keys[keyName] = value;
-        console.log(`[KeyResolver]   ✓ ${keyName} found in env`);
+      const value = overwrittenEnvKeys[keyName] ?? process.env[keyName];
+      if (!value) continue;
+      if (isOAuthShapedToken(value)) {
+        console.warn(
+          `[KeyResolver]   ✗ Ignoring ${keyName} — holds an OAuth token, not a Platform API key`,
+        );
+        continue;
       }
+      keys[keyName] = value;
+      console.log(`[KeyResolver]   ✓ ${keyName} found in env`);
     }
     return keys;
   }

--- a/src/gateway/utils/keyResolver.ts
+++ b/src/gateway/utils/keyResolver.ts
@@ -51,6 +51,17 @@ const PAPR_API_KEY_RETRY_COOLDOWN_MS = 3_000;
 const overwrittenEnvKeys: Record<string, string> = {};
 
 /**
+ * Bumped whenever the cached credentials change — auth-mode switch, key edit,
+ * re-auth. Chat sessions keep the credential they resolved at creation for their
+ * whole lifetime, so they compare epochs to notice theirs went stale.
+ */
+let authEpoch = 0;
+
+export function getAuthEpoch(): number {
+  return authEpoch;
+}
+
+/**
  * OAuth access tokens are not Platform API keys — sending one to the Platform
  * API fails or bills against the wrong quota, so never resolve one as a key.
  */
@@ -350,6 +361,7 @@ export async function getPaprApiKey(
  * @param keyName - Optional specific key to clear, or undefined to clear all
  */
 export function clearKeyCache(keyName?: string): void {
+  authEpoch += 1;
   if (keyName) {
     delete keyCache[keyName];
     if (keyName === "PAPR_API_KEY") {
@@ -428,7 +440,11 @@ export async function getProviderAuth(
   // Populate OAuth cache from Electron main process when available.
   // In dev mode getApiKeys() reads process.env only, but the gateway still runs
   // as an Electron child with IPC — so OAuth tokens from Settings must be loaded here.
-  if (ipcProcess.send && !hasValidOAuthToken(provider)) {
+  //
+  // Ask on every resolution, not just when the cache is empty: main decides which
+  // credentials the gateway may see (it withholds OAuth when the user picked API
+  // key), and a cached token must never keep us from re-reading that decision.
+  if (ipcProcess.send) {
     try {
       await requestKeysViaIPC([keyName], ipcProcess);
     } catch (error) {

--- a/src/gateway/websocket/agent.ts
+++ b/src/gateway/websocket/agent.ts
@@ -74,9 +74,16 @@ export async function setupAgentHandlers(
         let authType: "oauth" | "apiKey" | undefined;
         let usePaprProxy = false;
 
+        const { getAuthEpoch } = await import("../utils/keyResolver.js");
+        const authEpoch = getAuthEpoch();
+
         if (
           existingSession &&
-          agentService.isSameProvider(existingSession.config, config)
+          agentService.isSameProvider(existingSession.config, config) &&
+          // A session holds its credential for its whole lifetime, so reusing it
+          // blindly would keep sending the old one after the user switched auth
+          // mode or updated a key. Only reuse while the epoch still matches.
+          existingSession.config.authEpoch === authEpoch
         ) {
           // Reuse API key and auth type from existing session (ZERO keychain access!)
           apiKey = existingSession.config.apiKey;
@@ -86,6 +93,11 @@ export async function setupAgentHandlers(
             `[Agent WS] Reusing cached API key for chat ${chatId} (${config.provider})`,
           );
         } else {
+          if (existingSession && existingSession.config.authEpoch !== authEpoch) {
+            console.log(
+              `[Agent WS] Credentials changed since session was created — re-resolving auth for chat ${chatId}`,
+            );
+          }
           // Fetch API key via IPC (secure method - never sent over WebSocket)
           // Only happens on first message or when switching providers
           const t2 = performance.now();
@@ -194,7 +206,13 @@ export async function setupAgentHandlers(
         }
 
         // Create internal config with API key and auth type (for OAuth vs API key routing)
-        const configInternal = { ...config, apiKey, authType, usePaprProxy };
+        const configInternal = {
+          ...config,
+          apiKey,
+          authType,
+          usePaprProxy,
+          authEpoch,
+        };
 
         // Log which authentication method is being used
         if (usePaprProxy) {

--- a/tests/key-resolver-ipc.test.ts
+++ b/tests/key-resolver-ipc.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   clearKeyCache,
   getApiKeys,
+  getAuthEpoch,
   getPaprApiKey,
+  getProviderAuth,
   preserveEnvKeyBeforeOverwrite,
 } from "../src/gateway/utils/keyResolver.js";
 import type {
@@ -105,6 +107,57 @@ describe("keyResolver IPC flow", () => {
     const keys = await getApiKeys(["OPENAI_API_KEY"], fakeIpcWithoutSend);
 
     expect(keys.OPENAI_API_KEY).toBe("env-fallback-key");
+  });
+
+  test("bumps the auth epoch when cached credentials are cleared", () => {
+    // Chat sessions keep the credential they resolved at creation, so the epoch is
+    // the only signal telling them an auth-mode switch invalidated it.
+    const before = getAuthEpoch();
+
+    clearKeyCache("ANTHROPIC_API_KEY");
+
+    expect(getAuthEpoch()).toBeGreaterThan(before);
+  });
+
+  test("re-asks main for OAuth tokens even when one is already cached", async () => {
+    // Main withholds the OAuth token once the user picks API key, so a cached
+    // token must not stop us from re-reading that decision.
+    process.env.NODE_ENV = "development";
+    process.env.ANTHROPIC_API_KEY = "sk-ant-api03-real-platform-key";
+
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    let withholdOAuth = false;
+
+    class TogglingOAuthIpc extends EventEmitter {
+      public sentMessages: RequestKeysMessage[] = [];
+
+      send = (message: unknown): void => {
+        const typedMessage = message as RequestKeysMessage;
+        this.sentMessages.push(typedMessage);
+        this.emit("message", {
+          type: "KEYS_RESPONSE",
+          requestId: typedMessage.requestId,
+          keys: {},
+          oauthTokens: withholdOAuth
+            ? {}
+            : { anthropic: { accessToken: "sk-ant-oat01-token", expiresAt } },
+        } satisfies KeysResponseMessage);
+      };
+    }
+
+    const fakeIpc = new TogglingOAuthIpc();
+
+    const asOAuth = await getProviderAuth("anthropic", fakeIpc);
+    expect(asOAuth).toEqual({ type: "oauth", token: "sk-ant-oat01-token" });
+
+    withholdOAuth = true;
+    const asApiKey = await getProviderAuth("anthropic", fakeIpc);
+
+    expect(asApiKey).toEqual({
+      type: "apiKey",
+      key: "sk-ant-api03-real-platform-key",
+    });
+    expect(fakeIpc.sentMessages).toHaveLength(2);
   });
 
   test("getPaprApiKey rejects IPC key scoped to a different namespace", async () => {

--- a/tests/key-resolver-ipc.test.ts
+++ b/tests/key-resolver-ipc.test.ts
@@ -3,6 +3,7 @@ import {
   clearKeyCache,
   getApiKeys,
   getPaprApiKey,
+  preserveEnvKeyBeforeOverwrite,
 } from "../src/gateway/utils/keyResolver.js";
 import type {
   RequestKeysMessage,
@@ -32,10 +33,13 @@ describe("keyResolver IPC flow", () => {
   const originalPaprOrg = process.env.PAPR_ORG_ID;
   const originalPaprNamespace = process.env.PAPR_NAMESPACE_ID;
 
+  const originalAnthropicKey = process.env.ANTHROPIC_API_KEY;
+
   beforeEach(() => {
     clearKeyCache();
     delete process.env.OPENAI_API_KEY;
     delete process.env.PAPR_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
   });
 
   afterEach(() => {
@@ -44,6 +48,8 @@ describe("keyResolver IPC flow", () => {
     else process.env.PAPR_ORG_ID = originalPaprOrg;
     if (originalPaprNamespace === undefined) delete process.env.PAPR_NAMESPACE_ID;
     else process.env.PAPR_NAMESPACE_ID = originalPaprNamespace;
+    if (originalAnthropicKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalAnthropicKey;
   });
 
   test("uses process.env in development mode", async () => {
@@ -53,6 +59,29 @@ describe("keyResolver IPC flow", () => {
     const keys = await getApiKeys(["OPENAI_API_KEY"]);
 
     expect(keys.OPENAI_API_KEY).toBe("env-dev-key");
+  });
+
+  test("ignores an OAuth token sitting in a provider's API key env var", async () => {
+    // The pi-ai OAuth path assigns the OAuth token to ANTHROPIC_API_KEY, and an
+    // OAuth token is never a valid Platform key.
+    process.env.NODE_ENV = "development";
+    process.env.ANTHROPIC_API_KEY = "sk-ant-oat01-not-a-platform-key";
+
+    const keys = await getApiKeys(["ANTHROPIC_API_KEY"]);
+
+    expect(keys.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  test("recovers the real API key after the OAuth path overwrites env", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.ANTHROPIC_API_KEY = "sk-ant-api03-real-platform-key";
+
+    preserveEnvKeyBeforeOverwrite("ANTHROPIC_API_KEY");
+    process.env.ANTHROPIC_API_KEY = "sk-ant-oat01-oauth-token";
+
+    const keys = await getApiKeys(["ANTHROPIC_API_KEY"]);
+
+    expect(keys.ANTHROPIC_API_KEY).toBe("sk-ant-api03-real-platform-key");
   });
 
   test("requests keys via IPC in production and caches response", async () => {

--- a/ui/__tests__/stores/chatStore.test.ts
+++ b/ui/__tests__/stores/chatStore.test.ts
@@ -268,6 +268,52 @@ describe("ChatStore", () => {
     });
   });
 
+  // ── Stream Recovery Reason ──────────────────────────────────────
+
+  describe("Stream Recovery Reason", () => {
+    it("should default to a connection reason so the original banner copy wins", () => {
+      initChat("chat-1");
+
+      useChatStore.getState().setNeedsStreamRecovery("chat-1", true);
+
+      const state = useChatStore.getState().getChatState("chat-1");
+      expect(state.needsStreamRecovery).toBe(true);
+      expect(state.streamRecoveryReason).toBe("connection");
+    });
+
+    it("should record a rate limit reason when the provider ran out of capacity", () => {
+      initChat("chat-1");
+
+      useChatStore.getState().setNeedsStreamRecovery("chat-1", true, "rateLimit");
+
+      const state = useChatStore.getState().getChatState("chat-1");
+      expect(state.needsStreamRecovery).toBe(true);
+      expect(state.streamRecoveryReason).toBe("rateLimit");
+    });
+
+    it("should clear the reason once recovery is no longer needed", () => {
+      initChat("chat-1");
+
+      useChatStore.getState().setNeedsStreamRecovery("chat-1", true, "rateLimit");
+      useChatStore.getState().setNeedsStreamRecovery("chat-1", false);
+
+      const state = useChatStore.getState().getChatState("chat-1");
+      expect(state.needsStreamRecovery).toBe(false);
+      expect(state.streamRecoveryReason).toBeUndefined();
+    });
+
+    it("should not leak a rate limit reason into other chats", () => {
+      initChat("chat-1");
+      initChat("chat-2");
+
+      useChatStore.getState().setNeedsStreamRecovery("chat-1", true, "rateLimit");
+
+      expect(
+        useChatStore.getState().getChatState("chat-2").streamRecoveryReason,
+      ).toBeUndefined();
+    });
+  });
+
   // ── Unread & Read State ─────────────────────────────────────────
 
   describe("Unread & Read State", () => {

--- a/ui/components/Chat/ChatContainer.tsx
+++ b/ui/components/Chat/ChatContainer.tsx
@@ -150,6 +150,7 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
   const isSending = chatState?.isSending ?? false;
   const connectionPaused = chatState?.connectionPaused ?? false;
   const needsStreamRecovery = chatState?.needsStreamRecovery ?? false;
+  const streamRecoveryReason = chatState?.streamRecoveryReason ?? "connection";
 
   const error = useChatStore((state) => state.error);
 
@@ -824,7 +825,9 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
       {needsStreamRecovery && (
         <div className="stream-recovery-banner">
           <span className="stream-recovery-banner__message">
-            Connection restored, but the agent response may be incomplete.
+            {streamRecoveryReason === "rateLimit"
+              ? `${selectedModel.name} hit the provider's rate limit, so the reply never started. Wait a moment and tap Resume, or switch to another model.`
+              : "Connection restored, but the agent response may be incomplete."}
           </span>
           <button
             type="button"

--- a/ui/components/Settings/OAuthSection.tsx
+++ b/ui/components/Settings/OAuthSection.tsx
@@ -46,7 +46,10 @@ export function OAuthSection({
   const { status, loading, startOAuthLogin, disconnect } = useOAuth(provider, {
     source: oauthSource,
   });
+  // Persisted in the main process: it decides which credential the gateway ever
+  // sees, so this is the mode the agent actually runs on, not just which form shows.
   const [useApiKey, setUseApiKey] = useState(false);
+  const [authPrefLoaded, setAuthPrefLoaded] = useState(false);
   const [showPasteToken, setShowPasteToken] = useState(false);
   const [pasteMode, setPasteMode] = useState<PasteMode>("idle");
   const [prevTimedOut, setPrevTimedOut] = useState(false);
@@ -143,6 +146,40 @@ export function OAuthSection({
   }, [status.timedOut, status.error, status.connected, status.showPasteField, provider]);
 
 
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const result =
+          await window.electronAPI?.providerAuth?.getPreference(provider);
+        if (!cancelled && result?.preference === "apiKey") {
+          setUseApiKey(true);
+        }
+      } catch (error) {
+        console.error("Failed to load provider auth preference:", error);
+      } finally {
+        if (!cancelled) setAuthPrefLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [provider]);
+
+  const handleToggleAuthMode = async () => {
+    const next = !useApiKey;
+    setUseApiKey(next);
+    try {
+      await window.electronAPI?.providerAuth?.setPreference(
+        provider,
+        next ? "apiKey" : "oauth",
+      );
+    } catch (error) {
+      console.error("Failed to save provider auth preference:", error);
+      setUseApiKey(!next);
+    }
+  };
+
   // Check if API key already exists when switching to API key mode
   React.useEffect(() => {
     if (useApiKey) {
@@ -207,10 +244,20 @@ export function OAuthSection({
     <div className="oauth-card">
       <div className="oauth-card__header">
         <h3>{title}</h3>
-        {status.connected && (
-          <span className="oauth-badge oauth-badge--connected">
-            ✓ Connected
-          </span>
+        {/* In API key mode the OAuth token is deliberately unused, so showing it
+            as connected is what made the switch look like it hadn't applied. */}
+        {useApiKey ? (
+          apiKeySaved && (
+            <span className="oauth-badge oauth-badge--connected">
+              ✓ Using API key
+            </span>
+          )
+        ) : (
+          status.connected && (
+            <span className="oauth-badge oauth-badge--connected">
+              ✓ Connected
+            </span>
+          )
         )}
       </div>
 
@@ -469,7 +516,8 @@ export function OAuthSection({
         </span>
         <button
           className="oauth-toggle-switch"
-          onClick={() => setUseApiKey(!useApiKey)}
+          onClick={() => void handleToggleAuthMode()}
+          disabled={!authPrefLoaded}
           aria-label="Toggle between OAuth and API Key"
         >
           <span className={`oauth-toggle-slider ${useApiKey ? 'right' : 'left'}`} />

--- a/ui/hooks/useAgent.ts
+++ b/ui/hooks/useAgent.ts
@@ -1127,7 +1127,7 @@ export function useAgent() {
               );
               setSending(chatId, false);
               setConnectionPaused(chatId, false);
-              setNeedsStreamRecovery(chatId, true);
+              setNeedsStreamRecovery(chatId, true, "rateLimit");
               setError(null);
 
               const streamingMessageId =

--- a/ui/stores/chatStore.ts
+++ b/ui/stores/chatStore.ts
@@ -11,6 +11,7 @@ import type {
   ChatState,
   StreamingState,
   SequenceItem,
+  StreamRecoveryReason,
 } from "../types/chat";
 import type { MemoryAudience } from "../constants/memoryScope";
 import type { ToolCall } from "../types/core";
@@ -53,7 +54,11 @@ interface ChatStore {
   setLoading: (loading: boolean) => void;
   setSending: (chatId: string, sending: boolean) => void;
   setConnectionPaused: (chatId: string, paused: boolean) => void;
-  setNeedsStreamRecovery: (chatId: string, needs: boolean) => void;
+  setNeedsStreamRecovery: (
+    chatId: string,
+    needs: boolean,
+    reason?: StreamRecoveryReason,
+  ) => void;
   setError: (error: string | null) => void;
 
   // Parallel chat state management
@@ -420,7 +425,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       return { chatStates: newChatStates };
     }),
 
-  setNeedsStreamRecovery: (chatId, needs) =>
+  setNeedsStreamRecovery: (chatId, needs, reason = "connection") =>
     set((state) => {
       const chatState = state.chatStates.get(chatId);
       if (!chatState) return state;
@@ -429,7 +434,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       newChatStates.set(chatId, {
         ...chatState,
         needsStreamRecovery: needs,
-        ...(needs ? { connectionPaused: false } : {}),
+        ...(needs
+          ? { connectionPaused: false, streamRecoveryReason: reason }
+          : { streamRecoveryReason: undefined }),
       });
 
       return { chatStates: newChatStates };

--- a/ui/types/chat.ts
+++ b/ui/types/chat.ts
@@ -46,6 +46,12 @@ export interface ChatMessage extends CoreMessage {
   sequence?: SequenceItem[];
 }
 
+/**
+ * Why the turn stopped and is offering Resume. The banner copy differs: a dropped
+ * gateway is our problem to explain, a provider rate limit is the user's to wait out.
+ */
+export type StreamRecoveryReason = "connection" | "rateLimit";
+
 export interface ChatState {
   messages: ChatMessage[];
   isLoading: boolean;
@@ -55,6 +61,8 @@ export interface ChatState {
   connectionPaused?: boolean;
   /** Auto-resume failed — user can tap Continue to retry stream recovery */
   needsStreamRecovery?: boolean;
+  /** Defaults to "connection" when unset, matching the original recovery banner. */
+  streamRecoveryReason?: StreamRecoveryReason;
   hasUnread: boolean;
   draftMessage?: string; // Persisted draft message for this chat
   lastSelectedModelId?: string; // Last model user chose for this chat

--- a/ui/types/electron.d.ts
+++ b/ui/types/electron.d.ts
@@ -437,6 +437,16 @@ export interface ElectronAPI {
     ) => Promise<{ success: boolean; enabled: boolean }>;
   };
 
+  providerAuth: {
+    getPreference: (
+      provider: "openai" | "anthropic",
+    ) => Promise<{ preference: "oauth" | "apiKey" }>;
+    setPreference: (
+      provider: "openai" | "anthropic",
+      preference: "oauth" | "apiKey",
+    ) => Promise<{ success: boolean; preference: "oauth" | "apiKey" }>;
+  };
+
   chatAttachments: {
     save: (input: {
       chatId: string;


### PR DESCRIPTION
## Summary

Picking **API Key** for Claude (or OpenAI) left the agent running on OAuth. Users capped by a personal Claude subscription had no way to reach their organization's much higher Platform limits short of disconnecting the subscription entirely. Reported symptom: *"I just switched from OAuth to API key but it's not saving this configuration and not using API key still — when I tried to send a test message it didn't work."*

Two independent defects were behind it.

**1. The toggle was cosmetic.** It was plain component state (`useState(false)`) that only chose which *form* to render. It reset on every remount and told nothing downstream. Since key resolution prefers OAuth whenever a token exists, the API key could never win regardless of what was clicked.

The choice now persists in the **main process**, which is the only place that can enforce it — main decides which tokens the gateway ever receives. Choosing API key withholds that provider's OAuth token from `KEYS_RESPONSE` and invalidates the gateway's cached credential, so the switch lands on the next message instead of requiring a restart.

**2. The real Platform key was being destroyed in memory.** This is why the test message failed even with a valid `sk-ant-api03…` key present. pi-ai reads its credential from `process.env`, so every OAuth turn ran `process.env.ANTHROPIC_API_KEY = <oauth token>`, clobbering the real key for the life of the gateway process. Any later API-key resolution then handed an `sk-ant-oat…` token to the Platform API. Visible in the logs as `✓ ANTHROPIC_API_KEY found in env` immediately followed by `prefix: sk-ant-oat01-…`.

The resolver now stashes the real key before it is overwritten, and never resolves an OAuth-shaped token as an API key.

Two smaller fixes that came out of the same report:

- The card header claimed `✓ Connected` (OAuth) while in API-key mode, which is a large part of why the switch looked like it hadn't applied. It now reads `✓ Using API key`.
- The stream recovery banner blamed the connection for provider rate limits, so a turn that never started read as a network blip. Rate-limit stops now name the throttled model and say what to do. This part is independent of the auth change and can be reviewed on its own (`ui/types/chat.ts`, `ui/stores/chatStore.ts`, `ui/hooks/useAgent.ts`, `ui/components/Chat/ChatContainer.tsx`).

## Why the Anthropic console showed no usage

Worth recording, since it looked like a contradiction: OAuth billed against the personal Claude subscription's rolling caps, which never appear in the org console. Once on the API key, usage shows there and gets the org limits.

## Test plan

- [x] `tests/key-resolver-ipc.test.ts` — 6/6, including two new regressions: an OAuth token in a provider's API-key env var is ignored, and the real key is recovered after the OAuth path overwrites env
- [x] `ui/__tests__/stores/chatStore.test.ts` — 24/24, covering the recovery reason default, the rate-limit reason, clearing, and no leakage between chats
- [x] `npm run type-check` clean on all touched files (pre-existing errors elsewhere unchanged)
- [x] `npm run build` succeeds; changes verified present in `dist`
- [x] `node --check` on `index.cjs` and `preload.cjs`
- [ ] Manual: restart, flip Claude to **API Key**, send a message. Expect `[Electron] ↷ Claude OAuth withheld — user chose API key` then `[KeyResolver] Using API key for anthropic (prefix: sk-ant-api03…)` and routing at `authType=apiKey` (AI SDK rather than pi-ai)
- [ ] Manual: reopen Settings and confirm the toggle is still on **API Key**
- [ ] Manual: flip back to **OAuth** and confirm pi-ai routing returns

## Note for reviewers

In dev mode keys are read from `.env`, not the keychain, so a key entered only in the Settings UI is ignored in dev (it works in a packaged build). That behavior is pre-existing and left alone here; flagging it as a possible follow-up.

Made with [Cursor](https://cursor.com)