### PR TITLE
Grant microphone access to local mini-apps

### DIFF
--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -10,5 +10,15 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <!--
+      Media capture runs in the renderer helper, not the main process, so under
+      hardened runtime the helper needs these device entitlements too. Without
+      them getUserMedia fails in signed builds even though the main bundle
+      already declares audio-input and the user granted access in TCC.
+    -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
   </dict>
 </plist>

--- a/src/electron/index.cjs
+++ b/src/electron/index.cjs
@@ -2160,6 +2160,40 @@ app.whenReady().then(async () => {
   console.log("[Electron] Start time:", new Date(appStartTime).toISOString());
   console.log("[Electron] ===========================================");
 
+  // Media permissions for locally-hosted mini-apps.
+  //
+  // Electron denies getUserMedia by default when no handler is registered, so
+  // every mini-app saw "Permission denied" no matter what macOS had granted.
+  // That made a live microphone meter impossible to build, and the Meetings
+  // app recorded silence with nothing in the UI able to detect it.
+  //
+  // Scoped to the local gateway origin: remote content still gets denied, and
+  // macOS TCC remains the outer gate — this only stops Electron from refusing
+  // before the OS is ever asked.
+  {
+    const { session } = require("electron");
+    const LOCAL_APP_ORIGIN = "http://localhost:18789";
+    const MEDIA_PERMISSIONS = new Set(["media", "audioCapture", "videoCapture"]);
+
+    const isLocalApp = (url) => typeof url === "string" && url.startsWith(LOCAL_APP_ORIGIN);
+
+    session.defaultSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
+      if (!MEDIA_PERMISSIONS.has(permission)) return callback(false);
+      const url = details?.requestingUrl || webContents?.getURL?.() || "";
+      const allowed = isLocalApp(url);
+      if (!allowed) console.warn("[Electron] Denied", permission, "for", url);
+      callback(allowed);
+    });
+
+    // permissions.query() consults this separately; without it a mini-app reads
+    // state "denied" and can show a misleading "check System Settings" message
+    // before it has even tried.
+    session.defaultSession.setPermissionCheckHandler((_webContents, permission, requestingOrigin) => {
+      if (!MEDIA_PERMISSIONS.has(permission)) return false;
+      return isLocalApp(requestingOrigin);
+    });
+  }
+
   // Register custom URL protocol for papr:// deep links
   if (process.defaultApp) {
     if (process.argv.length >= 2) {


### PR DESCRIPTION
## The problem

**No mini-app can use `getUserMedia`.** Electron denies media permission by default when no handler is registered, and Paprwork registers none:

```
grep -rn "setPermissionRequestHandler\|setPermissionCheckHandler" src/electron
# (no matches)
```

Measured from inside a mini-app iframe:

```json
{ "secure": true, "hasMD": true,
  "permissionState": "denied",
  "gum": "NotAllowedError: Permission denied" }
```

Note `permissionState: "denied"`, not `"prompt"` — the request never reaches macOS. This affects **every mini-app**, not one.

## How it surfaced

The Meetings Manager recorder captured 5.28 s of **digital silence** — peak amplitude `0` across all 84,480 samples, both tracks byte-identical. Whisper answered that silence with a plausible hallucination (`" you"`), so the failure looked like a working recording until someone read the transcript.

A live level meter is the obvious way to catch this *before* recording. It was impossible to build.

## The change

Register both handlers, scoped to the local gateway origin:

- **`setPermissionRequestHandler`** — allows `media` / `audioCapture` / `videoCapture` for `http://localhost:18789`, denies everything else and logs it
- **`setPermissionCheckHandler`** — `permissions.query()` consults this separately. Without it an app reads `denied` and can show a misleading "check System Settings" message before it has even tried.

Remote content is still denied. **macOS TCC remains the outer gate** — this only stops Electron from refusing before the OS is ever consulted.

## Second bug found while here

`build/entitlements.mac.inherit.plist` was missing `device.audio-input`:

```
entitlements.mac.plist          → device.audio-input: present
entitlements.mac.inherit.plist  → device.audio-input: MISSING
```

Media capture runs in the **renderer helper**, not the main process. Under hardened runtime, signed builds would fail even with the handlers in place and full TCC approval. Dev builds hide this — the entitlement only bites once signed.

`NSMicrophoneUsageDescription` / `NSCameraUsageDescription` were already in `electron-builder.json`, so nothing needed there.

## Testing

- Confirmed `denied` before the change, from a real mini-app iframe (numbers above)
- Handlers run at `app.whenReady()`, so **verifying the fix requires an app restart** — I have not yet confirmed a working meter post-restart, only that the pre-change state was definitively broken at the shell layer
- Scope check: non-media permissions and non-localhost origins both fall through to `false`

## Review notes

- Origin is hardcoded to `http://localhost:18789`. If the gateway port is ever configurable, this should read from the same source.
- Only `videoCapture` is granted alongside audio, on the grounds that the camera entitlement and usage description already exist and a video mini-app would hit the identical wall. Happy to drop it to audio-only if you'd rather widen that deliberately later.