### PR TITLE
Heal Turso schema drift when PRIMARY KEY or column type differs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4730,4 +4730,45 @@ if (result.valid) {
 
 ---
 
+### Issue 70: Gateway OOM — Duplicated and Unbounded Tool Payloads ✅ FIXED
+**Added:** 2026-08-21
+**Severity:** CRITICAL — Gateway crash / chat unopenable
+**Problem:** Opening a chat with heavy tool use crashed the gateway with a V8 heap OOM. On a real 3.0GB `chats.db`, the 150 largest messages held 1.96GB — about 64% of the file — and parsing one of them exhausted the ~4GB heap.
+**Root Causes:** Three compounding issues:
+1. **Duplication** — every tool payload was written twice: `messages.tool_calls` (canonical: LLM context, analytics, Papr sync) and `messages.sequence` (UI ordering, carrying its own copy of `input`/`output`)
+2. **Unbounded rows** — no cap on a single row, so file reads/scrapes/delegation transcripts pushed rows past 100MB
+3. **Eager parsing** — `loadMessages` parsed both columns for every row, including rows nothing was about to render
+**Solution:**
+1. **Store each payload once** — `tool_calls` stays canonical; `sequence` keeps ordering metadata plus `inputRef`/`outputRef` pointers, rehydrated on read by `restoreSequencePayloads()`. A JSON `null` output stays inline (it serializes to nothing in `tool_calls`, so a pointer could not restore it).
+2. **Offload large payloads** — results over 256KB move to `~/.paprwork-v2/tool-results/<chatId>/<messageId>/<toolCallId>.txt`, leaving a 4KB preview plus a `resultOffload` pointer. `get_full_tool_result` follows the pointer, so **nothing is discarded**. The whole column also has a 1MB budget: the largest remaining results spill until the row fits.
+3. **Size-guard every read** — `boundedPayloadSql()` returns NULL instead of a column over 2MB, so an oversized row is never pulled into the heap. This stops the crash even before the backfill runs.
+4. **Background backfill** — `startToolPayloadMigration()` compacts existing rows in chunks of 50, entirely inside SQLite via `json_set`/`json_remove`, so a 100MB column is never parsed in JS. Idempotent and resumable via a `tool_payload_migrated` flag.
+**Results (real 3.0GB database, verified byte-for-byte against the untouched original):**
+
+| Sample | Rows before | Rows after | Sidecars | Checks |
+|---|---|---|---|---|
+| 25 largest messages | 1,199MB | **7.6MB** (−99.4%) | 585MB | 2,528 passed, 0 failed |
+| 150 largest messages | 1,958MB | **44.4MB** (−97.7%) | 929MB | 12,309 passed, 0 failed |
+
+**Files Created:**
+- `src/gateway/services/storage/messagePayloadStore.ts` — serialize/restore, offload, sidecar I/O
+- `src/gateway/services/storage/toolPayloadMigration.ts` — backfill scheduling and progress
+- `src/gateway/services/storage/toolPayloadRowRewrite.ts` — per-row SQL surgery (json_set/json_remove)
+- `tests/message-payload-store.test.ts` — 11 round-trip/offload tests
+- `scripts/test-tool-payload-migration.mjs` — 26 backfill tests (Electron)
+- `scripts/verify-payload-migration-on-real-db.mjs` — losslessness check against a real DB (read-only)
+- `docs/TOOL_PAYLOAD_OFFLOADING.md` — complete documentation
+**Files Changed:**
+- `LocalStorageProvider.ts` — serialize on write, restore + guard on read, sidecar cleanup on delete, starts backfill, `getUnsyncedMessages` no longer uses `SELECT *`
+- `HybridStorageProvider.ts`, `IStorageProvider.ts` — `resultOffload` + `readOffloadedToolResult`
+- `toolResultLookup.ts`, `core/tools/chatHistory.ts` — `get_full_tool_result` resolves pointers
+- `contextFootprint.ts` — untruncated size uses `resultOffload.totalChars`, not the preview
+- `contextFootprintSql.ts`, `contextFootprintStore.ts`, `memorySearchSavings.ts` — bounded reads
+**Testing:** `npx vitest run tests/message-payload-store.test.ts --project unit-backend` and `npm run test:payload-migration`. SQLite tests run under Electron because `better-sqlite3` is built for Electron's runtime (`ERR_DLOPEN_FAILED` under plain Node).
+**Note:** SQLite does not return freed pages to the filesystem — run `VACUUM` after the backfill to shrink the file.
+**Prevention:** Cap what a row may hold; store a payload once and point at it; guard every read that parses a payload column; select named columns (`SELECT *` can pull a 100MB column into the heap just to discard it); do bulk JSON rewrites inside SQLite when values are too large for JS.
+**See:** `docs/TOOL_PAYLOAD_OFFLOADING.md`
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**

--- a/docs/TOOL_PAYLOAD_OFFLOADING.md
+++ b/docs/TOOL_PAYLOAD_OFFLOADING.md
@@ -1,0 +1,185 @@
+# Tool Payload Offloading
+
+**Added:** 2026-08-21
+
+Fixes the gateway running out of memory when opening a chat with heavy tool use.
+
+---
+
+## The problem
+
+Every assistant turn wrote its tool payloads to SQLite **twice**:
+
+- `messages.tool_calls` — canonical: LLM context, analytics, Papr sync
+- `messages.sequence` — UI ordering, carrying its own copy of the same `input`/`output`
+
+Combined with results that are not truncated on disk (file reads, scrapes,
+delegation transcripts), single rows reached **100 MB+**. Opening such a chat
+parsed every copy into the V8 heap, hit the ~4 GB ceiling, and aborted the
+gateway process. On one real database, the 150 largest messages held **1.96 GB**
+— about 64% of a 3.0 GB file.
+
+Three things were wrong at once:
+
+1. **Duplication** — the same bytes stored twice.
+2. **Unbounded rows** — no cap on what a single row could hold.
+3. **Eager parsing** — `loadMessages` parsed both columns for every row, even
+   rows nothing was about to render.
+
+---
+
+## The fix
+
+### 1. Store each payload once
+
+`tool_calls` stays canonical. `sequence` keeps its ordering metadata and
+replaces the duplicated values with pointers:
+
+```jsonc
+// stored
+{ "type": "tool", "data": { "toolCallId": "tc-1", "inputRef": "toolCall", "outputRef": "toolCall:string" } }
+
+// returned by loadMessages, after restoreSequencePayloads()
+{ "type": "tool", "data": { "toolCallId": "tc-1", "input": { "command": "ls" }, "output": "…" } }
+```
+
+`outputRef` records the shape to rebuild (`toolCall:string` vs `toolCall:json`)
+since `tool_calls` stores the stringified form. A JSON `null` output stays
+inline — it serializes to nothing in `tool_calls`, so a pointer could not
+restore it.
+
+### 2. Move large payloads out of the row
+
+A result over **256 KB** is written to a sidecar file and the row keeps a
+4 KB preview plus a pointer:
+
+```
+~/.paprwork-v2/tool-results/<chatId>/<messageId>/<toolCallId>.txt
+```
+
+```jsonc
+{
+  "id": "tc-1",
+  "result": "first 4096 chars…\n\n[... 1,203,456 more characters stored outside the database (total 1,207,552). Full result: get_full_tool_result({ toolCallId: \"tc-1\" })]",
+  "resultOffload": { "file": "tool-results/c1/m1/tc-1.txt", "totalChars": 1207552 }
+}
+```
+
+**Nothing is discarded.** `get_full_tool_result` follows the pointer and reads
+the sidecar, so the agent still has the complete text.
+
+Because many medium results can add up, the whole `tool_calls` column also has
+a **1 MB budget**: once exceeded, the largest remaining results spill to
+sidecars until the row fits. Sidecars are deleted with their chat.
+
+### 3. Never parse a row large enough to be dangerous
+
+Reads cap what they will pull into the heap at **2 MB per column**
+(`MAX_INLINE_PAYLOAD_BYTES`). Anything larger returns `NULL` from SQL rather
+than being selected and parsed:
+
+```ts
+boundedPayloadSql("tool_calls")
+// CASE WHEN LENGTH(tool_calls) > 2097152 THEN NULL ELSE tool_calls END AS tool_calls
+```
+
+Applied in `loadMessages`, `loadMessagesForLLM`, `patchDelegateTaskToolResult`,
+the context-footprint queries, and memory-search savings. This alone stops the
+crash, including on databases that have not been compacted yet.
+
+---
+
+## Backfill for existing databases
+
+`startToolPayloadMigration()` runs automatically 5 seconds after the gateway
+opens the database, in chunks of 50 messages with the event loop yielding
+between chunks. Nothing blocks startup.
+
+Every rewrite happens **inside SQLite** via `json_set` / `json_remove`, so a
+100 MB column is never parsed in JS. Only one result at a time crosses into
+JS, on its way to its sidecar file.
+
+The work is idempotent and resumable — a `tool_payload_migrated` flag with a
+partial index marks each message once handled, so an interrupted run resumes
+where it stopped. A malformed row is logged, left byte-identical, and flagged
+so it cannot stall the backfill.
+
+SQLite does not return freed pages to the filesystem on its own. Run `VACUUM`
+once the backfill finishes to shrink the file.
+
+---
+
+## Results on a real 3.0 GB database
+
+Verified with `scripts/verify-payload-migration-on-real-db.mjs`, which copies
+the largest messages into a scratch database, migrates the copy, and compares
+every payload back against the untouched original.
+
+| Sample | Rows in DB before | After | Sidecars | Checks |
+|---|---|---|---|---|
+| 25 largest messages | 1,199 MB | **7.6 MB** (−99.4%) | 585 MB | 2,528 passed, 0 failed |
+| 150 largest messages | 1,958 MB | **44.4 MB** (−97.7%) | 929 MB | 12,309 passed, 0 failed |
+
+The difference between the original size and (rows + sidecars) is the
+duplication that is now gone — roughly 985 MB across those 150 rows.
+
+---
+
+## Files
+
+**Added**
+- `src/gateway/services/storage/messagePayloadStore.ts` — serialize/restore, offload, sidecar I/O
+- `src/gateway/services/storage/toolPayloadMigration.ts` — backfill scheduling and progress
+- `src/gateway/services/storage/toolPayloadRowRewrite.ts` — the per-row SQL surgery
+- `tests/message-payload-store.test.ts` — round-trip and offload unit tests
+- `scripts/test-tool-payload-migration.mjs` — backfill tests (Electron)
+- `scripts/verify-payload-migration-on-real-db.mjs` — losslessness check against a real DB
+
+**Changed**
+- `LocalStorageProvider.ts` — serialize on write, restore + size-guard on read, sidecar cleanup on delete, starts the backfill
+- `HybridStorageProvider.ts` — passes through `readOffloadedToolResult`
+- `IStorageProvider.ts` — `resultOffload` field, optional `readOffloadedToolResult`
+- `toolResultLookup.ts`, `core/tools/chatHistory.ts` — `get_full_tool_result` follows pointers
+- `contextFootprint.ts` — untruncated size uses `resultOffload.totalChars`, not the preview
+- `contextFootprintSql.ts`, `contextFootprintStore.ts`, `memorySearchSavings.ts` — bounded reads
+
+---
+
+## Testing
+
+```bash
+npx vitest run tests/message-payload-store.test.ts --project unit-backend   # 11 tests
+npm run test:payload-migration                                              # 26 tests (Electron)
+
+# Optional: prove losslessness against your own database (read-only)
+ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron \
+  scripts/verify-payload-migration-on-real-db.mjs --rows=25
+```
+
+SQLite-backed tests run under Electron because `better-sqlite3` is compiled for
+Electron's runtime and cannot be loaded by plain Node (`ERR_DLOPEN_FAILED`).
+
+---
+
+## Notes and limits
+
+- **Rows still oversized before the backfill reaches them** return no
+  `toolCalls`/`sequence` and log a placeholder. The turn stays visible; tool
+  detail returns once compacted. This replaces a crash.
+- **The UI shows the preview**, not the sidecar text. The inline notice tells
+  the agent how to fetch the rest. There is no lazy sidecar load in the UI yet.
+- **Chat export** truncates tool results to 500 chars anyway, so the 4 KB
+  preview is unaffected.
+- **Papr sync** receives the full in-memory message on first sync, before
+  SQLite slimming, so cloud fidelity is unchanged.
+
+---
+
+## Prevention
+
+1. Cap what a single row may hold; do not let payload size grow unbounded.
+2. Store a payload once and point at it, rather than copying it per consumer.
+3. Guard every read that parses a payload column with a size limit.
+4. Select named columns — `SELECT *` can pull a 100 MB column into the heap
+   just to discard it.
+5. Do bulk JSON rewrites inside SQLite when the values are too large for JS.

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "test:app-agent-storage-e2e": "node scripts/test-app-agent-storage-e2e.mjs",
     "test:app-agent-deploy-verify": "node scripts/verify-app-agent-chat-deploy.mjs",
     "setup:apps-dns": "node scripts/setup-apps-papr-ai-dns.mjs",
+    "test:payload-migration": "npm run build:gateway && ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron scripts/test-tool-payload-migration.mjs",
     "test:turso-auto-push": "ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron scripts/test-turso-auto-push.mjs",
     "test:turso-permanent-skip": "npm run build:gateway && ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron scripts/test-turso-permanent-skip.mjs",
     "test:turso-delta-sync": "npm run build:gateway && ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron scripts/test-turso-delta-sync.mjs",

--- a/scripts/analyze-heapsnapshot.mjs
+++ b/scripts/analyze-heapsnapshot.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Summarize a V8 heap snapshot: what is holding the memory, grouped by
+ * constructor, plus the largest individual objects.
+ *
+ * Usage:
+ *   node --max-old-space-size=8192 scripts/analyze-heapsnapshot.mjs <file.heapsnapshot>
+ */
+
+import fs from "fs";
+
+const file = process.argv[2];
+if (!file) {
+  console.error("Usage: analyze-heapsnapshot.mjs <file.heapsnapshot>");
+  process.exit(1);
+}
+
+const MB = 1024 * 1024;
+const mb = (n) => (n / MB).toFixed(1).padStart(8);
+
+console.log(`Reading ${file} (${(fs.statSync(file).size / MB).toFixed(0)}MB)...`);
+const snap = JSON.parse(fs.readFileSync(file, "utf8"));
+
+const meta = snap.snapshot.meta;
+const nodeFields = meta.node_fields;
+const nodeTypes = meta.node_types[0];
+const stride = nodeFields.length;
+
+const iType = nodeFields.indexOf("type");
+const iName = nodeFields.indexOf("name");
+const iSelf = nodeFields.indexOf("self_size");
+
+const nodes = snap.nodes;
+const strings = snap.strings;
+const count = snap.snapshot.node_count;
+
+const byGroup = new Map(); // "type|name" -> { bytes, count }
+const byType = new Map();
+const largest = [];
+let total = 0;
+
+for (let i = 0; i < count; i++) {
+  const base = i * stride;
+  const type = nodeTypes[nodes[base + iType]];
+  const name = strings[nodes[base + iName]] ?? "";
+  const self = nodes[base + iSelf];
+
+  total += self;
+  byType.set(type, (byType.get(type) ?? 0) + self);
+
+  const key = `${type}|${name}`;
+  const entry = byGroup.get(key);
+  if (entry) {
+    entry.bytes += self;
+    entry.count += 1;
+  } else {
+    byGroup.set(key, { bytes: self, count: 1, type, name });
+  }
+
+  if (self > 1 * MB) {
+    largest.push({ self, type, name });
+  }
+}
+
+console.log(`\nTotal self size: ${(total / MB).toFixed(0)}MB across ${count.toLocaleString()} nodes\n`);
+
+console.log("── By node type ─────────────────────────────────────────");
+for (const [type, bytes] of [...byType].sort((a, b) => b[1] - a[1]).slice(0, 12)) {
+  console.log(`${mb(bytes)}MB  ${((bytes / total) * 100).toFixed(1).padStart(5)}%  ${type}`);
+}
+
+console.log("\n── Top 30 by aggregate size (type / constructor) ────────");
+const groups = [...byGroup.values()].sort((a, b) => b.bytes - a.bytes).slice(0, 30);
+for (const g of groups) {
+  const label = g.name.length > 60 ? g.name.slice(0, 57) + "..." : g.name;
+  console.log(
+    `${mb(g.bytes)}MB  ${((g.bytes / total) * 100).toFixed(1).padStart(5)}%  ` +
+      `${String(g.count).padStart(9)} objs  ${g.type}: ${label || "(unnamed)"}`,
+  );
+}
+
+console.log("\n── Largest individual objects (>1MB) ────────────────────");
+largest.sort((a, b) => b.self - a.self);
+for (const n of largest.slice(0, 25)) {
+  const label = n.name.length > 90 ? n.name.slice(0, 87).replace(/\n/g, "\\n") + "..." : n.name.replace(/\n/g, "\\n");
+  console.log(`${mb(n.self)}MB  ${n.type}: ${label || "(unnamed)"}`);
+}
+if (largest.length === 0) console.log("  (none — memory is spread across many small objects)");

--- a/scripts/test-tool-payload-migration.mjs
+++ b/scripts/test-tool-payload-migration.mjs
@@ -1,0 +1,409 @@
+#!/usr/bin/env node
+/**
+ * Backfill tests for the tool payload migration.
+ *
+ * Builds a database shaped like one written before offloading existed — two
+ * copies of every payload and results large enough to blow the heap — then
+ * checks the migration shrinks it without losing anything.
+ *
+ * Runs under Electron because better-sqlite3 is built for Electron's runtime.
+ *
+ * Usage:
+ *   npm run test:payload-migration
+ *   # or: ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron scripts/test-tool-payload-migration.mjs
+ */
+
+import Database from "better-sqlite3";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.join(__dirname, "..", "dist", "gateway", "services", "storage");
+
+let passed = 0;
+let failed = 0;
+
+function ok(label) {
+  console.log(`  ✅ ${label}`);
+  passed += 1;
+}
+
+function fail(label, detail) {
+  console.log(`  ❌ ${label}${detail ? `: ${detail}` : ""}`);
+  failed += 1;
+}
+
+function check(label, condition, detail) {
+  if (condition) ok(label);
+  else fail(label, detail);
+}
+
+function section(title) {
+  console.log(`\n=== ${title} ===`);
+}
+
+async function importDist(file) {
+  const target = path.join(distDir, file);
+  if (!fs.existsSync(target)) {
+    console.error(
+      `Missing ${target}\nBuild the gateway first: npm run build:gateway`,
+    );
+    process.exit(1);
+  }
+  return import(pathToFileURL(target).href);
+}
+
+const migration = await importDist("toolPayloadMigration.js");
+const store = await importDist("messagePayloadStore.js");
+
+const { OFFLOAD_THRESHOLD_CHARS, MAX_INLINE_PAYLOAD_BYTES } = store;
+
+/** A message as it was written before offloading: payload stored twice. */
+function legacyRow({ id, chatId, results }) {
+  const toolCalls = results.map((result, i) => ({
+    id: `${id}-tc-${i}`,
+    name: "bash",
+    args: { command: `run ${i}` },
+    result,
+    status: "success",
+  }));
+
+  const sequence = [
+    { type: "text", data: "Working on it." },
+    ...results.map((result, i) => ({
+      type: "tool",
+      data: {
+        toolCallId: `${id}-tc-${i}`,
+        name: "bash",
+        input: { command: `run ${i}` },
+        output: result,
+        status: "success",
+      },
+    })),
+  ];
+
+  return {
+    id,
+    chat_id: chatId,
+    role: "assistant",
+    content: "done",
+    timestamp: new Date().toISOString(),
+    tool_calls: JSON.stringify(toolCalls),
+    sequence: JSON.stringify(sequence),
+  };
+}
+
+function createDb(dbDir) {
+  const db = new Database(path.join(dbDir, "chats.db"));
+  db.exec(`
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      chat_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      tool_calls TEXT,
+      sequence TEXT
+    );
+  `);
+  return db;
+}
+
+function insert(db, row) {
+  db.prepare(
+    `INSERT INTO messages (id, chat_id, role, content, timestamp, tool_calls, sequence)
+     VALUES (@id, @chat_id, @role, @content, @timestamp, @tool_calls, @sequence)`,
+  ).run(row);
+}
+
+function readRow(db, id) {
+  const row = db
+    .prepare("SELECT tool_calls, sequence FROM messages WHERE id = ?")
+    .get(id);
+  return {
+    toolCalls: row.tool_calls ? JSON.parse(row.tool_calls) : undefined,
+    sequence: row.sequence ? JSON.parse(row.sequence) : undefined,
+    rawBytes: (row.tool_calls?.length ?? 0) + (row.sequence?.length ?? 0),
+  };
+}
+
+/** Drains the chunked migration the way the background loop would. */
+function runMigration(db, dbDir) {
+  migration.ensurePayloadMigrationSchema(db);
+  let guard = 0;
+  for (;;) {
+    const stats = migration.migrateToolPayloadsChunk(db, dbDir);
+    if (stats.rowsProcessed === 0 || stats.remaining === 0) return stats;
+    if (++guard > 1000) throw new Error("migration did not converge");
+  }
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "payload-migration-"));
+
+try {
+  section("Legacy rows shrink without losing data");
+  {
+    const dbDir = path.join(tmp, "case-1");
+    fs.mkdirSync(dbDir);
+    const db = createDb(dbDir);
+
+    const huge = "H".repeat(OFFLOAD_THRESHOLD_CHARS + 5_000);
+    const small = "small result";
+    insert(db, legacyRow({ id: "m1", chatId: "c1", results: [huge, small] }));
+
+    const before = readRow(db, "m1");
+    runMigration(db, dbDir);
+    const after = readRow(db, "m1");
+
+    check(
+      "row is dramatically smaller",
+      after.rawBytes < before.rawBytes / 2,
+      `${before.rawBytes} -> ${after.rawBytes}`,
+    );
+    check(
+      "row is now under the read limit",
+      after.rawBytes < MAX_INLINE_PAYLOAD_BYTES,
+      `${after.rawBytes} bytes`,
+    );
+
+    const offloaded = after.toolCalls[0];
+    check("oversized result has a pointer", Boolean(offloaded.resultOffload));
+    check(
+      "sidecar holds the original text",
+      store.readOffloadedResult(dbDir, offloaded.resultOffload) === huge,
+    );
+    check(
+      "preview stayed inline",
+      offloaded.result.startsWith(huge.slice(0, 100)) &&
+        offloaded.result.includes("get_full_tool_result"),
+    );
+    check(
+      "small result untouched",
+      after.toolCalls[1].result === small && !after.toolCalls[1].resultOffload,
+    );
+
+    // The duplicate copies are gone from `sequence`, but a read rebuilds them.
+    check(
+      "sequence no longer duplicates the payload",
+      !JSON.stringify(after.sequence).includes(small.repeat(2)) &&
+        after.sequence[2].data.output === undefined,
+    );
+
+    const restored = store.restoreSequencePayloads(after.sequence, after.toolCalls);
+    check("text items survive", restored[0].data === "Working on it.");
+    check(
+      "small output rebuilt exactly",
+      restored[2].data.output === small,
+      JSON.stringify(restored[2].data.output)?.slice(0, 80),
+    );
+    check(
+      "inputs rebuilt exactly",
+      JSON.stringify(restored[1].data.input) === JSON.stringify({ command: "run 0" }),
+    );
+    check(
+      "offloaded output shows the preview, not a hole",
+      typeof restored[1].data.output === "string" &&
+        restored[1].data.output.includes("get_full_tool_result"),
+    );
+    check(
+      "status metadata preserved",
+      restored[1].data.status === "success" &&
+        after.toolCalls[0].status === "success",
+    );
+
+    db.close();
+  }
+
+  section("Many medium results still fit the row budget");
+  {
+    const dbDir = path.join(tmp, "case-2");
+    fs.mkdirSync(dbDir);
+    const db = createDb(dbDir);
+
+    const medium = "M".repeat(200 * 1024);
+    insert(
+      db,
+      legacyRow({ id: "m1", chatId: "c1", results: Array(12).fill(medium) }),
+    );
+
+    runMigration(db, dbDir);
+    const after = readRow(db, "m1");
+
+    check(
+      "row fits under the read limit",
+      after.rawBytes < MAX_INLINE_PAYLOAD_BYTES,
+      `${after.rawBytes} bytes`,
+    );
+    const spilled = after.toolCalls.filter((tc) => tc.resultOffload);
+    check("largest results spilled to sidecars", spilled.length > 0);
+    check(
+      "every spilled result is readable in full",
+      spilled.every((tc) => store.readOffloadedResult(dbDir, tc.resultOffload) === medium),
+    );
+
+    db.close();
+  }
+
+  section("Orphan sequence output gets its own sidecar");
+  {
+    const dbDir = path.join(tmp, "case-3");
+    fs.mkdirSync(dbDir);
+    const db = createDb(dbDir);
+
+    const huge = "O".repeat(OFFLOAD_THRESHOLD_CHARS + 2_000);
+    insert(db, {
+      id: "m1",
+      chat_id: "c1",
+      role: "assistant",
+      content: "done",
+      timestamp: new Date().toISOString(),
+      tool_calls: null,
+      sequence: JSON.stringify([
+        { type: "tool", data: { toolCallId: "orphan", name: "x", output: huge } },
+      ]),
+    });
+
+    runMigration(db, dbDir);
+    const after = readRow(db, "m1");
+
+    check(
+      "orphan row shrank",
+      after.rawBytes < MAX_INLINE_PAYLOAD_BYTES,
+      `${after.rawBytes} bytes`,
+    );
+    check(
+      "orphan payload is readable in full",
+      store.readOffloadedResult(dbDir, after.sequence[0].data.outputOffload) === huge,
+    );
+
+    db.close();
+  }
+
+  section("Edge cases and reruns");
+  {
+    const dbDir = path.join(tmp, "case-4");
+    fs.mkdirSync(dbDir);
+    const db = createDb(dbDir);
+
+    const huge = "R".repeat(OFFLOAD_THRESHOLD_CHARS + 1_000);
+    insert(db, legacyRow({ id: "m1", chatId: "c1", results: [huge] }));
+
+    // Rows the migration must tolerate rather than choke on.
+    insert(db, {
+      id: "m2",
+      chat_id: "c1",
+      role: "user",
+      content: "hi",
+      timestamp: new Date().toISOString(),
+      tool_calls: null,
+      sequence: null,
+    });
+    insert(db, {
+      id: "m3",
+      chat_id: "c1",
+      role: "assistant",
+      content: "broken",
+      timestamp: new Date().toISOString(),
+      tool_calls: "{not json",
+      sequence: null,
+    });
+    insert(db, {
+      id: "m4",
+      chat_id: "c1",
+      role: "assistant",
+      content: "null output",
+      timestamp: new Date().toISOString(),
+      tool_calls: JSON.stringify([{ id: "tc", name: "noop", args: {} }]),
+      sequence: JSON.stringify([
+        { type: "tool", data: { toolCallId: "tc", name: "noop", output: null } },
+      ]),
+    });
+
+    runMigration(db, dbDir);
+
+    const m3 = db
+      .prepare(
+        "SELECT tool_calls, tool_payload_migrated FROM messages WHERE id='m3'",
+      )
+      .get();
+    check(
+      "malformed row left byte-identical",
+      m3.tool_calls === "{not json",
+      m3.tool_calls,
+    );
+    check(
+      "malformed row flagged so it cannot stall the backfill",
+      m3.tool_payload_migrated === 1,
+    );
+    check(
+      "null output stays inline so it round-trips",
+      store.restoreSequencePayloads(
+        readRow(db, "m4").sequence,
+        readRow(db, "m4").toolCalls,
+      )[0].data.output === null,
+    );
+    check(
+      "nothing left pending",
+      migration.countPendingPayloadMigrations(db) === 0,
+    );
+
+    // Rerunning must not double-offload or corrupt the stub.
+    const beforeRerun = readRow(db, "m1");
+    const rerun = runMigration(db, dbDir);
+    const afterRerun = readRow(db, "m1");
+
+    check("rerun processes nothing", rerun.rowsProcessed === 0);
+    check(
+      "rerun leaves the row byte-identical",
+      JSON.stringify(beforeRerun) === JSON.stringify(afterRerun),
+    );
+
+    // A row written after the flag exists (new saves) is skipped too.
+    db.prepare(
+      `INSERT INTO messages (id, chat_id, role, content, timestamp, tool_calls, sequence, tool_payload_migrated)
+       VALUES ('m5','c1','assistant','x',?,NULL,NULL,1)`,
+    ).run(new Date().toISOString());
+    check(
+      "already-migrated rows are not revisited",
+      migration.countPendingPayloadMigrations(db) === 0,
+    );
+
+    db.close();
+  }
+
+  section("Forced re-migration is idempotent");
+  {
+    const dbDir = path.join(tmp, "case-5");
+    fs.mkdirSync(dbDir);
+    const db = createDb(dbDir);
+
+    const huge = "I".repeat(OFFLOAD_THRESHOLD_CHARS + 3_000);
+    insert(db, legacyRow({ id: "m1", chatId: "c1", results: [huge, "tail"] }));
+
+    runMigration(db, dbDir);
+    const first = readRow(db, "m1");
+
+    // Simulate an interrupted run that flagged nothing: clear and redo.
+    db.prepare("UPDATE messages SET tool_payload_migrated = 0").run();
+    runMigration(db, dbDir);
+    const second = readRow(db, "m1");
+
+    check(
+      "second pass changes nothing",
+      JSON.stringify(first) === JSON.stringify(second),
+    );
+    check(
+      "payload still intact after two passes",
+      store.readOffloadedResult(dbDir, second.toolCalls[0].resultOffload) === huge,
+    );
+
+    db.close();
+  }
+} finally {
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/verify-payload-migration-on-real-db.mjs
+++ b/scripts/verify-payload-migration-on-real-db.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * Proves the payload migration is lossless against a real database.
+ *
+ * Copies the largest messages from your chats.db into a scratch database,
+ * migrates that copy, then compares every payload back against the untouched
+ * original. The real database is opened read-only and never modified.
+ *
+ * Usage:
+ *   ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron \
+ *     scripts/verify-payload-migration-on-real-db.mjs [--rows=25] [--db=/path/chats.db]
+ */
+
+import Database from "better-sqlite3";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.join(__dirname, "..", "dist", "gateway", "services", "storage");
+
+const arg = (name, fallback) => {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.split("=").slice(1).join("=") : fallback;
+};
+
+const sourcePath = arg(
+  "db",
+  path.join(os.homedir(), ".paprwork-v2", "chats.db"),
+);
+const rowLimit = Number(arg("rows", "25"));
+
+if (!fs.existsSync(sourcePath)) {
+  console.error(`No database at ${sourcePath}`);
+  process.exit(1);
+}
+
+const migration = await import(
+  pathToFileURL(path.join(distDir, "toolPayloadMigration.js")).href
+);
+const store = await import(
+  pathToFileURL(path.join(distDir, "messagePayloadStore.js")).href
+);
+
+let passed = 0;
+let failed = 0;
+const problems = [];
+
+function check(condition, label) {
+  if (condition) {
+    passed += 1;
+  } else {
+    failed += 1;
+    if (problems.length < 20) problems.push(label);
+  }
+}
+
+const mb = (n) => `${(n / 1024 / 1024).toFixed(1)}MB`;
+
+const source = new Database(sourcePath, { readonly: true });
+const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "payload-verify-"));
+
+try {
+  console.log(`Source: ${sourcePath} (${mb(fs.statSync(sourcePath).size)})`);
+  console.log(`Sampling the ${rowLimit} largest messages…\n`);
+
+  const fattest = source
+    .prepare(
+      `SELECT id, chat_id,
+              IFNULL(LENGTH(tool_calls), 0) AS tc_len,
+              IFNULL(LENGTH(sequence), 0) AS seq_len
+       FROM messages
+       WHERE tool_calls IS NOT NULL OR sequence IS NOT NULL
+       ORDER BY (IFNULL(LENGTH(tool_calls),0) + IFNULL(LENGTH(sequence),0)) DESC
+       LIMIT ?`,
+    )
+    .all(rowLimit);
+
+  if (fattest.length === 0) {
+    console.log("No messages with payloads — nothing to verify.");
+    process.exit(0);
+  }
+
+  // Copy the sampled rows into a scratch database, inside SQLite so the giant
+  // columns never enter the JS heap.
+  const scratchPath = path.join(scratchDir, "chats.db");
+  const scratch = new Database(scratchPath);
+  scratch.exec(`
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      chat_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      tool_calls TEXT,
+      sequence TEXT
+    );
+  `);
+  scratch.exec(`ATTACH DATABASE '${sourcePath.replace(/'/g, "''")}' AS src`);
+  const ids = fattest.map((r) => r.id);
+  scratch
+    .prepare(
+      `INSERT INTO messages (id, chat_id, role, content, timestamp, tool_calls, sequence)
+       SELECT id, chat_id, role, content, timestamp, tool_calls, sequence
+       FROM src.messages WHERE id IN (${ids.map(() => "?").join(",")})`,
+    )
+    .run(...ids);
+  scratch.exec("DETACH DATABASE src");
+
+  const beforeBytes = fattest.reduce((s, r) => s + r.tc_len + r.seq_len, 0);
+
+  // Snapshot the originals so comparisons never touch the live database.
+  const origToolCall = scratch.prepare(
+    "SELECT json_extract(tool_calls, ?) AS v FROM messages WHERE id = ?",
+  );
+  const originals = new Map();
+  for (const row of fattest) {
+    const count = scratch
+      .prepare(
+        "SELECT json_array_length(tool_calls) AS n FROM messages WHERE id = ?",
+      )
+      .get(row.id);
+    originals.set(row.id, count?.n ?? 0);
+  }
+
+  console.log(`Migrating ${fattest.length} rows (${mb(beforeBytes)})…`);
+  const startedAt = Date.now();
+
+  migration.ensurePayloadMigrationSchema(scratch);
+  let guard = 0;
+  for (;;) {
+    const stats = migration.migrateToolPayloadsChunk(scratch, scratchDir, 10);
+    if (stats.rowsProcessed === 0 || stats.remaining === 0) break;
+    if (++guard > 1000) throw new Error("migration did not converge");
+  }
+
+  const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+
+  const after = scratch
+    .prepare(
+      `SELECT id,
+              IFNULL(LENGTH(tool_calls),0) AS tc_len,
+              IFNULL(LENGTH(sequence),0) AS seq_len
+       FROM messages`,
+    )
+    .all();
+  const afterBytes = after.reduce((s, r) => s + r.tc_len + r.seq_len, 0);
+
+  console.log(
+    `Migrated in ${elapsed}s: ${mb(beforeBytes)} -> ${mb(afterBytes)} ` +
+      `(${(100 - (afterBytes / beforeBytes) * 100).toFixed(1)}% smaller)\n`,
+  );
+
+  // Every payload must still be recoverable, byte for byte, from the original.
+  console.log("Comparing every payload against the untouched original…");
+
+  const newToolCall = scratch.prepare(
+    "SELECT json_extract(tool_calls, ?) AS v FROM messages WHERE id = ?",
+  );
+  const newOffload = scratch.prepare(
+    "SELECT json_extract(tool_calls, ?) AS v FROM messages WHERE id = ?",
+  );
+  const srcToolCall = source.prepare(
+    "SELECT json_extract(tool_calls, ?) AS v FROM messages WHERE id = ?",
+  );
+
+  let comparedResults = 0;
+  let offloadedResults = 0;
+
+  for (const row of fattest) {
+    const count = originals.get(row.id) ?? 0;
+
+    for (let i = 0; i < count; i++) {
+      const original = srcToolCall.get(`$[${i}].result`, row.id)?.v;
+      if (typeof original !== "string") continue;
+
+      comparedResults += 1;
+      const offloadJson = newOffload.get(`$[${i}].resultOffload`, row.id)?.v;
+
+      if (offloadJson) {
+        offloadedResults += 1;
+        const ref = JSON.parse(offloadJson);
+        const recovered = store.readOffloadedResult(scratchDir, ref);
+        check(
+          recovered === original,
+          `${row.id}[${i}] sidecar differs from the original`,
+        );
+        check(
+          ref.totalChars === original.length,
+          `${row.id}[${i}] totalChars wrong`,
+        );
+
+        // The inline stub must still start with the real text, not a hole.
+        const stub = newToolCall.get(`$[${i}].result`, row.id)?.v ?? "";
+        check(
+          original.startsWith(stub.slice(0, 200)),
+          `${row.id}[${i}] preview does not match the original`,
+        );
+      } else {
+        const kept = newToolCall.get(`$[${i}].result`, row.id)?.v;
+        check(
+          kept === original,
+          `${row.id}[${i}] inline result was altered`,
+        );
+      }
+    }
+
+    // Args must survive untouched — the sequence pointers rebuild from them.
+    for (let i = 0; i < count; i++) {
+      const before = srcToolCall.get(`$[${i}].args`, row.id)?.v;
+      const now = newToolCall.get(`$[${i}].args`, row.id)?.v;
+      check(
+        JSON.stringify(before ?? null) === JSON.stringify(now ?? null),
+        `${row.id}[${i}] args changed`,
+      );
+    }
+
+    // And a slimmed sequence must rebuild into what it held before.
+    const seqLen =
+      scratch
+        .prepare("SELECT json_array_length(sequence) AS n FROM messages WHERE id = ?")
+        .get(row.id)?.n ?? 0;
+
+    for (let i = 0; i < seqLen; i++) {
+      const type = scratch
+        .prepare("SELECT json_extract(sequence, ?) AS v FROM messages WHERE id = ?")
+        .get(`$[${i}].type`, row.id)?.v;
+      if (type !== "tool") continue;
+
+      const outputRef = scratch
+        .prepare("SELECT json_extract(sequence, ?) AS v FROM messages WHERE id = ?")
+        .get(`$[${i}].data.outputRef`, row.id)?.v;
+      if (!outputRef) continue;
+
+      const toolCallId = scratch
+        .prepare("SELECT json_extract(sequence, ?) AS v FROM messages WHERE id = ?")
+        .get(`$[${i}].data.toolCallId`, row.id)?.v;
+
+      const twinIndex = scratch
+        .prepare(
+          `SELECT CAST(j.key AS INTEGER) AS idx FROM messages m, json_each(m.tool_calls) j
+           WHERE m.id = ? AND json_extract(j.value, '$.id') = ?`,
+        )
+        .get(row.id, toolCallId)?.idx;
+
+      check(
+        twinIndex !== undefined,
+        `${row.id} sequence[${i}] points at a missing tool call`,
+      );
+    }
+  }
+
+  console.log(
+    `\nCompared ${comparedResults} results (${offloadedResults} offloaded to sidecars).`,
+  );
+
+  const sidecarBytes = (() => {
+    const root = path.join(scratchDir, "tool-results");
+    if (!fs.existsSync(root)) return 0;
+    let total = 0;
+    const walk = (dir) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(p);
+        else total += fs.statSync(p).size;
+      }
+    };
+    walk(root);
+    return total;
+  })();
+
+  console.log(`Sidecars on disk: ${mb(sidecarBytes)} (nothing discarded).`);
+  console.log(`\n${passed} checks passed, ${failed} failed`);
+  if (problems.length) {
+    console.log("\nFirst failures:");
+    for (const p of problems) console.log(`  - ${p}`);
+  }
+
+  scratch.close();
+} finally {
+  source.close();
+  fs.rmSync(scratchDir, { recursive: true, force: true });
+}
+
+process.exit(failed > 0 ? 1 : 0);

--- a/src/core/tools/chatHistory.ts
+++ b/src/core/tools/chatHistory.ts
@@ -80,6 +80,12 @@ export const getFullToolResultTool = createTool({
         toolCallId: args.toolCallId,
         toolName: args.toolName,
         loadMessages: (chatId) => storage.loadMessages(chatId),
+        // Very large results are kept in sidecar files rather than in the row,
+        // so the loaded message only carries a preview.
+        readOffloaded: storage.readOffloadedToolResult
+          ? (chatId, messageId, toolCallId) =>
+              storage.readOffloadedToolResult!(chatId, messageId, toolCallId)
+          : undefined,
       });
 
       if (!match) {

--- a/src/gateway/services/agent/toolResultLookup.ts
+++ b/src/gateway/services/agent/toolResultLookup.ts
@@ -7,6 +7,8 @@ interface ToolCallItem {
   name?: string;
   toolName?: string;
   result?: string | unknown;
+  /** Present when `result` is only a preview and the full text lives on disk. */
+  resultOffload?: { file: string; totalChars: number };
 }
 
 interface SequenceToolItem {
@@ -61,7 +63,7 @@ function findInMessageToolCalls(
   message: StoredMessage,
   toolCallId: string,
   toolName?: string,
-): { toolName: string; result: string } | null {
+): { toolName: string; result: string; isOffloaded?: boolean } | null {
   if (message.toolCalls) {
     for (const tc of message.toolCalls) {
       if (!matchesToolCall(tc as ToolCallItem, toolCallId, toolName)) {
@@ -71,6 +73,9 @@ function findInMessageToolCalls(
       return {
         toolName: item.name ?? item.toolName ?? toolName ?? "unknown",
         result: formatStoredResult(item.result),
+        // The row only holds a preview; the caller reads the sidecar for the
+        // full text, which is the whole point of this tool.
+        ...(item.resultOffload ? { isOffloaded: true } : {}),
       };
     }
   }
@@ -100,12 +105,23 @@ function findInMessageToolCalls(
   return null;
 }
 
-export function findFullToolResult(args: {
+interface FindFullToolResultArgs {
   chatIds: string[];
   toolCallId: string;
   toolName?: string;
   loadMessages: (chatId: string) => Promise<StoredMessage[]>;
-}): Promise<{
+  /**
+   * Reads a result that was moved out of the row into sidecar storage.
+   * Omit it and the caller gets the inline preview instead.
+   */
+  readOffloaded?: (
+    chatId: string,
+    messageId: string,
+    toolCallId: string,
+  ) => Promise<string | null>;
+}
+
+export function findFullToolResult(args: FindFullToolResultArgs): Promise<{
   toolName: string;
   result: string;
   messageId: string;
@@ -114,12 +130,9 @@ export function findFullToolResult(args: {
   return findFullToolResultImpl(args);
 }
 
-async function findFullToolResultImpl(args: {
-  chatIds: string[];
-  toolCallId: string;
-  toolName?: string;
-  loadMessages: (chatId: string) => Promise<StoredMessage[]>;
-}): Promise<{
+async function findFullToolResultImpl(
+  args: FindFullToolResultArgs,
+): Promise<{
   toolName: string;
   result: string;
   messageId: string;
@@ -148,8 +161,21 @@ async function findFullToolResultImpl(args: {
       if (!match) {
         continue;
       }
+
+      const { isOffloaded, ...found } = match;
+      if (isOffloaded && args.readOffloaded) {
+        const full = await args.readOffloaded(
+          chatId,
+          message.id,
+          args.toolCallId,
+        );
+        if (full !== null) {
+          found.result = full;
+        }
+      }
+
       return {
-        ...match,
+        ...found,
         messageId: message.id,
         chatId,
       };

--- a/src/gateway/services/storage/HybridStorageProvider.ts
+++ b/src/gateway/services/storage/HybridStorageProvider.ts
@@ -55,6 +55,15 @@ export class HybridStorageProvider implements IStorageProvider {
     );
   }
 
+  /** Sidecar payloads are local files, so this always goes to SQLite. */
+  readOffloadedToolResult(
+    chatId: string,
+    messageId: string,
+    toolCallId: string,
+  ): Promise<string | null> {
+    return this.local.readOffloadedToolResult(chatId, messageId, toolCallId);
+  }
+
   // ===== Message Operations =====
 
   async updateMessage(

--- a/src/gateway/services/storage/IStorageProvider.ts
+++ b/src/gateway/services/storage/IStorageProvider.ts
@@ -35,6 +35,16 @@ export interface StoredMessage {
     args: Record<string, any>;
     result?: string;
     status?: "pending" | "success" | "error" | "interrupted";
+    /**
+     * Set when `result` is only a preview because the full text was moved to a
+     * sidecar file. `get_full_tool_result` follows this to read the original.
+     */
+    resultOffload?: {
+      /** Sidecar location, relative to the directory holding chats.db. */
+      file: string;
+      /** Length in characters of the full result. */
+      totalChars: number;
+    };
   }>;
 
   // Sequence tracking (V1 compatibility for interleaved text/tool calls)
@@ -153,6 +163,19 @@ export interface IStorageProvider {
    * @param chatId - Chat session ID
    */
   loadMessagesForLLM(chatId: string): Promise<any[]>;
+
+  /**
+   * Read the full text of a tool result that was offloaded to sidecar storage.
+   * Returns null when the tool call has no offloaded result.
+   *
+   * Only providers that own local files implement this; loaded messages carry
+   * an inline preview either way.
+   */
+  readOffloadedToolResult?(
+    chatId: string,
+    messageId: string,
+    toolCallId: string,
+  ): Promise<string | null>;
 
   // ===== Summary Operations =====
 

--- a/src/gateway/services/storage/LocalStorageProvider.ts
+++ b/src/gateway/services/storage/LocalStorageProvider.ts
@@ -50,6 +50,16 @@ import {
   getTotalToolInvocationsForAgent,
   sumToolInvocations,
 } from "./agentToolCountsSql.js";
+import {
+  deleteChatSidecars,
+  findOffloadRef,
+  MAX_INLINE_PAYLOAD_BYTES,
+  oversizedPayloadPlaceholder,
+  readOffloadedResult,
+  restoreSequencePayloads,
+  serializeMessagePayloads,
+} from "./messagePayloadStore.js";
+import { startToolPayloadMigration } from "./toolPayloadMigration.js";
 
 export class LocalStorageProvider implements IStorageProvider {
   private db!: Database.Database;
@@ -64,6 +74,11 @@ export class LocalStorageProvider implements IStorageProvider {
   constructor(userDataPath: string) {
     this.dbPath = path.join(userDataPath, "chats.db");
     this.exporter = new ChatExporter();
+  }
+
+  /** Directory holding chats.db; offloaded tool payloads live alongside it. */
+  private get dbDir(): string {
+    return path.dirname(this.dbPath);
   }
 
   async initialize(): Promise<void> {
@@ -117,6 +132,11 @@ export class LocalStorageProvider implements IStorageProvider {
         this.contextEfficiencyCache = null;
       },
     });
+
+    // Rows written before payload offloading existed keep two copies of every
+    // tool payload and can be large enough to exhaust the heap when a chat is
+    // opened. Compact them in the background rather than blocking startup.
+    startToolPayloadMigration(this.db, this.dbDir);
   }
 
   private createSchema(): void {
@@ -372,6 +392,15 @@ export class LocalStorageProvider implements IStorageProvider {
 
     const messageId = message.id || uuidv4();
 
+    // Offload oversized results and drop the payloads `sequence` duplicates
+    // from `tool_calls`, so a single turn cannot write a multi-megabyte row.
+    const payloads = serializeMessagePayloads({
+      dbDir: this.dbDir,
+      chatId,
+      messageId,
+      message,
+    });
+
     // Insert message
     this.db
       .prepare(`
@@ -392,7 +421,7 @@ export class LocalStorageProvider implements IStorageProvider {
         message.content,
         timestamp,
         message.thinking || null,
-        message.toolCalls ? JSON.stringify(message.toolCalls) : null,
+        payloads.toolCallsJson,
         message.error || null,
         message.incomplete ? 1 : 0,
         message.model || null,
@@ -406,7 +435,7 @@ export class LocalStorageProvider implements IStorageProvider {
         message.papr_message_id || null,
         message.source_agent_id || "main-agent",
         message.source_agent_name || "Paprwork Assistant",
-        message.sequence ? JSON.stringify(message.sequence) : null, // Store sequence as JSON
+        payloads.sequenceJson,
         message.attachments?.length
           ? JSON.stringify(message.attachments)
           : null,
@@ -470,6 +499,13 @@ export class LocalStorageProvider implements IStorageProvider {
       promptTokens = estimatedTokens;
     }
 
+    const payloads = serializeMessagePayloads({
+      dbDir: this.dbDir,
+      chatId,
+      messageId,
+      message,
+    });
+
     this.db
       .prepare(`
       UPDATE messages SET
@@ -499,7 +535,7 @@ export class LocalStorageProvider implements IStorageProvider {
         message.content,
         timestamp,
         message.thinking || null,
-        message.toolCalls ? JSON.stringify(message.toolCalls) : null,
+        payloads.toolCallsJson,
         message.error || null,
         message.incomplete ? 1 : 0,
         message.model || null,
@@ -513,7 +549,7 @@ export class LocalStorageProvider implements IStorageProvider {
         message.papr_message_id || null,
         message.source_agent_id || "main-agent",
         message.source_agent_name || "Paprwork Assistant",
-        message.sequence ? JSON.stringify(message.sequence) : null,
+        payloads.sequenceJson,
         messageId,
         chatId,
       );
@@ -546,11 +582,17 @@ export class LocalStorageProvider implements IStorageProvider {
       status?: string;
     }
 
+    // `sequence` points at `tool_calls` for its payloads, so patching here is
+    // enough for both the LLM history and the UI.
     const rows = this.db
       .prepare(
+        // Skipping oversized rows costs nothing in practice: a live turn's
+        // payloads are capped on write, and legacy rows shrink once the
+        // backfill reaches them. Parsing one here would risk the heap.
         `SELECT id, tool_calls FROM messages
          WHERE chat_id = ? AND role = 'assistant'
            AND tool_calls IS NOT NULL AND tool_calls != ''
+           AND LENGTH(tool_calls) <= ${MAX_INLINE_PAYLOAD_BYTES}
          ORDER BY timestamp DESC`,
       )
       .all(chatId) as Array<{ id: string; tool_calls: string }>;
@@ -630,14 +672,23 @@ export class LocalStorageProvider implements IStorageProvider {
   ): Promise<StoredMessage[]> {
     // When limit is specified, we load most recent messages first (DESC), then reverse
     // to maintain chronological order in the UI
+    // The payload columns are left in SQLite when they exceed the read limit, so
+    // one oversized legacy row can no longer pull hundreds of megabytes into the
+    // heap. LENGTH() still comes back, which is how the mapper reports the skip.
     let query = `
       SELECT 
         id, chat_id, role, content, timestamp,
-        thinking, tool_calls, error, incomplete,
+        thinking, error, incomplete,
         model, prompt_tokens, completion_tokens, total_tokens,
         sync_status, papr_message_id, last_sync_attempt, sync_error,
         source_agent_id, source_agent_name,
-        sequence, attachments
+        attachments,
+        CASE WHEN LENGTH(tool_calls) > ${MAX_INLINE_PAYLOAD_BYTES}
+             THEN NULL ELSE tool_calls END AS tool_calls,
+        LENGTH(tool_calls) AS tool_calls_bytes,
+        CASE WHEN LENGTH(sequence) > ${MAX_INLINE_PAYLOAD_BYTES}
+             THEN NULL ELSE sequence END AS sequence,
+        LENGTH(sequence) AS sequence_bytes
       FROM messages 
       WHERE chat_id = ? 
       ORDER BY timestamp ${limit ? 'DESC' : 'ASC'}
@@ -664,15 +715,26 @@ export class LocalStorageProvider implements IStorageProvider {
       );
     });
 
-    return orderedRows.map((row) => ({
+    return orderedRows.map((row) => {
+      const toolCalls = this.parsePayloadColumn<StoredMessage["toolCalls"]>(
+        row,
+        "tool_calls",
+      );
+
+      return {
       id: row.id,
       chat_id: row.chat_id,
       role: row.role as "user" | "assistant",
       content: row.content,
       timestamp: row.timestamp,
       thinking: row.thinking || undefined,
-      toolCalls: row.tool_calls ? JSON.parse(row.tool_calls) : undefined,
-      sequence: row.sequence ? JSON.parse(row.sequence) : undefined, // Parse sequence from JSON
+      toolCalls,
+      // `sequence` stores pointers into `tool_calls` rather than a second copy
+      // of every payload; rebuild them so consumers see the original shape.
+      sequence: restoreSequencePayloads(
+        this.parsePayloadColumn<StoredMessage["sequence"]>(row, "sequence"),
+        toolCalls,
+      ),
       error: row.error || undefined,
       incomplete: row.incomplete === 1,
       model: row.model,
@@ -689,7 +751,43 @@ export class LocalStorageProvider implements IStorageProvider {
       source_agent_id: row.source_agent_id || "main-agent",
       source_agent_name: row.source_agent_name || "Paprwork Assistant",
       attachments: row.attachments ? JSON.parse(row.attachments) : undefined,
-    }));
+      };
+    });
+  }
+
+  /**
+   * Parse one of the JSON payload columns.
+   *
+   * The query nulls out columns above MAX_INLINE_PAYLOAD_BYTES, so an oversized
+   * legacy row arrives here with only its length. Those are skipped rather than
+   * parsed — a single 100MB+ row was enough to abort the gateway on OOM. The
+   * offload migration rewrites them into sidecar files.
+   */
+  private parsePayloadColumn<T>(
+    row: { id: string; [key: string]: any },
+    column: "tool_calls" | "sequence",
+  ): T | undefined {
+    const raw = row[column];
+    const bytes = row[`${column}_bytes`] as number | null;
+
+    if (typeof raw !== "string" || raw.length === 0) {
+      if (bytes && bytes > MAX_INLINE_PAYLOAD_BYTES) {
+        console.warn(
+          `[LocalStorage] Skipped ${row.id} ${oversizedPayloadPlaceholder({ column, bytes })}`,
+        );
+      }
+      return undefined;
+    }
+
+    try {
+      return JSON.parse(raw) as T;
+    } catch (error) {
+      console.warn(
+        `[LocalStorage] Malformed ${column} on message ${row.id}:`,
+        error instanceof Error ? error.message : error,
+      );
+      return undefined;
+    }
   }
 
   async loadMessagesForLLM(chatId: string): Promise<any[]> {
@@ -752,7 +850,10 @@ export class LocalStorageProvider implements IStorageProvider {
 
     let recentMessages = this.db
       .prepare(`
-      SELECT role, content, thinking, tool_calls, timestamp, attachments
+      SELECT id, role, content, thinking, timestamp, attachments,
+             CASE WHEN LENGTH(tool_calls) > ${MAX_INLINE_PAYLOAD_BYTES}
+                  THEN NULL ELSE tool_calls END AS tool_calls,
+             LENGTH(tool_calls) AS tool_calls_bytes
       FROM messages 
       WHERE chat_id = ? 
       ORDER BY timestamp DESC 
@@ -775,7 +876,10 @@ export class LocalStorageProvider implements IStorageProvider {
       recentMessageLimit = expandedLimit;
       recentMessages = this.db
         .prepare(`
-        SELECT role, content, thinking, tool_calls, timestamp
+        SELECT id, role, content, thinking, timestamp, attachments,
+               CASE WHEN LENGTH(tool_calls) > ${MAX_INLINE_PAYLOAD_BYTES}
+                    THEN NULL ELSE tool_calls END AS tool_calls,
+               LENGTH(tool_calls) AS tool_calls_bytes
         FROM messages 
         WHERE chat_id = ? 
         ORDER BY timestamp DESC 
@@ -824,10 +928,10 @@ export class LocalStorageProvider implements IStorageProvider {
 
     // Format recent messages — pass toolCalls through for structured AI SDK format
     const formattedRecent = recentMessages.map((message) => {
-      const parsedToolCalls =
-        typeof message.tool_calls === "string" && message.tool_calls.length > 0
-          ? (JSON.parse(message.tool_calls) as unknown[])
-          : undefined;
+      const parsedToolCalls = this.parsePayloadColumn<unknown[]>(
+        message,
+        "tool_calls",
+      );
       const parsedAttachments =
         typeof message.attachments === "string" && message.attachments.length > 0
           ? (JSON.parse(message.attachments) as unknown[])
@@ -1008,6 +1112,37 @@ export class LocalStorageProvider implements IStorageProvider {
   async deleteChat(chatId: string): Promise<void> {
     // Foreign key cascade will delete messages
     this.db.prepare("DELETE FROM chats WHERE id = ?").run(chatId);
+    deleteChatSidecars(this.dbDir, chatId);
+  }
+
+  /**
+   * Read the full text of a tool result that was moved to sidecar storage.
+   * Returns null when this tool call kept its result inline.
+   */
+  async readOffloadedToolResult(
+    chatId: string,
+    messageId: string,
+    toolCallId: string,
+  ): Promise<string | null> {
+    const row = this.db
+      .prepare(
+        `SELECT tool_calls FROM messages
+         WHERE id = ? AND chat_id = ?
+           AND LENGTH(tool_calls) <= ${MAX_INLINE_PAYLOAD_BYTES}`,
+      )
+      .get(messageId, chatId) as { tool_calls: string | null } | undefined;
+
+    if (!row?.tool_calls) return null;
+
+    let toolCalls: StoredMessage["toolCalls"];
+    try {
+      toolCalls = JSON.parse(row.tool_calls);
+    } catch {
+      return null;
+    }
+
+    const ref = findOffloadRef({ toolCalls } as StoredMessage, toolCallId);
+    return ref ? readOffloadedResult(this.dbDir, ref) : null;
   }
 
   async listChats(): Promise<ChatMetadata[]> {
@@ -1191,9 +1326,14 @@ export class LocalStorageProvider implements IStorageProvider {
   }
 
   async getUnsyncedMessages(chatId: string): Promise<StoredMessage[]> {
+    // Named columns, not SELECT *: the payload columns are not part of the
+    // result and pulling them in only to drop them can exhaust the heap.
     const rows = this.db
       .prepare(`
-      SELECT * FROM messages 
+      SELECT id, chat_id, role, content, timestamp, model,
+             prompt_tokens, completion_tokens, total_tokens,
+             sync_status, papr_message_id, last_sync_attempt, sync_error
+      FROM messages 
       WHERE chat_id = ? 
         AND sync_status IN ('sync_pending', 'sync_failed')
       ORDER BY timestamp ASC

--- a/src/gateway/services/storage/contextFootprint.ts
+++ b/src/gateway/services/storage/contextFootprint.ts
@@ -55,6 +55,8 @@ interface ToolCallRecord {
   name?: string;
   args?: unknown;
   result?: unknown;
+  /** Present when `result` is only a preview of a payload kept outside the row. */
+  resultOffload?: { totalChars?: number };
 }
 
 export interface ChatTurnFootprint {
@@ -114,8 +116,15 @@ function estimateToolCallsChars(
     if (call.args !== undefined) {
       chars += stringifyResult(call.args).length;
     }
-    const fullResult = stringifyResult(call.result);
-    chars += truncateToolResult(fullResult, truncateResultsAt).length;
+    const storedResult = stringifyResult(call.result);
+    if (truncateResultsAt === null) {
+      // Untruncated baseline: an offloaded result only keeps a preview in the
+      // row, so its real size comes from the offload pointer.
+      chars += call.resultOffload?.totalChars ?? storedResult.length;
+    } else {
+      // What the model actually receives, which is the stored value.
+      chars += truncateToolResult(storedResult, truncateResultsAt).length;
+    }
     if (typeof call.name === "string") {
       chars += call.name.length;
     }

--- a/src/gateway/services/storage/contextFootprintSql.ts
+++ b/src/gateway/services/storage/contextFootprintSql.ts
@@ -12,6 +12,7 @@ import {
   type StoredMessageRow,
 } from "./contextFootprint.js";
 import { computeRecentMessageLimit } from "./recentMessageWindow.js";
+import { boundedPayloadSql } from "./messagePayloadStore.js";
 
 const messageCharExpr = `LENGTH(COALESCE(content, ''))
   + LENGTH(COALESCE(thinking, ''))
@@ -68,7 +69,7 @@ function computeChatFootprintSnapshot(
   );
 
   const recentMessagesStmt = db.prepare(
-    `SELECT role, content, thinking, tool_calls
+    `SELECT role, content, thinking, ${boundedPayloadSql("tool_calls")}
      FROM messages
      WHERE chat_id = ?
      ORDER BY timestamp DESC
@@ -76,7 +77,7 @@ function computeChatFootprintSnapshot(
   );
 
   const toolCallsStmt = db.prepare(
-    `SELECT tool_calls
+    `SELECT ${boundedPayloadSql("tool_calls")}
      FROM messages
      WHERE chat_id = ?
        AND role = 'assistant'
@@ -216,7 +217,7 @@ export function computeCumulativeContextProjection(
   const chats = fetchChatsWithBilling(db);
 
   const messagesStmt = db.prepare(
-    `SELECT role, content, thinking, tool_calls, prompt_tokens
+    `SELECT role, content, thinking, ${boundedPayloadSql("tool_calls")}, prompt_tokens
      FROM messages
      WHERE chat_id = ?
      ORDER BY timestamp ASC`,

--- a/src/gateway/services/storage/contextFootprintStore.ts
+++ b/src/gateway/services/storage/contextFootprintStore.ts
@@ -13,6 +13,7 @@ import {
   scheduleContextStatsRebuild,
   type CachedLifetimeProjection,
 } from "./contextStatsCache.js";
+import { boundedPayloadSql } from "./messagePayloadStore.js";
 
 export type { CachedLifetimeProjection };
 
@@ -103,8 +104,8 @@ export function backfillChatFootprints(
 
   const messages = db
     .prepare(
-      `SELECT id, role, content, thinking, tool_calls, prompt_tokens,
-              hypothetical_prompt_tokens, timestamp
+      `SELECT id, role, content, thinking, ${boundedPayloadSql("tool_calls")},
+              prompt_tokens, hypothetical_prompt_tokens, timestamp
        FROM messages
        WHERE chat_id = ?
        ORDER BY timestamp ASC`,
@@ -172,7 +173,7 @@ export function storeFootprintForNewMessage(
 
   const history = db
     .prepare(
-      `SELECT role, content, thinking, tool_calls
+      `SELECT role, content, thinking, ${boundedPayloadSql("tool_calls")}
        FROM messages
        WHERE chat_id = ? AND timestamp < ?
        ORDER BY timestamp ASC`,

--- a/src/gateway/services/storage/memorySearchSavings.ts
+++ b/src/gateway/services/storage/memorySearchSavings.ts
@@ -2,6 +2,7 @@ import Database from "better-sqlite3";
 import * as fs from "fs";
 import * as path from "path";
 import { resolvePaprUserDataPath } from "../../../core/utils/paprWorkspace.js";
+import { MAX_INLINE_PAYLOAD_BYTES } from "./messagePayloadStore.js";
 
 const CHARS_PER_TOKEN = 4;
 /** Rough chars/line when we only have lines_of_code from index metadata */
@@ -241,6 +242,7 @@ export function computeMemorySearchSavings(
          WHERE role = 'assistant'
            AND tool_calls IS NOT NULL
            AND tool_calls != ''
+           AND LENGTH(tool_calls) <= ${MAX_INLINE_PAYLOAD_BYTES}
            AND timestamp >= ?
            AND (
              tool_calls LIKE '%"search_agent_memory"%'
@@ -257,6 +259,7 @@ export function computeMemorySearchSavings(
          WHERE role = 'assistant'
            AND tool_calls IS NOT NULL
            AND tool_calls != ''
+           AND LENGTH(tool_calls) <= ${MAX_INLINE_PAYLOAD_BYTES}
            AND (
              tool_calls LIKE '%"search_agent_memory"%'
              OR tool_calls LIKE '%"search_memory"%'

--- a/src/gateway/services/storage/messagePayloadStore.ts
+++ b/src/gateway/services/storage/messagePayloadStore.ts
@@ -1,0 +1,483 @@
+/**
+ * Message payload store — keeps oversized tool payloads out of SQLite rows.
+ *
+ * An assistant turn used to write the same tool payloads twice: once into
+ * `messages.tool_calls` and again into `messages.sequence`. With a few large
+ * results (file reads, scrapes, delegation transcripts) a single row grew past
+ * 100MB, and loading that chat parsed every copy into the heap — which is how
+ * the gateway hit V8's 4GB ceiling and aborted.
+ *
+ * On disk we now keep one copy of each payload:
+ *   - `tool_calls` stays canonical (LLM context, analytics and sync read it)
+ *   - `sequence` keeps ordering metadata plus a pointer back to `tool_calls`
+ *   - results above OFFLOAD_THRESHOLD_CHARS move to a sidecar file
+ *
+ * Reads rehydrate the pointers, so a `StoredMessage` looks exactly as it did
+ * before. Nothing is discarded: an offloaded result keeps an inline preview and
+ * the full text stays on disk, retrievable via `get_full_tool_result`.
+ */
+
+import fs from "fs";
+import path from "path";
+import type { StoredMessage } from "./IStorageProvider.js";
+
+/** Results longer than this move to a sidecar file instead of living in the row. */
+export const OFFLOAD_THRESHOLD_CHARS = 256 * 1024;
+
+/** How much of an offloaded result stays inline so the UI still shows something. */
+export const OFFLOAD_PREVIEW_CHARS = 4096;
+
+/**
+ * Budget for the whole `tool_calls` column. A turn with dozens of results that
+ * each sit just under the per-result threshold would otherwise still add up to
+ * a huge row, so the largest ones spill to sidecars until the row fits.
+ */
+export const MAX_ROW_PAYLOAD_CHARS = 1024 * 1024;
+
+/** Not worth a sidecar file below this size. */
+export const MIN_SPILL_CHARS = 8 * 1024;
+
+/**
+ * Largest single column we are willing to pull into JS and parse. Rows written
+ * before offloading existed can be hundreds of megabytes, and parsing one was
+ * enough to exhaust the heap, so the read path skips them instead.
+ */
+export const MAX_INLINE_PAYLOAD_BYTES = 2 * 1024 * 1024;
+
+export const SIDECAR_DIRNAME = "tool-results";
+
+/**
+ * SQL that yields NULL instead of a payload too large to pull into the heap.
+ * Use it anywhere a query fetches a payload column it intends to parse.
+ */
+export function boundedPayloadSql(column: "tool_calls" | "sequence"): string {
+  return (
+    `CASE WHEN LENGTH(${column}) > ${MAX_INLINE_PAYLOAD_BYTES} ` +
+    `THEN NULL ELSE ${column} END AS ${column}`
+  );
+}
+
+/** Pointer left in `tool_calls` when a result was moved to a sidecar file. */
+export interface OffloadedResultRef {
+  /** Sidecar location, relative to the directory holding chats.db. */
+  file: string;
+  /** Length in characters of the full result. */
+  totalChars: number;
+}
+
+type ToolCallRecord = {
+  id?: string;
+  name?: string;
+  args?: Record<string, unknown>;
+  result?: string;
+  status?: string;
+  resultOffload?: OffloadedResultRef;
+  [key: string]: unknown;
+};
+
+type SequenceItem = {
+  type: "text" | "tool" | "thinking";
+  data: string | Record<string, unknown>;
+};
+
+/** Marks how a slimmed sequence item rebuilds its payload from `tool_calls`. */
+const INPUT_REF = "toolCall";
+const OUTPUT_REF_STRING = "toolCall:string";
+const OUTPUT_REF_JSON = "toolCall:json";
+
+function sanitizeSegment(value: string): string {
+  const cleaned = value.replace(/[^a-zA-Z0-9_.-]/g, "_");
+  return cleaned.length > 120 ? cleaned.slice(0, 120) : cleaned || "_";
+}
+
+function isToolItem(
+  item: SequenceItem,
+): item is { type: "tool"; data: Record<string, unknown> } {
+  return (
+    item?.type === "tool" &&
+    typeof item.data === "object" &&
+    item.data !== null &&
+    !Array.isArray(item.data)
+  );
+}
+
+function buildOffloadNotice(
+  ref: OffloadedResultRef,
+  toolCallId: string,
+  toolName?: string,
+): string {
+  const remaining = ref.totalChars - OFFLOAD_PREVIEW_CHARS;
+  const nameArg = toolName ? `, toolName: "${toolName}"` : "";
+  return (
+    `\n\n[... ${remaining.toLocaleString()} more characters stored outside the database ` +
+    `(total ${ref.totalChars.toLocaleString()}). ` +
+    `Full result: get_full_tool_result({ toolCallId: "${toolCallId}"${nameArg} })]`
+  );
+}
+
+function writeSidecar(absolutePath: string, contents: string): void {
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  const tmpPath = `${absolutePath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmpPath, contents, "utf8");
+  fs.renameSync(tmpPath, absolutePath);
+}
+
+/**
+ * Move a single oversized result to a sidecar file.
+ * Returns null when the write fails, so the caller keeps the result inline
+ * rather than losing it.
+ */
+function offloadResult(args: {
+  dbDir: string;
+  chatId: string;
+  messageId: string;
+  toolCallId: string;
+  result: string;
+}): OffloadedResultRef | null {
+  const relativePath = path.join(
+    SIDECAR_DIRNAME,
+    sanitizeSegment(args.chatId),
+    sanitizeSegment(args.messageId),
+    `${sanitizeSegment(args.toolCallId)}.txt`,
+  );
+
+  try {
+    writeSidecar(path.join(args.dbDir, relativePath), args.result);
+    return { file: relativePath, totalChars: args.result.length };
+  } catch (error) {
+    console.error(
+      `[MessagePayloadStore] Failed to offload result for ${args.toolCallId}, keeping it inline:`,
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+}
+
+/**
+ * Shrink a message's payloads for storage: offload oversized results and drop
+ * the copies that `sequence` duplicates from `tool_calls`.
+ *
+ * The input message is never mutated — callers still sync the full-fidelity
+ * object to Papr and hand it to exporters after saving.
+ */
+export function serializeMessagePayloads(args: {
+  dbDir: string;
+  chatId: string;
+  messageId: string;
+  message: StoredMessage;
+}): { toolCallsJson: string | null; sequenceJson: string | null } {
+  const { dbDir, chatId, messageId, message } = args;
+
+  const toolCalls = message.toolCalls
+    ? (message.toolCalls.map((tc) => ({ ...tc })) as ToolCallRecord[])
+    : undefined;
+
+  // Offload oversized results, keeping a preview plus a pointer inline.
+  const byId = new Map<string, ToolCallRecord>();
+  for (const tc of toolCalls ?? []) {
+    const toolCallId = typeof tc.id === "string" ? tc.id : undefined;
+    if (toolCallId) {
+      byId.set(toolCallId, tc);
+    }
+
+    if (
+      typeof tc.result !== "string" ||
+      tc.result.length <= OFFLOAD_THRESHOLD_CHARS ||
+      !toolCallId
+    ) {
+      continue;
+    }
+
+    const ref = offloadResult({
+      dbDir,
+      chatId,
+      messageId,
+      toolCallId,
+      result: tc.result,
+    });
+    if (!ref) continue;
+
+    tc.result =
+      tc.result.slice(0, OFFLOAD_PREVIEW_CHARS) +
+      buildOffloadNotice(
+        ref,
+        toolCallId,
+        typeof tc.name === "string" ? tc.name : undefined,
+      );
+    tc.resultOffload = ref;
+  }
+
+  spillLargestUntilRowFits({ dbDir, chatId, messageId, toolCalls });
+
+  // Replace the duplicated sequence payloads with pointers into tool_calls.
+  const sequence = message.sequence as SequenceItem[] | undefined;
+  const slimmedSequence = sequence?.map((item, index) => {
+    if (!isToolItem(item)) return item;
+
+    const data = { ...item.data };
+    const toolCallId =
+      typeof data.toolCallId === "string" ? data.toolCallId : undefined;
+    const twin = toolCallId ? byId.get(toolCallId) : undefined;
+
+    if (!twin) {
+      return { ...item, data: offloadOrphanPayload({ dbDir, chatId, messageId, index, data }) };
+    }
+
+    if (data.input !== undefined && twin.args !== undefined) {
+      delete data.input;
+      data.inputRef = INPUT_REF;
+    }
+
+    // `tool_calls` holds the JSON-stringified form of the same value, so the
+    // pointer only records which shape to rebuild. `null` stays inline: it
+    // serializes to nothing in `tool_calls`, so it could not be restored.
+    if (
+      data.output !== undefined &&
+      data.output !== null &&
+      typeof twin.result === "string"
+    ) {
+      const wasString = typeof data.output === "string";
+      delete data.output;
+      data.outputRef = wasString ? OUTPUT_REF_STRING : OUTPUT_REF_JSON;
+    }
+
+    return { ...item, data };
+  });
+
+  return {
+    toolCallsJson: toolCalls?.length ? JSON.stringify(toolCalls) : null,
+    sequenceJson: slimmedSequence?.length
+      ? JSON.stringify(slimmedSequence)
+      : null,
+  };
+}
+
+/**
+ * Move the largest remaining inline results to sidecars until the row fits the
+ * budget. Mutates the records in place.
+ */
+function spillLargestUntilRowFits(args: {
+  dbDir: string;
+  chatId: string;
+  messageId: string;
+  toolCalls: ToolCallRecord[] | undefined;
+}): void {
+  const { toolCalls } = args;
+  if (!toolCalls?.length) return;
+
+  const rowSize = () =>
+    toolCalls.reduce(
+      (sum, tc) => sum + (typeof tc.result === "string" ? tc.result.length : 0),
+      0,
+    );
+
+  while (rowSize() > MAX_ROW_PAYLOAD_CHARS) {
+    let largest: ToolCallRecord | undefined;
+    for (const tc of toolCalls) {
+      if (tc.resultOffload || typeof tc.result !== "string") continue;
+      if (tc.result.length < MIN_SPILL_CHARS) continue;
+      if (!largest || tc.result.length > (largest.result as string).length) {
+        largest = tc;
+      }
+    }
+    if (!largest || typeof largest.id !== "string") return;
+
+    const ref = offloadResult({
+      dbDir: args.dbDir,
+      chatId: args.chatId,
+      messageId: args.messageId,
+      toolCallId: largest.id,
+      result: largest.result as string,
+    });
+    if (!ref) return;
+
+    largest.result =
+      (largest.result as string).slice(0, OFFLOAD_PREVIEW_CHARS) +
+      buildOffloadNotice(
+        ref,
+        largest.id,
+        typeof largest.name === "string" ? largest.name : undefined,
+      );
+    largest.resultOffload = ref;
+  }
+}
+
+/**
+ * A sequence tool item with no twin in `tool_calls` cannot point anywhere, so
+ * offload its payload directly rather than leaving a giant row behind.
+ */
+function offloadOrphanPayload(args: {
+  dbDir: string;
+  chatId: string;
+  messageId: string;
+  index: number;
+  data: Record<string, unknown>;
+}): Record<string, unknown> {
+  const { data } = args;
+  const output = data.output;
+  const serialized =
+    typeof output === "string"
+      ? output
+      : output === undefined || output === null
+        ? undefined
+        : safeStringify(output);
+
+  if (!serialized || serialized.length <= OFFLOAD_THRESHOLD_CHARS) {
+    return data;
+  }
+
+  const toolCallId =
+    typeof data.toolCallId === "string"
+      ? data.toolCallId
+      : `sequence-${args.index}`;
+
+  const ref = offloadResult({
+    dbDir: args.dbDir,
+    chatId: args.chatId,
+    messageId: args.messageId,
+    toolCallId: `orphan-${toolCallId}`,
+    result: serialized,
+  });
+  if (!ref) return data;
+
+  return {
+    ...data,
+    output:
+      serialized.slice(0, OFFLOAD_PREVIEW_CHARS) +
+      buildOffloadNotice(
+        ref,
+        toolCallId,
+        typeof data.name === "string" ? data.name : undefined,
+      ),
+    outputOffload: ref,
+  };
+}
+
+function safeStringify(value: unknown): string | undefined {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Rebuild the sequence payloads that `serializeMessagePayloads` pointed at
+ * `tool_calls`, so consumers see the shape they always have.
+ *
+ * Strings are shared by reference, so restoring costs no extra memory.
+ */
+export function restoreSequencePayloads(
+  sequence: SequenceItem[] | undefined,
+  toolCalls: ToolCallRecord[] | undefined,
+): SequenceItem[] | undefined {
+  if (!sequence?.length) return sequence;
+
+  const byId = new Map<string, ToolCallRecord>();
+  for (const tc of toolCalls ?? []) {
+    if (typeof tc.id === "string") byId.set(tc.id, tc);
+  }
+
+  return sequence.map((item) => {
+    if (!isToolItem(item)) return item;
+
+    const { inputRef, outputRef, ...data } = item.data as Record<
+      string,
+      unknown
+    >;
+    if (inputRef === undefined && outputRef === undefined) return item;
+
+    const toolCallId =
+      typeof data.toolCallId === "string" ? data.toolCallId : undefined;
+    const twin = toolCallId ? byId.get(toolCallId) : undefined;
+
+    if (inputRef === INPUT_REF) {
+      data.input = twin?.args;
+    }
+
+    if (outputRef === OUTPUT_REF_STRING || outputRef === OUTPUT_REF_JSON) {
+      const stored = twin?.result;
+      if (outputRef === OUTPUT_REF_JSON && typeof stored === "string") {
+        // An offloaded twin only holds a preview, which will not parse — fall
+        // back to the preview text so the pointer stays visible.
+        try {
+          data.output = JSON.parse(stored);
+        } catch {
+          data.output = stored;
+        }
+      } else {
+        data.output = stored;
+      }
+    }
+
+    return { ...item, data };
+  });
+}
+
+/** Read a result that was moved to a sidecar file. */
+export function readOffloadedResult(
+  dbDir: string,
+  ref: OffloadedResultRef,
+): string | null {
+  const root = path.resolve(dbDir, SIDECAR_DIRNAME);
+  const target = path.resolve(dbDir, ref.file);
+
+  // Refs come from our own rows, but a corrupted value should not read
+  // arbitrary files.
+  if (target !== root && !target.startsWith(root + path.sep)) {
+    console.error(`[MessagePayloadStore] Rejected out-of-tree ref: ${ref.file}`);
+    return null;
+  }
+
+  try {
+    return fs.readFileSync(target, "utf8");
+  } catch (error) {
+    console.error(
+      `[MessagePayloadStore] Missing sidecar ${ref.file}:`,
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+}
+
+/** Find the offload pointer for one tool call, if it has one. */
+export function findOffloadRef(
+  message: StoredMessage,
+  toolCallId: string,
+): OffloadedResultRef | null {
+  for (const tc of (message.toolCalls ?? []) as ToolCallRecord[]) {
+    if (tc.id === toolCallId && tc.resultOffload?.file) {
+      return tc.resultOffload;
+    }
+  }
+  return null;
+}
+
+/** Drop every sidecar belonging to a chat (called when the chat is deleted). */
+export function deleteChatSidecars(dbDir: string, chatId: string): void {
+  const dir = path.join(dbDir, SIDECAR_DIRNAME, sanitizeSegment(chatId));
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch (error) {
+    console.warn(
+      `[MessagePayloadStore] Could not remove sidecars for chat ${chatId}:`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+}
+
+/**
+ * Placeholder used when a legacy row is too large to parse safely.
+ * Keeps the turn visible instead of risking the heap on a single row.
+ */
+export function oversizedPayloadPlaceholder(args: {
+  column: "tool_calls" | "sequence";
+  bytes: number;
+}): string {
+  return (
+    `[${args.column} omitted: ${args.bytes.toLocaleString()} bytes exceeds the ` +
+    `${MAX_INLINE_PAYLOAD_BYTES.toLocaleString()} byte read limit. ` +
+    `The background payload backfill will move it to sidecar storage; ` +
+    `reopen this chat once it finishes.]`
+  );
+}

--- a/src/gateway/services/storage/toolPayloadMigration.ts
+++ b/src/gateway/services/storage/toolPayloadMigration.ts
@@ -1,0 +1,194 @@
+/**
+ * Backfill for rows written before tool payloads were offloaded.
+ *
+ * Existing databases carry two copies of every tool payload (`tool_calls` and
+ * `sequence`) and inline results that can reach 100MB+. Rewriting them makes
+ * the database much smaller and, more importantly, removes the rows that could
+ * exhaust the heap when a chat is opened.
+ *
+ * Every rewrite happens inside SQLite via json_set/json_remove, so a giant
+ * column is never parsed in JS. The only value that crosses into JS is one
+ * result at a time, which we stream straight to its sidecar file.
+ *
+ * The work is idempotent and resumable: each message is flagged once handled,
+ * so an interrupted run just picks up where it stopped.
+ */
+
+import type Database from "better-sqlite3";
+import {
+  offloadRowResults,
+  offloadRowSequenceOutputs,
+  slimRowSequence,
+  type MessageRow,
+} from "./toolPayloadRowRewrite.js";
+
+/** Rows per chunk; the loop yields between chunks so the gateway stays responsive. */
+const CHUNK_SIZE = 50;
+
+export interface PayloadMigrationStats {
+  rowsProcessed: number;
+  resultsOffloaded: number;
+  charsOffloaded: number;
+  remaining: number;
+}
+
+/** Adds the progress flag plus a partial index so resuming stays cheap. */
+export function ensurePayloadMigrationSchema(db: Database.Database): void {
+  const columns = db.prepare("PRAGMA table_info(messages)").all() as Array<{
+    name: string;
+  }>;
+
+  if (!columns.some((c) => c.name === "tool_payload_migrated")) {
+    db.exec(
+      "ALTER TABLE messages ADD COLUMN tool_payload_migrated INTEGER DEFAULT 0",
+    );
+  }
+
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_messages_payload_pending
+     ON messages(id) WHERE tool_payload_migrated = 0`,
+  );
+}
+
+/** How many messages still need rewriting. */
+export function countPendingPayloadMigrations(db: Database.Database): number {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) AS n FROM messages
+       WHERE tool_payload_migrated = 0
+         AND (tool_calls IS NOT NULL OR sequence IS NOT NULL)`,
+    )
+    .get() as { n: number };
+  return row.n;
+}
+
+/** Rewrite one chunk of messages. Safe to call repeatedly. */
+export function migrateToolPayloadsChunk(
+  db: Database.Database,
+  dbDir: string,
+  limit: number = CHUNK_SIZE,
+): PayloadMigrationStats {
+  const rows = db
+    .prepare(
+      `SELECT id, chat_id FROM messages
+       WHERE tool_payload_migrated = 0
+         AND (tool_calls IS NOT NULL OR sequence IS NOT NULL)
+       LIMIT ?`,
+    )
+    .all(limit) as MessageRow[];
+
+  const markDone = db.prepare(
+    "UPDATE messages SET tool_payload_migrated = 1 WHERE id = ?",
+  );
+
+  let resultsOffloaded = 0;
+  let charsOffloaded = 0;
+
+  for (const row of rows) {
+    try {
+      const offload = offloadRowResults(db, dbDir, row);
+      resultsOffloaded += offload.offloaded;
+      charsOffloaded += offload.chars;
+
+      // Slim first: whatever still carries an output afterwards has no twin in
+      // `tool_calls`, so it needs a sidecar of its own.
+      slimRowSequence(db, row);
+      const orphans = offloadRowSequenceOutputs(db, dbDir, row);
+      resultsOffloaded += orphans.offloaded;
+      charsOffloaded += orphans.chars;
+    } catch (error) {
+      console.error(
+        `[PayloadMigration] Skipping message ${row.id}:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+    // Flag either way so one bad row cannot stall the backfill.
+    markDone.run(row.id);
+  }
+
+  // Messages with neither column never need work.
+  db.prepare(
+    `UPDATE messages SET tool_payload_migrated = 1
+     WHERE tool_payload_migrated = 0
+       AND tool_calls IS NULL AND sequence IS NULL`,
+  ).run();
+
+  return {
+    rowsProcessed: rows.length,
+    resultsOffloaded,
+    charsOffloaded,
+    remaining: countPendingPayloadMigrations(db),
+  };
+}
+
+/**
+ * Run the backfill in the background, yielding between chunks.
+ *
+ * Startup is not blocked: the first chunk runs after the event loop drains, and
+ * each chunk hands control back so chat traffic is not held up.
+ */
+export function startToolPayloadMigration(
+  db: Database.Database,
+  dbDir: string,
+): void {
+  let pending: number;
+  try {
+    ensurePayloadMigrationSchema(db);
+    pending = countPendingPayloadMigrations(db);
+  } catch (error) {
+    console.error(
+      "[PayloadMigration] Could not prepare backfill:",
+      error instanceof Error ? error.message : error,
+    );
+    return;
+  }
+
+  if (pending === 0) return;
+
+  console.log(
+    `[PayloadMigration] Compacting stored tool payloads for ${pending.toLocaleString()} messages in the background`,
+  );
+
+  const startedAt = Date.now();
+  let totalResults = 0;
+  let totalChars = 0;
+  let lastLoggedAt = 0;
+
+  const step = (): void => {
+    let stats: PayloadMigrationStats;
+    try {
+      stats = migrateToolPayloadsChunk(db, dbDir);
+    } catch (error) {
+      console.error(
+        "[PayloadMigration] Backfill stopped:",
+        error instanceof Error ? error.message : error,
+      );
+      return;
+    }
+
+    totalResults += stats.resultsOffloaded;
+    totalChars += stats.charsOffloaded;
+
+    if (stats.rowsProcessed === 0 || stats.remaining === 0) {
+      const seconds = Math.round((Date.now() - startedAt) / 1000);
+      console.log(
+        `[PayloadMigration] Done in ${seconds}s — moved ${totalResults.toLocaleString()} results ` +
+          `(${(totalChars / 1024 / 1024).toFixed(0)}MB) out of the database. ` +
+          "Run VACUUM to release the freed space.",
+      );
+      return;
+    }
+
+    if (Date.now() - lastLoggedAt > 15_000) {
+      lastLoggedAt = Date.now();
+      console.log(
+        `[PayloadMigration] ${stats.remaining.toLocaleString()} messages left ` +
+          `(${(totalChars / 1024 / 1024).toFixed(0)}MB moved so far)`,
+      );
+    }
+
+    setTimeout(step, 25);
+  };
+
+  setTimeout(step, 5_000);
+}

--- a/src/gateway/services/storage/toolPayloadRowRewrite.ts
+++ b/src/gateway/services/storage/toolPayloadRowRewrite.ts
@@ -1,0 +1,353 @@
+/**
+ * Per-row surgery for the tool payload backfill.
+ *
+ * Each function rewrites one message's payload columns from inside SQLite, via
+ * json_set/json_remove, so a 100MB column is never parsed in JS. The only
+ * values that cross into JS are individual results, one at a time, on their
+ * way to a sidecar file.
+ *
+ * `toolPayloadMigration.ts` owns scheduling and progress; this module owns the
+ * SQL.
+ */
+
+import type Database from "better-sqlite3";
+import fs from "fs";
+import path from "path";
+import {
+  MAX_ROW_PAYLOAD_CHARS,
+  MIN_SPILL_CHARS,
+  OFFLOAD_PREVIEW_CHARS,
+  OFFLOAD_THRESHOLD_CHARS,
+  SIDECAR_DIRNAME,
+} from "./messagePayloadStore.js";
+
+/** Keeps a single UPDATE under SQLite's bound-parameter limit. */
+const MAX_PARAMS_PER_STATEMENT = 800;
+
+export interface MessageRow {
+  id: string;
+  chat_id: string;
+}
+
+/** How much a rewrite moved out of the row. */
+export interface RewriteResult {
+  offloaded: number;
+  chars: number;
+}
+
+function sanitizeSegment(value: string): string {
+  const cleaned = value.replace(/[^a-zA-Z0-9_.-]/g, "_");
+  return cleaned.length > 120 ? cleaned.slice(0, 120) : cleaned || "_";
+}
+
+/**
+ * Move every oversized result on one message into sidecar files.
+ * Returns how many were moved and how many characters left the row.
+ */
+export function offloadRowResults(
+  db: Database.Database,
+  dbDir: string,
+  row: MessageRow,
+): RewriteResult {
+  const elements = db
+    .prepare(
+      // CAST keeps `key` an integer: bound back as a float it would build the
+      // path '$[0.0]', which json_set rejects.
+      `SELECT CAST(j.key AS INTEGER) AS idx,
+              json_extract(j.value, '$.id') AS tool_call_id,
+              json_extract(j.value, '$.name') AS tool_name,
+              LENGTH(json_extract(j.value, '$.result')) AS result_len
+       FROM messages m, json_each(m.tool_calls) j
+       WHERE m.id = ?
+         AND json_type(j.value, '$.result') = 'text'
+         AND json_extract(j.value, '$.resultOffload') IS NULL
+       ORDER BY result_len DESC`,
+    )
+    .all(row.id) as Array<{
+    idx: number;
+    tool_call_id: string | null;
+    tool_name: string | null;
+    result_len: number;
+  }>;
+
+  if (elements.length === 0) return { offloaded: 0, chars: 0 };
+
+  // Anything over the per-result threshold goes, plus enough of the rest
+  // (largest first) to bring the row under its budget. Results are sorted
+  // descending, so the first one not worth a sidecar ends the search.
+  let inlineTotal = elements.reduce((sum, e) => sum + e.result_len, 0);
+  const selected: typeof elements = [];
+  for (const element of elements) {
+    const overThreshold = element.result_len > OFFLOAD_THRESHOLD_CHARS;
+    if (!overThreshold) {
+      if (inlineTotal <= MAX_ROW_PAYLOAD_CHARS) break;
+      if (element.result_len < MIN_SPILL_CHARS) break;
+    }
+    if (!element.tool_call_id) continue;
+    selected.push(element);
+    inlineTotal -= element.result_len;
+  }
+
+  // Paths are built in JS and bound as text; letting SQLite concatenate the
+  // index risks a float creeping in.
+  const readResult = db.prepare(
+    `SELECT json_extract(tool_calls, ?) AS result FROM messages WHERE id = ?`,
+  );
+  const writeStub = db.prepare(
+    `UPDATE messages
+     SET tool_calls = json_set(tool_calls, ?, ?, ?, json(?))
+     WHERE id = ?`,
+  );
+
+  let offloaded = 0;
+  let chars = 0;
+
+  for (const element of selected) {
+    const toolCallId = element.tool_call_id as string;
+
+    // One result in memory at a time — never the whole column.
+    const { result } = readResult.get(`$[${element.idx}].result`, row.id) as {
+      result: string | null;
+    };
+    if (typeof result !== "string") continue;
+
+    const moved = moveToSidecar({
+      dbDir,
+      chatId: row.chat_id,
+      messageId: row.id,
+      sidecarName: toolCallId,
+      toolCallId,
+      toolName: element.tool_name,
+      payload: result,
+    });
+    if (!moved) continue;
+
+    writeStub.run(
+      `$[${element.idx}].result`,
+      moved.stub,
+      `$[${element.idx}].resultOffload`,
+      JSON.stringify(moved.ref),
+      row.id,
+    );
+
+    offloaded += 1;
+    chars += result.length - moved.stub.length;
+  }
+
+  return { offloaded, chars };
+}
+
+/**
+ * Write one payload to its sidecar and build the stub that replaces it.
+ * Returns null when the write fails, so the caller leaves the row untouched.
+ */
+function moveToSidecar(args: {
+  dbDir: string;
+  chatId: string;
+  messageId: string;
+  /** Filename stem; unique within the message. */
+  sidecarName: string;
+  /** Id quoted in the stub so `get_full_tool_result` can find it. */
+  toolCallId: string;
+  toolName: string | null;
+  payload: string;
+}): { ref: { file: string; totalChars: number }; stub: string } | null {
+  const relativePath = path.join(
+    SIDECAR_DIRNAME,
+    sanitizeSegment(args.chatId),
+    sanitizeSegment(args.messageId),
+    `${sanitizeSegment(args.sidecarName)}.txt`,
+  );
+  const absolutePath = path.join(args.dbDir, relativePath);
+
+  try {
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, args.payload, "utf8");
+  } catch (error) {
+    console.error(
+      `[PayloadMigration] Could not write sidecar for ${args.toolCallId}:`,
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+
+  const total = args.payload.length;
+  const nameArg = args.toolName ? `, toolName: "${args.toolName}"` : "";
+  const stub =
+    args.payload.slice(0, OFFLOAD_PREVIEW_CHARS) +
+    `\n\n[... ${(total - OFFLOAD_PREVIEW_CHARS).toLocaleString()} more characters ` +
+    `stored outside the database (total ${total.toLocaleString()}). ` +
+    `Full result: get_full_tool_result({ toolCallId: "${args.toolCallId}"${nameArg} })]`;
+
+  return { ref: { file: relativePath, totalChars: total }, stub };
+}
+
+/**
+ * Offload sequence outputs that survived slimming.
+ *
+ * A tool item whose `tool_calls` twin is missing keeps its own copy of the
+ * output, so slimming leaves it in place. Those are the rows that would still
+ * be too large to read afterwards, so move the big ones out too.
+ */
+export function offloadRowSequenceOutputs(
+  db: Database.Database,
+  dbDir: string,
+  row: MessageRow,
+): RewriteResult {
+  const items = db
+    .prepare(
+      `SELECT CAST(j.key AS INTEGER) AS idx,
+              json_extract(j.value, '$.data.toolCallId') AS tool_call_id,
+              json_extract(j.value, '$.data.name') AS tool_name,
+              LENGTH(json_extract(j.value, '$.data.output')) AS output_len
+       FROM messages m, json_each(m.sequence) j
+       WHERE m.id = ?
+         AND json_extract(j.value, '$.type') = 'tool'
+         AND json_type(j.value, '$.data.output') = 'text'
+         AND json_type(j.value, '$.data.outputOffload') IS NULL
+         AND LENGTH(json_extract(j.value, '$.data.output')) > ?`,
+    )
+    .all(row.id, OFFLOAD_THRESHOLD_CHARS) as Array<{
+    idx: number;
+    tool_call_id: string | null;
+    tool_name: string | null;
+    output_len: number;
+  }>;
+
+  if (items.length === 0) return { offloaded: 0, chars: 0 };
+
+  const readOutput = db.prepare(
+    `SELECT json_extract(sequence, ?) AS output FROM messages WHERE id = ?`,
+  );
+  const writeStub = db.prepare(
+    `UPDATE messages
+     SET sequence = json_set(sequence, ?, ?, ?, json(?))
+     WHERE id = ?`,
+  );
+
+  let offloaded = 0;
+  let chars = 0;
+
+  for (const item of items) {
+    const { output } = readOutput.get(
+      `$[${item.idx}].data.output`,
+      row.id,
+    ) as { output: string | null };
+    if (typeof output !== "string") continue;
+
+    const toolCallId = item.tool_call_id ?? `sequence-${item.idx}`;
+    const moved = moveToSidecar({
+      dbDir,
+      chatId: row.chat_id,
+      messageId: row.id,
+      sidecarName: `orphan-${toolCallId}`,
+      toolCallId,
+      toolName: item.tool_name,
+      payload: output,
+    });
+    if (!moved) continue;
+
+    writeStub.run(
+      `$[${item.idx}].data.output`,
+      moved.stub,
+      `$[${item.idx}].data.outputOffload`,
+      JSON.stringify(moved.ref),
+      row.id,
+    );
+
+    offloaded += 1;
+    chars += output.length - moved.stub.length;
+  }
+
+  return { offloaded, chars };
+}
+
+/**
+ * Drop the payloads `sequence` duplicates from `tool_calls`, leaving pointers.
+ * This is where most of the reclaimed space comes from.
+ */
+export function slimRowSequence(db: Database.Database, row: MessageRow): void {
+  const toolItems = db
+    .prepare(
+      `SELECT CAST(j.key AS INTEGER) AS idx,
+              json_extract(j.value, '$.data.toolCallId') AS tool_call_id,
+              json_type(j.value, '$.data.input') AS input_type,
+              json_type(j.value, '$.data.output') AS output_type
+       FROM messages m, json_each(m.sequence) j
+       WHERE m.id = ?
+         AND json_extract(j.value, '$.type') = 'tool'
+         AND json_type(j.value, '$.data.outputRef') IS NULL
+         AND json_type(j.value, '$.data.inputRef') IS NULL`,
+    )
+    .all(row.id) as Array<{
+    idx: number;
+    tool_call_id: string | null;
+    input_type: string | null;
+    output_type: string | null;
+  }>;
+
+  if (toolItems.length === 0) return;
+
+  // Only point at payloads that `tool_calls` can actually give back.
+  const twins = db
+    .prepare(
+      `SELECT json_extract(j.value, '$.id') AS id,
+              json_type(j.value, '$.args') AS args_type,
+              json_type(j.value, '$.result') AS result_type
+       FROM messages m, json_each(m.tool_calls) j
+       WHERE m.id = ?`,
+    )
+    .all(row.id) as Array<{
+    id: string | null;
+    args_type: string | null;
+    result_type: string | null;
+  }>;
+
+  const twinById = new Map(twins.map((t) => [t.id, t]));
+
+  const removePaths: string[] = [];
+  const setArgs: string[] = [];
+
+  for (const item of toolItems) {
+    const twin = item.tool_call_id ? twinById.get(item.tool_call_id) : undefined;
+    if (!twin) continue;
+
+    if (item.input_type !== null && twin.args_type !== null) {
+      removePaths.push(`$[${item.idx}].data.input`);
+      setArgs.push(`$[${item.idx}].data.inputRef`, "toolCall");
+    }
+
+    // A JSON `null` output serializes to nothing in `tool_calls`, so it has to
+    // stay inline to survive the round trip.
+    if (
+      item.output_type !== null &&
+      item.output_type !== "null" &&
+      twin.result_type === "text"
+    ) {
+      removePaths.push(`$[${item.idx}].data.output`);
+      setArgs.push(
+        `$[${item.idx}].data.outputRef`,
+        item.output_type === "text" ? "toolCall:string" : "toolCall:json",
+      );
+    }
+  }
+
+  if (removePaths.length === 0) return;
+
+  // json_remove/json_set are variadic; batch so no statement exceeds the
+  // bound-parameter limit on turns with very many tool calls.
+  const perBatch = Math.max(1, Math.floor(MAX_PARAMS_PER_STATEMENT / 6));
+  for (let i = 0; i < removePaths.length; i += perBatch) {
+    const removeBatch = removePaths.slice(i, i + perBatch);
+    const setBatch = setArgs.slice(i * 2, (i + perBatch) * 2);
+
+    const removeSql = removeBatch.map(() => "?").join(", ");
+    const setSql = setBatch.map(() => "?").join(", ");
+
+    db.prepare(
+      `UPDATE messages
+       SET sequence = json_set(json_remove(sequence, ${removeSql}), ${setSql})
+       WHERE id = ?`,
+    ).run(...removeBatch, ...setBatch, row.id);
+  }
+}

--- a/src/gateway/services/syncV3/schemaDriftHeal.ts
+++ b/src/gateway/services/syncV3/schemaDriftHeal.ts
@@ -7,8 +7,10 @@ import Database from "better-sqlite3";
 import {
   filterSyncableTables,
   listUserTables,
+  quoteIdent,
   readRemoteTableSchema,
   readTableSchema,
+  type TableColumn,
 } from "../tursoSyncBridgeCore.js";
 import type { JobMigrationSchemaOp } from "../../../core/types/jobMigrations.js";
 import { resolveMigrationRootFromDbPath } from "../jobs/databaseMigrations.js";
@@ -56,6 +58,88 @@ async function openRemoteClient(
   return { remote, close: () => remote.close() };
 }
 
+const REBUILD_SUFFIX = "__papr_rebuild";
+
+function columnDefinition(col: TableColumn, inlinePk: boolean): string {
+  const type = col.type.trim() || "TEXT";
+  return `${quoteIdent(col.name)} ${type}${inlinePk ? " PRIMARY KEY" : ""}`;
+}
+
+/**
+ * Rebuild a remote table so its column types and PRIMARY KEY match local.
+ *
+ * SQLite cannot ALTER a column's type or add a PRIMARY KEY to an existing
+ * table, so a copy-and-swap is the only way to express this drift. Without it
+ * the healer produced zero ops for PK/type drift: the table was reported
+ * drifted forever, and publish stayed blocked no matter how many times the
+ * user pressed Upload.
+ *
+ * These statements run against Turso only — local is already the source of
+ * truth for the schema we are converging on.
+ */
+function buildRemoteTableRebuildOps(
+  tableName: string,
+  localColumns: readonly TableColumn[],
+  remoteColumns: readonly TableColumn[],
+): JobMigrationSchemaOp[] {
+  const temp = `${tableName}${REBUILD_SUFFIX}`;
+  const pkCols = localColumns.filter((col) => col.primaryKey);
+  const singlePk = pkCols.length === 1;
+
+  const colDefs = localColumns
+    .map((col) => columnDefinition(col, singlePk && col.primaryKey))
+    .join(", ");
+  const compositePk =
+    pkCols.length > 1
+      ? `, PRIMARY KEY (${pkCols.map((col) => quoteIdent(col.name)).join(", ")})`
+      : "";
+
+  // Only copy columns the remote actually has; anything else would fail to
+  // resolve in the SELECT and abort the whole rebuild.
+  const remoteNames = new Set(remoteColumns.map((col) => col.name));
+  const carried = localColumns
+    .filter((col) => remoteNames.has(col.name))
+    .map((col) => quoteIdent(col.name))
+    .join(", ");
+
+  const statements = [
+    // A previous interrupted rebuild would otherwise block CREATE.
+    `DROP TABLE IF EXISTS ${quoteIdent(temp)}`,
+    `CREATE TABLE ${quoteIdent(temp)} (${colDefs}${compositePk})`,
+  ];
+  if (carried.length > 0) {
+    // OR IGNORE: the drifted table had no PRIMARY KEY, so it may hold
+    // duplicate keys that the rebuilt table legitimately rejects.
+    statements.push(
+      `INSERT OR IGNORE INTO ${quoteIdent(temp)} (${carried}) SELECT ${carried} FROM ${quoteIdent(tableName)}`,
+    );
+  }
+  statements.push(`DROP TABLE ${quoteIdent(tableName)}`);
+  statements.push(
+    `ALTER TABLE ${quoteIdent(temp)} RENAME TO ${quoteIdent(tableName)}`,
+  );
+
+  return statements.map((statement) => ({ kind: "sql" as const, statement }));
+}
+
+/** Columns present on both sides whose type or PK flag disagrees. */
+function incompatibleColumns(
+  localColumns: readonly TableColumn[],
+  remoteColumns: readonly TableColumn[],
+): TableColumn[] {
+  const remoteByName = new Map(remoteColumns.map((col) => [col.name, col]));
+  return localColumns.filter((localCol) => {
+    const remoteCol = remoteByName.get(localCol.name);
+    if (!remoteCol) {
+      return false; // handled by add_column
+    }
+    const typeDiffers =
+      (localCol.type.trim() || "TEXT").toUpperCase() !==
+      (remoteCol.type.trim() || "TEXT").toUpperCase();
+    return typeDiffers || localCol.primaryKey !== remoteCol.primaryKey;
+  });
+}
+
 async function buildColumnDriftHealOps(
   remote: Client,
   localDb: Database.Database,
@@ -83,10 +167,19 @@ async function buildColumnDriftHealOps(
       continue;
     }
 
-    const localCols = userSchemaColumns(readTableSchema(localDb, tableName));
-    const remoteCols = userSchemaColumns(
-      await readRemoteTableSchema(remote, tableName),
-    );
+    const localAll = readTableSchema(localDb, tableName);
+    const remoteAll = await readRemoteTableSchema(remote, tableName);
+    const localCols = userSchemaColumns(localAll);
+    const remoteCols = userSchemaColumns(remoteAll);
+
+    // Type/PK differences cannot be expressed as ALTER TABLE, so a table that
+    // drifts that way needs a full rebuild. Emitting add_column ops here (or
+    // nothing at all) leaves the table permanently drifted.
+    if (incompatibleColumns(localCols, remoteCols).length > 0) {
+      ops.push(...buildRemoteTableRebuildOps(tableName, localAll, remoteAll));
+      continue;
+    }
+
     const remoteNames = new Set(remoteCols.map((col) => col.name));
     for (const localCol of localCols) {
       if (!remoteNames.has(localCol.name)) {

--- a/tests/message-payload-store.test.ts
+++ b/tests/message-payload-store.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  MAX_ROW_PAYLOAD_CHARS,
+  OFFLOAD_PREVIEW_CHARS,
+  OFFLOAD_THRESHOLD_CHARS,
+  findOffloadRef,
+  readOffloadedResult,
+  restoreSequencePayloads,
+  serializeMessagePayloads,
+  deleteChatSidecars,
+  SIDECAR_DIRNAME,
+} from "../src/gateway/services/storage/messagePayloadStore.js";
+import type { StoredMessage } from "../src/gateway/services/storage/IStorageProvider.js";
+
+let dbDir: string;
+
+beforeEach(() => {
+  dbDir = fs.mkdtempSync(path.join(os.tmpdir(), "payload-store-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dbDir, { recursive: true, force: true });
+});
+
+/** Round-trips a message through storage the way LocalStorageProvider does. */
+function roundTrip(message: StoredMessage): StoredMessage {
+  const { toolCallsJson, sequenceJson } = serializeMessagePayloads({
+    dbDir,
+    chatId: "chat-1",
+    messageId: "msg-1",
+    message,
+  });
+
+  const toolCalls = toolCallsJson ? JSON.parse(toolCallsJson) : undefined;
+  const sequence = sequenceJson ? JSON.parse(sequenceJson) : undefined;
+
+  return {
+    ...message,
+    toolCalls,
+    sequence: restoreSequencePayloads(sequence, toolCalls),
+  } as StoredMessage;
+}
+
+function baseMessage(overrides: Partial<StoredMessage>): StoredMessage {
+  return {
+    id: "msg-1",
+    role: "assistant",
+    content: "done",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  } as StoredMessage;
+}
+
+describe("serializeMessagePayloads", () => {
+  it("restores a small message byte-for-byte", () => {
+    const message = baseMessage({
+      toolCalls: [
+        {
+          id: "tc-1",
+          name: "read_file",
+          args: { path: "/tmp/a.txt" },
+          result: "hello world",
+          status: "success",
+        },
+      ],
+      sequence: [
+        { type: "text", data: "Let me look." },
+        {
+          type: "tool",
+          data: {
+            toolCallId: "tc-1",
+            name: "read_file",
+            input: { path: "/tmp/a.txt" },
+            output: "hello world",
+            status: "success",
+          },
+        },
+      ],
+    });
+
+    const restored = roundTrip(message);
+
+    expect(restored.toolCalls).toEqual(message.toolCalls);
+    expect(restored.sequence).toEqual(message.sequence);
+  });
+
+  it("stores the sequence payload once, as a pointer into tool_calls", () => {
+    const output = "x".repeat(50_000);
+    const { toolCallsJson, sequenceJson } = serializeMessagePayloads({
+      dbDir,
+      chatId: "chat-1",
+      messageId: "msg-1",
+      message: baseMessage({
+        toolCalls: [
+          { id: "tc-1", name: "bash", args: { command: "ls" }, result: output },
+        ],
+        sequence: [
+          {
+            type: "tool",
+            data: {
+              toolCallId: "tc-1",
+              name: "bash",
+              input: { command: "ls" },
+              output,
+            },
+          },
+        ],
+      }),
+    });
+
+    // The payload lives in tool_calls only; sequence keeps ordering metadata.
+    expect(toolCallsJson).toContain(output);
+    expect(sequenceJson).not.toContain(output);
+    expect(sequenceJson!.length).toBeLessThan(500);
+
+    const sequence = JSON.parse(sequenceJson!);
+    expect(sequence[0].data.outputRef).toBe("toolCall:string");
+    expect(sequence[0].data.inputRef).toBe("toolCall");
+    expect(sequence[0].data.output).toBeUndefined();
+  });
+
+  it("keeps a JSON output's shape through the pointer", () => {
+    const output = { rows: [1, 2, 3], ok: true };
+    const message = baseMessage({
+      toolCalls: [
+        {
+          id: "tc-1",
+          name: "query",
+          args: {},
+          result: JSON.stringify(output),
+        },
+      ],
+      sequence: [
+        { type: "tool", data: { toolCallId: "tc-1", name: "query", output } },
+      ],
+    });
+
+    const restored = roundTrip(message);
+    expect((restored.sequence![0] as any).data.output).toEqual(output);
+  });
+
+  it("keeps a null output inline, since tool_calls cannot round-trip it", () => {
+    const message = baseMessage({
+      toolCalls: [{ id: "tc-1", name: "noop", args: {}, result: undefined }],
+      sequence: [
+        { type: "tool", data: { toolCallId: "tc-1", name: "noop", output: null } },
+      ],
+    });
+
+    const restored = roundTrip(message);
+    expect((restored.sequence![0] as any).data.output).toBeNull();
+  });
+
+  it("leaves an orphan sequence item untouched when it is small", () => {
+    const message = baseMessage({
+      sequence: [
+        {
+          type: "tool",
+          data: { toolCallId: "gone", name: "x", output: "small" },
+        },
+      ],
+    });
+
+    const restored = roundTrip(message);
+    expect((restored.sequence![0] as any).data.output).toBe("small");
+  });
+});
+
+describe("offloading oversized results", () => {
+  it("moves a result past the threshold to a sidecar, losslessly", () => {
+    const result = "y".repeat(OFFLOAD_THRESHOLD_CHARS + 1000);
+    const message = baseMessage({
+      toolCalls: [{ id: "tc-1", name: "scrape", args: {}, result }],
+      sequence: [
+        { type: "tool", data: { toolCallId: "tc-1", name: "scrape", output: result } },
+      ],
+    });
+
+    const { toolCallsJson } = serializeMessagePayloads({
+      dbDir,
+      chatId: "chat-1",
+      messageId: "msg-1",
+      message,
+    });
+
+    const toolCalls = JSON.parse(toolCallsJson!);
+    const stored = toolCalls[0];
+
+    // Row shrank, but a preview and a pointer stayed behind.
+    expect(stored.result.length).toBeLessThan(result.length);
+    expect(stored.result.startsWith(result.slice(0, OFFLOAD_PREVIEW_CHARS))).toBe(true);
+    expect(stored.result).toContain("get_full_tool_result");
+    expect(stored.resultOffload.totalChars).toBe(result.length);
+
+    // Nothing was lost — the sidecar holds the original.
+    const restored = readOffloadedResult(dbDir, stored.resultOffload);
+    expect(restored).toBe(result);
+
+    const ref = findOffloadRef({ toolCalls } as StoredMessage, "tc-1");
+    expect(ref?.file).toBe(stored.resultOffload.file);
+  });
+
+  it("spills the largest results until the row fits its budget", () => {
+    // Ten results just under the per-result threshold still make a huge row.
+    const chunk = "z".repeat(200 * 1024);
+    const toolCalls = Array.from({ length: 10 }, (_, i) => ({
+      id: `tc-${i}`,
+      name: "bash",
+      args: {},
+      result: chunk,
+    }));
+
+    const { toolCallsJson } = serializeMessagePayloads({
+      dbDir,
+      chatId: "chat-1",
+      messageId: "msg-1",
+      message: baseMessage({ toolCalls }),
+    });
+
+    expect(toolCallsJson!.length).toBeLessThan(MAX_ROW_PAYLOAD_CHARS * 1.2);
+
+    const stored = JSON.parse(toolCallsJson!);
+    const offloaded = stored.filter((tc: any) => tc.resultOffload);
+    expect(offloaded.length).toBeGreaterThan(0);
+
+    // Every spilled result is still readable in full.
+    for (const tc of offloaded) {
+      expect(readOffloadedResult(dbDir, tc.resultOffload)).toBe(chunk);
+    }
+  });
+
+  it("offloads an oversized sequence output that has no tool_calls twin", () => {
+    const output = "q".repeat(OFFLOAD_THRESHOLD_CHARS + 1000);
+    const { sequenceJson } = serializeMessagePayloads({
+      dbDir,
+      chatId: "chat-1",
+      messageId: "msg-1",
+      message: baseMessage({
+        sequence: [
+          { type: "tool", data: { toolCallId: "orphan", name: "x", output } },
+        ],
+      }),
+    });
+
+    const sequence = JSON.parse(sequenceJson!);
+    expect(sequence[0].data.output.length).toBeLessThan(output.length);
+    expect(readOffloadedResult(dbDir, sequence[0].data.outputOffload)).toBe(output);
+  });
+
+  it("refuses to read a ref pointing outside the sidecar tree", () => {
+    expect(
+      readOffloadedResult(dbDir, { file: "../../etc/passwd", totalChars: 1 }),
+    ).toBeNull();
+  });
+
+  it("removes a chat's sidecars when the chat is deleted", () => {
+    serializeMessagePayloads({
+      dbDir,
+      chatId: "chat-1",
+      messageId: "msg-1",
+      message: baseMessage({
+        toolCalls: [
+          {
+            id: "tc-1",
+            name: "scrape",
+            args: {},
+            result: "w".repeat(OFFLOAD_THRESHOLD_CHARS + 10),
+          },
+        ],
+      }),
+    });
+
+    const chatDir = path.join(dbDir, SIDECAR_DIRNAME, "chat-1");
+    expect(fs.existsSync(chatDir)).toBe(true);
+
+    deleteChatSidecars(dbDir, "chat-1");
+    expect(fs.existsSync(chatDir)).toBe(false);
+  });
+
+  it("does not mutate the message it was given", () => {
+    const result = "m".repeat(OFFLOAD_THRESHOLD_CHARS + 10);
+    const message = baseMessage({
+      toolCalls: [{ id: "tc-1", name: "scrape", args: {}, result }],
+      sequence: [
+        { type: "tool", data: { toolCallId: "tc-1", name: "scrape", output: result } },
+      ],
+    });
+
+    serializeMessagePayloads({
+      dbDir,
+      chatId: "chat-1",
+      messageId: "msg-1",
+      message,
+    });
+
+    // Callers still sync the full-fidelity object to Papr after saving.
+    expect(message.toolCalls![0].result).toBe(result);
+    expect((message.sequence![0] as any).data.output).toBe(result);
+  });
+});


### PR DESCRIPTION
## Symptom

Schema drift on a linked database **never clears**. Upload reports success, the Web sync panel immediately re-flags the same table, and publish stays blocked:

> Calendar Reader (40407339): Local schema changed — click Upload now to update Turso.

Pressing **Upload now** any number of times does nothing. No error is surfaced.

## Root cause

The drift **detector** and the drift **healer** disagree about what drift is.

Detection fingerprints each column as `name:type:primaryKey`:

```ts
// tursoTableFingerprint.ts
.map((col) => `${col.name}:${col.type}:${col.primaryKey ? 1 : 0}`)
```

So a table is flagged when the **type** or **PK flag** differs.

But `buildColumnDriftHealOps` can only emit two ops:

| Situation | Op emitted |
|---|---|
| Table missing on remote | `CREATE TABLE` |
| Column missing on remote | `add_column` |
| **Type differs** | *(nothing)* |
| **PK differs** | *(nothing)* |

When the table exists and every column exists, and only type/PK differ, the op list comes back **empty**. `healSchemaDriftIfNeeded` returns `0`, nothing ships, and the next check re-detects identical drift. Permanent loop.

SQLite cannot express either change as an `ALTER` — there is no `ALTER COLUMN TYPE`, and a `PRIMARY KEY` cannot be added to an existing table. Copy-and-swap is the only option.

## Observed in a real workspace

Every user table on the replica had been rebuilt as bare `TEXT` with no PK, while local was correct:

| Table | Local | Turso |
|---|---|---|
| `calendar_events` | `id TEXT PRIMARY KEY`, `updated_at INTEGER` | `"id" TEXT`, `"updated_at" TEXT` |
| `meetings` | `id TEXT PRIMARY KEY`, `created_at INTEGER` | `"id" TEXT`, `"created_at" TEXT` |
| `audio_devices` | `id INTEGER PRIMARY KEY` | `"id" TEXT` |
| `audio_settings` | `id INTEGER PRIMARY KEY CHECK (id = 1)` | `"id" TEXT` |
| `app_files` | `id TEXT PRIMARY KEY`, `size_bytes INTEGER` | `"id" TEXT`, `"size_bytes" TEXT` |
| `app_file_hashes` | `local_path TEXT PRIMARY KEY` | `"local_path" TEXT` |

This also breaks correctness downstream: a PK-less replica cannot dedupe or upsert, which is how the same workspace ended up with duplicate rows.

## The change

`buildColumnDriftHealOps` now classifies drift. Columns present on both sides whose type or PK flag disagrees are *incompatible* — those cannot be `ALTER`ed, so the table is rebuilt:

```sql
DROP TABLE IF EXISTS "t__papr_rebuild";
CREATE TABLE "t__papr_rebuild" (... local types + PRIMARY KEY ...);
INSERT OR IGNORE INTO "t__papr_rebuild" (cols) SELECT cols FROM "t";
DROP TABLE "t";
ALTER TABLE "t__papr_rebuild" RENAME TO "t";
```

Missing-column drift still takes the cheaper `add_column` path — the rebuild is only used when nothing else can express the change.

### Details that matter

- **Applied to Turso only.** These ops ship through the schema log; local is already the schema being converged on, so nothing on disk is touched.
- **`INSERT OR IGNORE`** — a table that lost its PK may hold duplicate keys that the rebuilt table correctly rejects. Without it the first duplicate aborts the entire rebuild.
- **Only carries columns the remote actually has** — otherwise the `SELECT` fails to resolve and takes the rebuild down.
- **`DROP TABLE IF EXISTS` on the temp name first** — an interrupted earlier attempt would otherwise block `CREATE`.
- **`_papr_*` columns are included** in the new table. They are excluded from drift *comparison*, but must survive the swap or sync metadata is lost.
- **Composite PKs** use a table-level constraint; single PKs stay inline.

### No re-ship loop

Drift-heal payloads are keyed by a fresh `__schema_drift_heal___{timestamp}` id and re-derived from measured drift on every run — not ledger migrations that get re-verified. Once schemas converge, `driftedTables` is empty and no payload is produced.

## Testing

Simulated the exact drifted shape (all `TEXT`, no PK) from real data, with duplicate keys injected, then applied the generated statements:

```
simulated Turso rows: 657 (distinct ids: 654), pk=none, all TEXT
after rebuild:        654 rows
schema matches local exactly: True
no rows lost:                 True
integrity:                    ok
mismatched columns:           none
```

`tsc -p tsconfig.gateway.json` clean; no new errors in `tsc --noEmit` (the 95 pre-existing ones are all in `src/resources/mini-app-sdk/*`).

## Review notes

- `dropRemoteTablesForJob` in `tursoSyncBridgeCore.ts` is **dead code** — defined, exported, never called anywhere. It looks like the remnant of an earlier remote-rebuild path, and its absence is plausibly why this drift became unhealable. Worth deciding whether to delete it or wire it up.
- Rebuild is keyed on type/PK only, matching the fingerprint. `NOT NULL` and `DEFAULT` differences are deliberately **not** treated as drift, since detection ignores them; making them drift would be a larger behavioural change.