### PR TITLE
Log CDC changes for rows with a NULL row version

### DIFF
--- a/src/gateway/services/rowSyncColumns.ts
+++ b/src/gateway/services/rowSyncColumns.ts
@@ -132,12 +132,17 @@ function buildRowSyncTriggerStatements(tableName: string): string[] {
     `CREATE TRIGGER IF NOT EXISTS ${quoteIdent(bumpName)} ` +
       `AFTER UPDATE ON ${quoted} ` +
       `FOR EACH ROW ` +
-      `WHEN OLD.${quoteIdent(PAPR_ROW_SYNC_COLUMNS.rowVersion)} = NEW.${quoteIdent(PAPR_ROW_SYNC_COLUMNS.rowVersion)} ` +
+      // IS, not =: in SQLite `NULL = NULL` evaluates to NULL, which is falsy,
+      // so a row whose version was never initialised silently skipped this
+      // trigger and never bumped. IS is the NULL-safe comparison.
+      `WHEN OLD.${quoteIdent(PAPR_ROW_SYNC_COLUMNS.rowVersion)} IS NEW.${quoteIdent(PAPR_ROW_SYNC_COLUMNS.rowVersion)} ` +
       `AND ${SYNC_MUTE_GUARD} ` +
       `BEGIN ` +
       `UPDATE ${quoted} SET ` +
       `${quoteIdent(PAPR_ROW_SYNC_COLUMNS.updatedAt)} = datetime('now'), ` +
-      `${quoteIdent(PAPR_ROW_SYNC_COLUMNS.rowVersion)} = OLD.${quoteIdent(PAPR_ROW_SYNC_COLUMNS.rowVersion)} + 1 ` +
+      // COALESCE so a NULL version becomes 1 rather than staying NULL
+      // (NULL + 1 is NULL, which would leave the row permanently stuck).
+      `${quoteIdent(PAPR_ROW_SYNC_COLUMNS.rowVersion)} = COALESCE(OLD.${quoteIdent(PAPR_ROW_SYNC_COLUMNS.rowVersion)}, 0) + 1 ` +
       `WHERE rowid = NEW.rowid; ` +
       `END`,
   ];

--- a/src/gateway/services/tursoSyncLog.ts
+++ b/src/gateway/services/tursoSyncLog.ts
@@ -92,7 +92,28 @@ function cdcUpdateWhenClause(columns: TableColumn[]): string {
     return mute;
   }
   const versionCol = quoteIdent(PAPR_ROW_SYNC_COLUMNS.rowVersion);
-  return `${mute} AND OLD.${versionCol} = NEW.${versionCol}`;
+  // IS, not =: `NULL = NULL` is NULL (falsy) in SQLite, so user edits to any
+  // row with an uninitialised version were never written to the change log —
+  // the edit stayed local forever with nothing reported as failed.
+  return `${mute} AND OLD.${versionCol} IS NEW.${versionCol}`;
+}
+
+/**
+ * Tables that cannot carry change capture, so the warning is logged once each
+ * rather than on every sync pass.
+ */
+const cdcDisabledWarned = new Set<string>();
+
+function warnCdcDisabledOnce(tableName: string): void {
+  if (cdcDisabledWarned.has(tableName)) {
+    return;
+  }
+  cdcDisabledWarned.add(tableName);
+  console.warn(
+    `[TursoSyncLog] "${tableName}" has no PRIMARY KEY — change capture is disabled ` +
+      `for it, so local inserts and deletes will never reach Turso. ` +
+      `Add a PRIMARY KEY (or let schema drift heal restore it) to re-enable sync.`,
+  );
 }
 
 export function parseRowPkJson(raw: unknown): unknown[] {
@@ -504,6 +525,11 @@ export function ensureLocalTableSyncTriggers(
   ensureLocalSyncInfrastructure(db);
   const columns = readTableSchema(db, tableName);
   if (!pkJsonExpr(columns, "NEW")) {
+    // No PRIMARY KEY means row_pk cannot be expressed, so this table gets no
+    // insert/delete change capture at all. Callers ignore this boolean, so
+    // without a warning the table just stops syncing: rows accumulate locally
+    // and the replica stays empty with every push still reporting success.
+    warnCdcDisabledOnce(tableName);
     return false;
   }
   ensureLocalRowSyncColumns(db, tableName);


### PR DESCRIPTION
## Symptom

Edits to certain rows are **silently dropped from sync**. The row is correct locally, the push reports success, nothing is queued, and the change never reaches Turso. No error surfaces anywhere.

## Root cause

Both the version-bump trigger and the CDC update trigger guard on:

```sql
WHEN OLD."_papr_row_version" = NEW."_papr_row_version"
```

In SQLite, `NULL = NULL` is **NULL**, not true — and a `WHEN` clause that evaluates to NULL does not fire.

```
sqlite> SELECT NULL = NULL;
(null)
```

So for any row with a NULL `_papr_row_version`, **neither trigger runs**: no change-log entry, no version bump, and no failure reported. `IS` is the NULL-safe comparison and fires correctly.

The bump also must stop propagating NULL: `NULL + 1` is NULL, so a row reaching the bump would keep its NULL version and break again on the next edit. `COALESCE(OLD.version, 0) + 1` sets it to `1`, so the row self-heals the first time it is touched.

## Impact

Real workspace, one linked database:

| Table | NULL version | Total |
|---|---|---|
| `calendar_events` | **357** | 654 |
| `meetings` | **6** | 97 |

Over half of `calendar_events` was silently unsyncable. Rows land in this state from any path that inserts without passing the insert trigger — most notably a table rebuild.

## Verification

Same data, both trigger variants:

```
SHIPPED  (OLD = NEW)
  LOST null-row  -> cdc ops: 0, row_version now: None
  ok   ok-row    -> cdc ops: 1, row_version now: 2
FIXED    (OLD IS NEW)
  ok   null-row  -> cdc ops: 1, row_version now: 1
  ok   ok-row    -> cdc ops: 1, row_version now: 2
```

Confirmed end-to-end on a live replica afterwards: a previously-stuck row round-tripped local `row_version 2` → remote `row_version 2`.

`tsc --noEmit` adds no new errors (95 pre-existing, all in `src/resources/mini-app-sdk/*`).

## No migration needed

Existing databases pick this up automatically:

- `_au` CDC trigger — dropped and recreated by `refreshLocalCdcUpdateTrigger`
- bump trigger — dropped and recreated by `ensureLocalRowSyncColumns` via `dropLocalRowSyncTriggers`
- the `changeLogReadyPaths` cache gating both is **in-memory**, so the first sync after restart rewrites them

## Second fix: warn when a table has no PRIMARY KEY

```ts
if (!pkJsonExpr(columns, "NEW")) {
  return false;   // ← every caller ignores this
}
```

Without a PK, `row_pk` cannot be expressed, so the table gets **no insert or delete change capture at all**. Every caller ignores the boolean, so the table just stops syncing: rows accumulate locally, the replica stays empty, and each push still reports success.

This is the real cost of a primary-key loss, and it was completely invisible — two tables in the workspace above sat at 0 rows remotely for this reason while local had data. Now warned once per table.

## Review notes

- The remote counterpart `ensureRemoteTableSyncTriggers` has the same silent `return false`. Left alone here since the remote schema is derived from local and would be noisy to warn on twice, but happy to add it.
- `NOT NULL` / `DEFAULT` drift still isn't part of the schema fingerprint (unchanged from #101) — a NULL version can therefore still be introduced by an external writer; this makes that harmless rather than silent.