### PR TITLE
fix(storage): keep offloaded tool results inline up to the model's own ceiling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4740,21 +4740,22 @@ if (result.valid) {
 3. **Eager parsing** — `loadMessages` parsed both columns for every row, including rows nothing was about to render
 **Solution:**
 1. **Store each payload once** — `tool_calls` stays canonical; `sequence` keeps ordering metadata plus `inputRef`/`outputRef` pointers, rehydrated on read by `restoreSequencePayloads()`. A JSON `null` output stays inline (it serializes to nothing in `tool_calls`, so a pointer could not restore it).
-2. **Offload large payloads** — results over 256KB move to `~/.paprwork-v2/tool-results/<chatId>/<messageId>/<toolCallId>.txt`, leaving a 4KB preview plus a `resultOffload` pointer. `get_full_tool_result` follows the pointer, so **nothing is discarded**. The whole column also has a 1MB budget: the largest remaining results spill until the row fits.
+2. **Offload large payloads** — results over 256KB move to `~/.paprwork-v2/tool-results/<chatId>/<messageId>/<toolCallId>.txt`, leaving a **40K preview** plus a `resultOffload` pointer. `get_full_tool_result` follows the pointer, so **nothing is discarded**. The preview is sized to the default `absoluteMaxChars` (40,000) so the history formatter truncates from the preview exactly as it would from the full result — offloading cannot take away context the model would otherwise have received. The whole column also has a 1MB budget: the largest results spill to sidecars, then previews are re-cut to 4K if previews alone still exceed it.
 3. **Size-guard every read** — `boundedPayloadSql()` returns NULL instead of a column over 2MB, so an oversized row is never pulled into the heap. This stops the crash even before the backfill runs.
 4. **Background backfill** — `startToolPayloadMigration()` compacts existing rows in chunks of 50, entirely inside SQLite via `json_set`/`json_remove`, so a 100MB column is never parsed in JS. Idempotent and resumable via a `tool_payload_migrated` flag.
 **Results (real 3.0GB database, verified byte-for-byte against the untouched original):**
 
 | Sample | Rows before | Rows after | Sidecars | Checks |
 |---|---|---|---|---|
-| 25 largest messages | 1,199MB | **7.6MB** (−99.4%) | 585MB | 2,528 passed, 0 failed |
-| 150 largest messages | 1,958MB | **44.4MB** (−97.7%) | 929MB | 12,309 passed, 0 failed |
+| 150 largest messages | 1,958MB | **53.5MB** (−97.3%) | 930MB | 12,321 passed, 0 failed |
+
+**Consumer impact (checked, not assumed):** the two columns were never "full copy for the UI, trimmed copy for the LLM" — they held the same payload written twice, and the UI/LLM split happens at read time. `sequence[].data.output` and `tool_calls[].result` are written from the identical source value in `messagePersistence.ts`, so rebuilding one from the other is faithful. The chat UI does not render successful tool output at all (`getToolResultFeedback` returns `null` for `success`), and chat export truncates to 500 chars, so preview length is invisible to both.
 
 **Files Created:**
 - `src/gateway/services/storage/messagePayloadStore.ts` — serialize/restore, offload, sidecar I/O
 - `src/gateway/services/storage/toolPayloadMigration.ts` — backfill scheduling and progress
 - `src/gateway/services/storage/toolPayloadRowRewrite.ts` — per-row SQL surgery (json_set/json_remove)
-- `tests/message-payload-store.test.ts` — 11 round-trip/offload tests
+- `tests/message-payload-store.test.ts` — 13 round-trip/offload/preview-budget tests
 - `scripts/test-tool-payload-migration.mjs` — 26 backfill tests (Electron)
 - `scripts/verify-payload-migration-on-real-db.mjs` — losslessness check against a real DB (read-only)
 - `docs/TOOL_PAYLOAD_OFFLOADING.md` — complete documentation

--- a/docs/TOOL_PAYLOAD_OFFLOADING.md
+++ b/docs/TOOL_PAYLOAD_OFFLOADING.md
@@ -51,7 +51,7 @@ restore it.
 ### 2. Move large payloads out of the row
 
 A result over **256 KB** is written to a sidecar file and the row keeps a
-4 KB preview plus a pointer:
+**40 K preview** plus a pointer:
 
 ```
 ~/.paprwork-v2/tool-results/<chatId>/<messageId>/<toolCallId>.txt
@@ -60,7 +60,7 @@ A result over **256 KB** is written to a sidecar file and the row keeps a
 ```jsonc
 {
   "id": "tc-1",
-  "result": "first 4096 chars…\n\n[... 1,203,456 more characters stored outside the database (total 1,207,552). Full result: get_full_tool_result({ toolCallId: \"tc-1\" })]",
+  "result": "first 40000 chars…\n\n[... 1,167,552 more characters stored outside the database (total 1,207,552). Full result: get_full_tool_result({ toolCallId: \"tc-1\" })]",
   "resultOffload": { "file": "tool-results/c1/m1/tc-1.txt", "totalChars": 1207552 }
 }
 ```
@@ -68,9 +68,39 @@ A result over **256 KB** is written to a sidecar file and the row keeps a
 **Nothing is discarded.** `get_full_tool_result` follows the pointer and reads
 the sidecar, so the agent still has the complete text.
 
+#### Why the preview is 40 K
+
+`OFFLOAD_PREVIEW_CHARS` is sized to the default `absoluteMaxChars` (40,000) from
+Settings → Agent Context. Every category limit in `historyFormatter` sits at or
+below that ceiling, so the formatter truncates from the preview exactly as it
+would have from the full result: **offloading cannot take away context the model
+would otherwise have received.**
+
+Two configurations reach past it, and both fall back to the pointer:
+
+- `absoluteMaxChars` raised above 40,000
+- `disableAllTruncation` enabled
+
+In those cases a result over the offload threshold arrives as the preview plus
+the notice, and the agent recovers the rest with `get_full_tool_result` (a
+full-retention tool, so the fetched text is not re-truncated).
+
+Cost of the larger preview, measured on the 150 largest messages of a real
+3.0 GB database: **53.5 MB instead of 44.4 MB** — about 9 MB to keep the default
+model ceiling fully inline.
+
+#### Row budget
+
 Because many medium results can add up, the whole `tool_calls` column also has
-a **1 MB budget**: once exceeded, the largest remaining results spill to
-sidecars until the row fits. Sidecars are deleted with their chat.
+a **1 MB budget**, enforced in two passes:
+
+1. Spill the largest still-inline results to sidecars (40 K preview each).
+2. If previews alone still exceed the budget — dozens of huge results in one
+   turn — re-cut the largest previews to `COMPACT_PREVIEW_CHARS` (4 K), largest
+   first, until the row fits. The full payload is already on disk, so this only
+   trades inline fidelity for a bounded row.
+
+Sidecars are deleted with their chat.
 
 ### 3. Never parse a row large enough to be dangerous
 
@@ -117,11 +147,10 @@ every payload back against the untouched original.
 
 | Sample | Rows in DB before | After | Sidecars | Checks |
 |---|---|---|---|---|
-| 25 largest messages | 1,199 MB | **7.6 MB** (−99.4%) | 585 MB | 2,528 passed, 0 failed |
-| 150 largest messages | 1,958 MB | **44.4 MB** (−97.7%) | 929 MB | 12,309 passed, 0 failed |
+| 150 largest messages | 1,958 MB | **53.5 MB** (−97.3%) | 930 MB | 12,321 passed, 0 failed |
 
 The difference between the original size and (rows + sidecars) is the
-duplication that is now gone — roughly 985 MB across those 150 rows.
+duplication that is now gone — roughly 975 MB across those 150 rows.
 
 ---
 
@@ -148,7 +177,7 @@ duplication that is now gone — roughly 985 MB across those 150 rows.
 ## Testing
 
 ```bash
-npx vitest run tests/message-payload-store.test.ts --project unit-backend   # 11 tests
+npx vitest run tests/message-payload-store.test.ts --project unit-backend   # 13 tests
 npm run test:payload-migration                                              # 26 tests (Electron)
 
 # Optional: prove losslessness against your own database (read-only)
@@ -166,10 +195,17 @@ Electron's runtime and cannot be loaded by plain Node (`ERR_DLOPEN_FAILED`).
 - **Rows still oversized before the backfill reaches them** return no
   `toolCalls`/`sequence` and log a placeholder. The turn stays visible; tool
   detail returns once compacted. This replaces a crash.
-- **The UI shows the preview**, not the sidecar text. The inline notice tells
-  the agent how to fetch the rest. There is no lazy sidecar load in the UI yet.
-- **Chat export** truncates tool results to 500 chars anyway, so the 4 KB
-  preview is unaffected.
+- **The chat UI does not render successful tool output at all**
+  (`getToolResultFeedback` returns `null` for `success`), so preview length is
+  invisible there. `FileWritePreview` renders from `args`, not `result`, with one
+  exception: `bash` needs a `__GIT_CHANGES__:` marker inside `result`, and those
+  payloads are far below the offload threshold.
+- **Error and warning rows** do read `result` to pull out a detail line. An
+  error payload over 256 KB would no longer `JSON.parse`, so the detail falls
+  back to the separate `toolCall.error` field. Error payloads that large are not
+  something we have observed.
+- **Chat export** truncates tool results to 500 chars anyway, well below the
+  preview, so exports are unaffected.
 - **Papr sync** receives the full in-memory message on first sync, before
   SQLite slimming, so cloud fidelity is unchanged.
 

--- a/src/gateway/services/storage/messagePayloadStore.ts
+++ b/src/gateway/services/storage/messagePayloadStore.ts
@@ -15,27 +15,38 @@
  * Reads rehydrate the pointers, so a `StoredMessage` looks exactly as it did
  * before. Nothing is discarded: an offloaded result keeps an inline preview and
  * the full text stays on disk, retrievable via `get_full_tool_result`.
+ *
+ * This module decides what to slim and what to offload; `toolResultSidecars.ts`
+ * owns the sidecar file layout and size budgets, and is re-exported here so
+ * callers have a single entry point.
  */
 
-import fs from "fs";
-import path from "path";
 import type { StoredMessage } from "./IStorageProvider.js";
+import {
+  buildOffloadStub,
+  COMPACT_PREVIEW_CHARS,
+  MAX_ROW_PAYLOAD_CHARS,
+  MIN_SPILL_CHARS,
+  offloadResult,
+  OFFLOAD_PREVIEW_CHARS,
+  OFFLOAD_THRESHOLD_CHARS,
+  type OffloadedResultRef,
+} from "./toolResultSidecars.js";
 
-/** Results longer than this move to a sidecar file instead of living in the row. */
-export const OFFLOAD_THRESHOLD_CHARS = 256 * 1024;
-
-/** How much of an offloaded result stays inline so the UI still shows something. */
-export const OFFLOAD_PREVIEW_CHARS = 4096;
-
-/**
- * Budget for the whole `tool_calls` column. A turn with dozens of results that
- * each sit just under the per-result threshold would otherwise still add up to
- * a huge row, so the largest ones spill to sidecars until the row fits.
- */
-export const MAX_ROW_PAYLOAD_CHARS = 1024 * 1024;
-
-/** Not worth a sidecar file below this size. */
-export const MIN_SPILL_CHARS = 8 * 1024;
+// The sidecar layout and budgets live in toolResultSidecars.ts; re-exported here
+// so callers have one entry point for message payload storage.
+export {
+  buildOffloadStub,
+  COMPACT_PREVIEW_CHARS,
+  deleteChatSidecars,
+  MAX_ROW_PAYLOAD_CHARS,
+  MIN_SPILL_CHARS,
+  OFFLOAD_PREVIEW_CHARS,
+  OFFLOAD_THRESHOLD_CHARS,
+  readOffloadedResult,
+  SIDECAR_DIRNAME,
+  type OffloadedResultRef,
+} from "./toolResultSidecars.js";
 
 /**
  * Largest single column we are willing to pull into JS and parse. Rows written
@@ -43,8 +54,6 @@ export const MIN_SPILL_CHARS = 8 * 1024;
  * enough to exhaust the heap, so the read path skips them instead.
  */
 export const MAX_INLINE_PAYLOAD_BYTES = 2 * 1024 * 1024;
-
-export const SIDECAR_DIRNAME = "tool-results";
 
 /**
  * SQL that yields NULL instead of a payload too large to pull into the heap.
@@ -55,14 +64,6 @@ export function boundedPayloadSql(column: "tool_calls" | "sequence"): string {
     `CASE WHEN LENGTH(${column}) > ${MAX_INLINE_PAYLOAD_BYTES} ` +
     `THEN NULL ELSE ${column} END AS ${column}`
   );
-}
-
-/** Pointer left in `tool_calls` when a result was moved to a sidecar file. */
-export interface OffloadedResultRef {
-  /** Sidecar location, relative to the directory holding chats.db. */
-  file: string;
-  /** Length in characters of the full result. */
-  totalChars: number;
 }
 
 type ToolCallRecord = {
@@ -85,11 +86,6 @@ const INPUT_REF = "toolCall";
 const OUTPUT_REF_STRING = "toolCall:string";
 const OUTPUT_REF_JSON = "toolCall:json";
 
-function sanitizeSegment(value: string): string {
-  const cleaned = value.replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return cleaned.length > 120 ? cleaned.slice(0, 120) : cleaned || "_";
-}
-
 function isToolItem(
   item: SequenceItem,
 ): item is { type: "tool"; data: Record<string, unknown> } {
@@ -99,58 +95,6 @@ function isToolItem(
     item.data !== null &&
     !Array.isArray(item.data)
   );
-}
-
-function buildOffloadNotice(
-  ref: OffloadedResultRef,
-  toolCallId: string,
-  toolName?: string,
-): string {
-  const remaining = ref.totalChars - OFFLOAD_PREVIEW_CHARS;
-  const nameArg = toolName ? `, toolName: "${toolName}"` : "";
-  return (
-    `\n\n[... ${remaining.toLocaleString()} more characters stored outside the database ` +
-    `(total ${ref.totalChars.toLocaleString()}). ` +
-    `Full result: get_full_tool_result({ toolCallId: "${toolCallId}"${nameArg} })]`
-  );
-}
-
-function writeSidecar(absolutePath: string, contents: string): void {
-  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
-  const tmpPath = `${absolutePath}.tmp-${process.pid}-${Date.now()}`;
-  fs.writeFileSync(tmpPath, contents, "utf8");
-  fs.renameSync(tmpPath, absolutePath);
-}
-
-/**
- * Move a single oversized result to a sidecar file.
- * Returns null when the write fails, so the caller keeps the result inline
- * rather than losing it.
- */
-function offloadResult(args: {
-  dbDir: string;
-  chatId: string;
-  messageId: string;
-  toolCallId: string;
-  result: string;
-}): OffloadedResultRef | null {
-  const relativePath = path.join(
-    SIDECAR_DIRNAME,
-    sanitizeSegment(args.chatId),
-    sanitizeSegment(args.messageId),
-    `${sanitizeSegment(args.toolCallId)}.txt`,
-  );
-
-  try {
-    writeSidecar(path.join(args.dbDir, relativePath), args.result);
-    return { file: relativePath, totalChars: args.result.length };
-  } catch (error) {
-    console.error(
-      `[MessagePayloadStore] Failed to offload result for ${args.toolCallId}, keeping it inline:`,
-      error instanceof Error ? error.message : error,
-    );
-    return null;
-  }
 }
 
 /**
@@ -197,13 +141,12 @@ export function serializeMessagePayloads(args: {
     });
     if (!ref) continue;
 
-    tc.result =
-      tc.result.slice(0, OFFLOAD_PREVIEW_CHARS) +
-      buildOffloadNotice(
-        ref,
-        toolCallId,
-        typeof tc.name === "string" ? tc.name : undefined,
-      );
+    tc.result = buildOffloadStub({
+      payload: tc.result,
+      previewChars: OFFLOAD_PREVIEW_CHARS,
+      toolCallId,
+      toolName: typeof tc.name === "string" ? tc.name : undefined,
+    });
     tc.resultOffload = ref;
   }
 
@@ -253,8 +196,12 @@ export function serializeMessagePayloads(args: {
 }
 
 /**
- * Move the largest remaining inline results to sidecars until the row fits the
- * budget. Mutates the records in place.
+ * Bring the row under budget, in two passes.
+ *
+ * First spill the largest results that are still fully inline. Once everything
+ * worth a sidecar has one, the row can still be over budget purely from
+ * previews (40K each adds up), so the second pass shrinks those previews to
+ * COMPACT_PREVIEW_CHARS, largest first. Mutates the records in place.
  */
 function spillLargestUntilRowFits(args: {
   dbDir: string;
@@ -280,7 +227,7 @@ function spillLargestUntilRowFits(args: {
         largest = tc;
       }
     }
-    if (!largest || typeof largest.id !== "string") return;
+    if (!largest || typeof largest.id !== "string") break;
 
     const ref = offloadResult({
       dbDir: args.dbDir,
@@ -289,16 +236,53 @@ function spillLargestUntilRowFits(args: {
       toolCallId: largest.id,
       result: largest.result as string,
     });
-    if (!ref) return;
+    if (!ref) break;
 
-    largest.result =
-      (largest.result as string).slice(0, OFFLOAD_PREVIEW_CHARS) +
-      buildOffloadNotice(
-        ref,
-        largest.id,
-        typeof largest.name === "string" ? largest.name : undefined,
-      );
+    largest.result = buildOffloadStub({
+      payload: largest.result as string,
+      previewChars: OFFLOAD_PREVIEW_CHARS,
+      toolCallId: largest.id,
+      toolName: typeof largest.name === "string" ? largest.name : undefined,
+    });
     largest.resultOffload = ref;
+  }
+
+  shrinkPreviewsUntilRowFits(toolCalls, rowSize);
+}
+
+/**
+ * Last resort once every spillable result already has a sidecar: re-cut the
+ * largest previews down to COMPACT_PREVIEW_CHARS. The full payload is already
+ * safe on disk, so this only trades inline fidelity for a bounded row.
+ */
+function shrinkPreviewsUntilRowFits(
+  toolCalls: ToolCallRecord[],
+  rowSize: () => number,
+): void {
+  while (rowSize() > MAX_ROW_PAYLOAD_CHARS) {
+    let largest: ToolCallRecord | undefined;
+    let largestRef: OffloadedResultRef | undefined;
+    for (const tc of toolCalls) {
+      const ref = tc.resultOffload;
+      if (!ref || typeof tc.result !== "string") continue;
+      if (tc.result.length <= COMPACT_PREVIEW_CHARS) continue;
+      if (!largest || tc.result.length > (largest.result as string).length) {
+        largest = tc;
+        largestRef = ref;
+      }
+    }
+    if (!largest || !largestRef || typeof largest.id !== "string") return;
+
+    // The existing preview starts with the payload's own head, so re-slicing it
+    // yields the same bytes a shorter preview would have taken originally. The
+    // true total comes from the ref, not from the preview we are slicing.
+    largest.result = buildOffloadStub({
+      payload: (largest.result as string).slice(0, COMPACT_PREVIEW_CHARS),
+      previewChars: COMPACT_PREVIEW_CHARS,
+      totalChars: largestRef.totalChars,
+      toolCallId: largest.id,
+      toolName: typeof largest.name === "string" ? largest.name : undefined,
+    });
   }
 }
 
@@ -342,13 +326,12 @@ function offloadOrphanPayload(args: {
 
   return {
     ...data,
-    output:
-      serialized.slice(0, OFFLOAD_PREVIEW_CHARS) +
-      buildOffloadNotice(
-        ref,
-        toolCallId,
-        typeof data.name === "string" ? data.name : undefined,
-      ),
+    output: buildOffloadStub({
+      payload: serialized,
+      previewChars: OFFLOAD_PREVIEW_CHARS,
+      toolCallId,
+      toolName: typeof data.name === "string" ? data.name : undefined,
+    }),
     outputOffload: ref,
   };
 }
@@ -414,32 +397,6 @@ export function restoreSequencePayloads(
   });
 }
 
-/** Read a result that was moved to a sidecar file. */
-export function readOffloadedResult(
-  dbDir: string,
-  ref: OffloadedResultRef,
-): string | null {
-  const root = path.resolve(dbDir, SIDECAR_DIRNAME);
-  const target = path.resolve(dbDir, ref.file);
-
-  // Refs come from our own rows, but a corrupted value should not read
-  // arbitrary files.
-  if (target !== root && !target.startsWith(root + path.sep)) {
-    console.error(`[MessagePayloadStore] Rejected out-of-tree ref: ${ref.file}`);
-    return null;
-  }
-
-  try {
-    return fs.readFileSync(target, "utf8");
-  } catch (error) {
-    console.error(
-      `[MessagePayloadStore] Missing sidecar ${ref.file}:`,
-      error instanceof Error ? error.message : error,
-    );
-    return null;
-  }
-}
-
 /** Find the offload pointer for one tool call, if it has one. */
 export function findOffloadRef(
   message: StoredMessage,
@@ -451,19 +408,6 @@ export function findOffloadRef(
     }
   }
   return null;
-}
-
-/** Drop every sidecar belonging to a chat (called when the chat is deleted). */
-export function deleteChatSidecars(dbDir: string, chatId: string): void {
-  const dir = path.join(dbDir, SIDECAR_DIRNAME, sanitizeSegment(chatId));
-  try {
-    fs.rmSync(dir, { recursive: true, force: true });
-  } catch (error) {
-    console.warn(
-      `[MessagePayloadStore] Could not remove sidecars for chat ${chatId}:`,
-      error instanceof Error ? error.message : error,
-    );
-  }
 }
 
 /**

--- a/src/gateway/services/storage/toolPayloadRowRewrite.ts
+++ b/src/gateway/services/storage/toolPayloadRowRewrite.ts
@@ -14,6 +14,8 @@ import type Database from "better-sqlite3";
 import fs from "fs";
 import path from "path";
 import {
+  buildOffloadStub,
+  COMPACT_PREVIEW_CHARS,
   MAX_ROW_PAYLOAD_CHARS,
   MIN_SPILL_CHARS,
   OFFLOAD_PREVIEW_CHARS,
@@ -75,6 +77,10 @@ export function offloadRowResults(
   // Anything over the per-result threshold goes, plus enough of the rest
   // (largest first) to bring the row under its budget. Results are sorted
   // descending, so the first one not worth a sidecar ends the search.
+  //
+  // Offloading reclaims everything past the preview, not the whole result, so
+  // the projection has to leave the preview behind or it will stop selecting
+  // too early and leave the row over budget.
   let inlineTotal = elements.reduce((sum, e) => sum + e.result_len, 0);
   const selected: typeof elements = [];
   for (const element of elements) {
@@ -85,8 +91,15 @@ export function offloadRowResults(
     }
     if (!element.tool_call_id) continue;
     selected.push(element);
-    inlineTotal -= element.result_len;
+    inlineTotal -= Math.max(element.result_len - OFFLOAD_PREVIEW_CHARS, 0);
   }
+
+  // Enough huge results and the previews alone exceed the budget. Nothing more
+  // can be moved out at that point, so trade inline fidelity for a bounded row.
+  const previewChars =
+    inlineTotal > MAX_ROW_PAYLOAD_CHARS
+      ? COMPACT_PREVIEW_CHARS
+      : OFFLOAD_PREVIEW_CHARS;
 
   // Paths are built in JS and bound as text; letting SQLite concatenate the
   // index risks a float creeping in.
@@ -119,6 +132,7 @@ export function offloadRowResults(
       toolCallId,
       toolName: element.tool_name,
       payload: result,
+      previewChars,
     });
     if (!moved) continue;
 
@@ -151,6 +165,7 @@ function moveToSidecar(args: {
   toolCallId: string;
   toolName: string | null;
   payload: string;
+  previewChars: number;
 }): { ref: { file: string; totalChars: number }; stub: string } | null {
   const relativePath = path.join(
     SIDECAR_DIRNAME,
@@ -171,15 +186,17 @@ function moveToSidecar(args: {
     return null;
   }
 
-  const total = args.payload.length;
-  const nameArg = args.toolName ? `, toolName: "${args.toolName}"` : "";
-  const stub =
-    args.payload.slice(0, OFFLOAD_PREVIEW_CHARS) +
-    `\n\n[... ${(total - OFFLOAD_PREVIEW_CHARS).toLocaleString()} more characters ` +
-    `stored outside the database (total ${total.toLocaleString()}). ` +
-    `Full result: get_full_tool_result({ toolCallId: "${args.toolCallId}"${nameArg} })]`;
+  const stub = buildOffloadStub({
+    payload: args.payload,
+    previewChars: args.previewChars,
+    toolCallId: args.toolCallId,
+    toolName: args.toolName ?? undefined,
+  });
 
-  return { ref: { file: relativePath, totalChars: total }, stub };
+  return {
+    ref: { file: relativePath, totalChars: args.payload.length },
+    stub,
+  };
 }
 
 /**
@@ -244,6 +261,7 @@ export function offloadRowSequenceOutputs(
       toolCallId,
       toolName: item.tool_name,
       payload: output,
+      previewChars: OFFLOAD_PREVIEW_CHARS,
     });
     if (!moved) continue;
 

--- a/src/gateway/services/storage/toolResultSidecars.ts
+++ b/src/gateway/services/storage/toolResultSidecars.ts
@@ -1,0 +1,169 @@
+/**
+ * Sidecar storage for oversized tool results.
+ *
+ * A result too large to keep in a SQLite row moves to a file under
+ * `<dbDir>/tool-results/<chatId>/<messageId>/<toolCallId>.txt`, and the row
+ * keeps a preview plus a pointer to it. Nothing is discarded — the full text
+ * stays on disk and `get_full_tool_result` follows the pointer.
+ *
+ * This module owns the file layout, the size budgets and the inline stub
+ * format. `messagePayloadStore.ts` decides which results to offload on write,
+ * and `toolPayloadRowRewrite.ts` does the same for existing rows.
+ */
+
+import fs from "fs";
+import path from "path";
+
+/** Results longer than this move to a sidecar file instead of living in the row. */
+export const OFFLOAD_THRESHOLD_CHARS = 256 * 1024;
+
+/**
+ * How much of an offloaded result stays inline.
+ *
+ * Sized to the default `absoluteMaxChars` (40,000) so offloading never takes
+ * away context the model would otherwise have received: the history formatter
+ * caps every category at or below that ceiling, so it truncates from the
+ * preview exactly as it would have from the full result. The tail beyond this
+ * is only reachable via `get_full_tool_result`, which is a full-retention tool.
+ *
+ * Raising `absoluteMaxChars` above this in Settings -> Agent Context (or turning
+ * truncation off) means results over the offload threshold reach the model as
+ * this preview plus a pointer rather than in full.
+ */
+export const OFFLOAD_PREVIEW_CHARS = 40_000;
+
+/**
+ * Fallback preview used when the row budget cannot be met otherwise. Keeping
+ * 40K per result would blow the budget on a turn with dozens of huge results,
+ * so those degrade to a short preview instead of an unbounded row.
+ */
+export const COMPACT_PREVIEW_CHARS = 4096;
+
+/**
+ * Budget for the whole `tool_calls` column. A turn with dozens of results that
+ * each sit just under the per-result threshold would otherwise still add up to
+ * a huge row, so the largest ones spill to sidecars until the row fits.
+ */
+export const MAX_ROW_PAYLOAD_CHARS = 1024 * 1024;
+
+/** Not worth a sidecar file below this size. */
+export const MIN_SPILL_CHARS = 8 * 1024;
+
+export const SIDECAR_DIRNAME = "tool-results";
+
+/** Pointer left in `tool_calls` when a result was moved to a sidecar file. */
+export interface OffloadedResultRef {
+  /** Sidecar location, relative to the directory holding chats.db. */
+  file: string;
+  /** Length in characters of the full result. */
+  totalChars: number;
+}
+
+function sanitizeSegment(value: string): string {
+  const cleaned = value.replace(/[^a-zA-Z0-9_.-]/g, "_");
+  return cleaned.length > 120 ? cleaned.slice(0, 120) : cleaned || "_";
+}
+
+/**
+ * Inline stand-in for an offloaded result: the head of the payload plus a
+ * notice telling the reader how to reach the rest. Shared with the backfill so
+ * a row written today and a row migrated later look identical.
+ */
+export function buildOffloadStub(args: {
+  payload: string;
+  previewChars: number;
+  toolCallId: string;
+  toolName?: string;
+  /**
+   * Length of the original result. Required when `payload` is itself already a
+   * preview, since its length no longer describes the full payload.
+   */
+  totalChars?: number;
+}): string {
+  const total = args.totalChars ?? args.payload.length;
+  const remaining = Math.max(total - args.previewChars, 0);
+  const nameArg = args.toolName ? `, toolName: "${args.toolName}"` : "";
+  return (
+    args.payload.slice(0, args.previewChars) +
+    `\n\n[... ${remaining.toLocaleString()} more characters stored outside the database ` +
+    `(total ${total.toLocaleString()}). ` +
+    `Full result: get_full_tool_result({ toolCallId: "${args.toolCallId}"${nameArg} })]`
+  );
+}
+
+function writeSidecar(absolutePath: string, contents: string): void {
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  const tmpPath = `${absolutePath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmpPath, contents, "utf8");
+  fs.renameSync(tmpPath, absolutePath);
+}
+
+/**
+ * Move a single oversized result to a sidecar file.
+ * Returns null when the write fails, so the caller keeps the result inline
+ * rather than losing it.
+ */
+export function offloadResult(args: {
+  dbDir: string;
+  chatId: string;
+  messageId: string;
+  toolCallId: string;
+  result: string;
+}): OffloadedResultRef | null {
+  const relativePath = path.join(
+    SIDECAR_DIRNAME,
+    sanitizeSegment(args.chatId),
+    sanitizeSegment(args.messageId),
+    `${sanitizeSegment(args.toolCallId)}.txt`,
+  );
+
+  try {
+    writeSidecar(path.join(args.dbDir, relativePath), args.result);
+    return { file: relativePath, totalChars: args.result.length };
+  } catch (error) {
+    console.error(
+      `[ToolResultSidecars] Failed to offload result for ${args.toolCallId}, keeping it inline:`,
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+}
+
+/** Read a result that was moved to a sidecar file. */
+export function readOffloadedResult(
+  dbDir: string,
+  ref: OffloadedResultRef,
+): string | null {
+  const root = path.resolve(dbDir, SIDECAR_DIRNAME);
+  const target = path.resolve(dbDir, ref.file);
+
+  // Refs come from our own rows, but a corrupted value should not read
+  // arbitrary files.
+  if (target !== root && !target.startsWith(root + path.sep)) {
+    console.error(`[ToolResultSidecars] Rejected out-of-tree ref: ${ref.file}`);
+    return null;
+  }
+
+  try {
+    return fs.readFileSync(target, "utf8");
+  } catch (error) {
+    console.error(
+      `[ToolResultSidecars] Missing sidecar ${ref.file}:`,
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+}
+
+/** Drop every sidecar belonging to a chat (called when the chat is deleted). */
+export function deleteChatSidecars(dbDir: string, chatId: string): void {
+  const dir = path.join(dbDir, SIDECAR_DIRNAME, sanitizeSegment(chatId));
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch (error) {
+    console.warn(
+      `[ToolResultSidecars] Could not remove sidecars for chat ${chatId}:`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+}

--- a/tests/message-payload-store.test.ts
+++ b/tests/message-payload-store.test.ts
@@ -14,6 +14,7 @@ import {
   SIDECAR_DIRNAME,
 } from "../src/gateway/services/storage/messagePayloadStore.js";
 import type { StoredMessage } from "../src/gateway/services/storage/IStorageProvider.js";
+import { ABSOLUTE_TOOL_RESULT_MAX_CHARS } from "../src/gateway/services/agent/toolResultTruncation.js";
 
 let dbDir: string;
 
@@ -228,6 +229,67 @@ describe("offloading oversized results", () => {
 
     // Every spilled result is still readable in full.
     for (const tc of offloaded) {
+      expect(readOffloadedResult(dbDir, tc.resultOffload)).toBe(chunk);
+    }
+  });
+
+  it("keeps enough inline for the model's own truncation ceiling", () => {
+    // The history formatter caps every category at or below absoluteMaxChars, so
+    // as long as the preview covers that ceiling, offloading cannot take away
+    // context the model would otherwise have received.
+    const result = "y".repeat(OFFLOAD_THRESHOLD_CHARS * 4);
+    const { toolCallsJson } = serializeMessagePayloads({
+      dbDir,
+      chatId: "chat-1",
+      messageId: "msg-1",
+      message: baseMessage({
+        toolCalls: [
+          { id: "tc-1", name: "read_file", args: {}, result, status: "success" },
+        ],
+      }),
+    });
+
+    const stored = JSON.parse(toolCallsJson!)[0];
+    expect(stored.result.length).toBeGreaterThanOrEqual(
+      ABSOLUTE_TOOL_RESULT_MAX_CHARS,
+    );
+    expect(stored.result.startsWith(result.slice(0, ABSOLUTE_TOOL_RESULT_MAX_CHARS))).toBe(
+      true,
+    );
+  });
+
+  it("degrades previews rather than exceeding the row budget", () => {
+    // Enough huge results that even the previews would blow the budget.
+    const chunk = "w".repeat(OFFLOAD_THRESHOLD_CHARS + 50_000);
+    const toolCalls = Array.from({ length: 40 }, (_, i) => ({
+      id: `tc-${i}`,
+      name: "bash",
+      args: {},
+      result: chunk,
+    }));
+
+    const { toolCallsJson } = serializeMessagePayloads({
+      dbDir,
+      chatId: "chat-1",
+      messageId: "msg-1",
+      message: baseMessage({ toolCalls }),
+    });
+
+    const stored = JSON.parse(toolCallsJson!);
+    const inlineChars = stored.reduce(
+      (sum: number, tc: any) => sum + tc.result.length,
+      0,
+    );
+    expect(inlineChars).toBeLessThanOrEqual(MAX_ROW_PAYLOAD_CHARS);
+
+    // Some previews were cut short, and every one still reports the true total
+    // and reads back in full.
+    expect(
+      stored.some((tc: any) => tc.result.length < OFFLOAD_PREVIEW_CHARS),
+    ).toBe(true);
+    for (const tc of stored) {
+      expect(tc.resultOffload.totalChars).toBe(chunk.length);
+      expect(tc.result).toContain(chunk.length.toLocaleString());
       expect(readOffloadedResult(dbDir, tc.resultOffload)).toBe(chunk);
     }
   });


### PR DESCRIPTION
Follow-up to #100. That PR bounded the rows that were crashing the gateway, but its 4KB inline preview shortened what the model sees. This restores that fidelity and fixes a budget-accounting bug in the backfill.

## The defect

#100 moves any tool result over 256KB to a sidecar file and leaves a preview plus a pointer in the row. The preview was 4KB.

But the history formatter's default `absoluteMaxChars` is **40,000** — for a result of, say, 300KB, the model used to receive 40KB of it. After #100 it receives 4KB. Offloading was supposed to bound memory, not shorten context.

Nothing was lost from disk in either case (the full text is in the sidecar), but the model's default view got smaller, which is a behavior change #100 did not intend.

## What changed

**Preview sized to the model's ceiling.** `OFFLOAD_PREVIEW_CHARS` is now 40,000, matching the default `absoluteMaxChars`. Truncation happens where it did before offloading existed: the formatter cuts the preview at exactly the point it would have cut the full result.

**Compact fallback so the row budget still converges.** A turn with 40 huge results would need 1.6MB of previews against a 1MB column budget. Those degrade to a 4KB `COMPACT_PREVIEW_CHARS` rather than producing an unbounded row — the case that caused the OOM. Both paths keep the full text in the sidecar, reachable via `get_full_tool_result` (a full-retention tool, so the fetched text is not re-truncated).

**Backfill spill accounting fix.** `offloadRowResults` projected the post-offload row size by subtracting each result's *whole* length, ignoring the preview it leaves behind. With generous previews that stops the selection loop early and leaves the row over budget. It now subtracts `result_len - previewChars`, and drops to the compact preview when even that will not fit.

**`buildOffloadStub` now takes an explicit `totalChars`.** When shrinking a preview that is *already* a preview, its length no longer describes the original payload, so the "N more characters" notice would have misreported. Callers in that position pass the ref's `totalChars`.

**File split for the LOC limit.** `messagePayloadStore.ts` reached 554 lines. Sidecar layout, size budgets and stub formatting move to `toolResultSidecars.ts` (169 lines), re-exported from the store (423 lines) so no caller's imports change.

## Cost

Measured on the 150 largest messages of a real 3.0GB database: **53.5MB instead of 44.4MB** — about 9MB to keep the default model ceiling fully inline, against 1,958MB before offloading.

## Verification

| Check | Result |
|---|---|
| `tests/message-payload-store.test.ts` | 13 passed (2 new: ceiling coverage, budget degradation) |
| `npm run test:payload-migration` | 26 passed, 0 failed |
| Real 3.0GB DB, 150 largest messages | 1,958MB → **53.5MB** (−97.3%), 930MB sidecars, **12,321 checks passed, 0 failed** |
| `tsc -p tsconfig.gateway.json` | clean |
| LOC limit | 423 / 169 / 371, all under 500 |

The real-DB script (`scripts/verify-payload-migration-on-real-db.mjs`) copies the largest messages to a scratch DB, migrates the copy, and compares every payload byte-for-byte against the untouched original — including reading each sidecar back.

The two new unit tests cover the specific regressions: one asserts a result just over the offload threshold retains at least `ABSOLUTE_TOOL_RESULT_MAX_CHARS` inline; the other builds 40 oversized results and asserts the column stays under budget *and* every full payload is still recoverable.

## Not in scope

The chat UI does not render successful tool output at all (`getToolResultFeedback` returns `null` for `success`) and export truncates to 500 chars, so preview length is invisible to both. A UI "expand full output" affordance for offloaded results remains a separate follow-up.

Made with [Cursor](https://cursor.com)