### PR TITLE
Stop losing remote tables when a schema rebuild is interrupted

### DIFF
--- a/src/gateway/services/syncV3/schemaDriftHeal.ts
+++ b/src/gateway/services/syncV3/schemaDriftHeal.ts
@@ -15,9 +15,7 @@ import {
 import type { JobMigrationSchemaOp } from "../../../core/types/jobMigrations.js";
 import { resolveMigrationRootFromDbPath } from "../jobs/databaseMigrations.js";
 import { migrationSatisfiedOnRemote } from "../jobs/jobMigrationLedgerSync.js";
-import {
-  normalizeMigrationIdList,
-} from "../jobs/migrationIdNormalize.js";
+import { normalizeMigrationIdList } from "../jobs/migrationIdNormalize.js";
 import {
   migrationHasExecutableOps,
   shouldSkipMigrationForRemoteLedger,
@@ -59,6 +57,23 @@ async function openRemoteClient(
 }
 
 const REBUILD_SUFFIX = "__papr_rebuild";
+const OLD_SUFFIX = "__papr_old";
+
+/**
+ * Rebuilds are expensive (they copy every row) and the remote apply is capped
+ * by a timeout. Shipping several in one payload means a slow table starves the
+ * rest and the whole payload is retried from the start each sync, so nothing
+ * ever converges. One per pass converges steadily instead.
+ */
+const MAX_REBUILDS_PER_PASS = 1;
+
+/** Scaffolding left behind by an interrupted rebuild. */
+function staleRebuildCleanupOps(tableName: string): JobMigrationSchemaOp[] {
+  return [
+    `DROP TABLE IF EXISTS ${quoteIdent(`${tableName}${REBUILD_SUFFIX}`)}`,
+    `DROP TABLE IF EXISTS ${quoteIdent(`${tableName}${OLD_SUFFIX}`)}`,
+  ].map((statement) => ({ kind: "sql" as const, statement }));
+}
 
 function columnDefinition(col: TableColumn, inlinePk: boolean): string {
   const type = col.type.trim() || "TEXT";
@@ -114,10 +129,28 @@ function buildRemoteTableRebuildOps(
       `INSERT OR IGNORE INTO ${quoteIdent(temp)} (${carried}) SELECT ${carried} FROM ${quoteIdent(tableName)}`,
     );
   }
-  statements.push(`DROP TABLE ${quoteIdent(tableName)}`);
+  // Swap by renaming rather than DROP-then-RENAME.
+  //
+  // These statements are applied one at a time on the remote and the run can
+  // be cut short by a timeout. DROP TABLE followed by ALTER ... RENAME leaves
+  // a window in which the real table has been destroyed and its replacement
+  // has not been installed: if the run dies there, the table is simply gone
+  // from the replica and the web app 500s with "no such table" until a later
+  // sync recreates it. Observed repeatedly on a slow link — a different table
+  // vanished on each attempt.
+  //
+  // Renaming the original aside first keeps the data reachable the whole time.
+  // The only gap is between two metadata-only renames, and a run that dies in
+  // it leaves the rows in `__papr_old` rather than deleting them.
+  const old = `${tableName}${OLD_SUFFIX}`;
+  statements.push(`DROP TABLE IF EXISTS ${quoteIdent(old)}`);
+  statements.push(
+    `ALTER TABLE ${quoteIdent(tableName)} RENAME TO ${quoteIdent(old)}`,
+  );
   statements.push(
     `ALTER TABLE ${quoteIdent(temp)} RENAME TO ${quoteIdent(tableName)}`,
   );
+  statements.push(`DROP TABLE IF EXISTS ${quoteIdent(old)}`);
 
   return statements.map((statement) => ({ kind: "sql" as const, statement }));
 }
@@ -146,6 +179,7 @@ async function buildColumnDriftHealOps(
   driftedTables: readonly string[],
 ): Promise<JobMigrationSchemaOp[]> {
   const ops: JobMigrationSchemaOp[] = [];
+  let rebuilds = 0;
   for (const tableName of driftedTables) {
     const exists = await remote.execute({
       sql: `SELECT 1 FROM sqlite_master WHERE type='table' AND name = ? LIMIT 1`,
@@ -159,6 +193,9 @@ async function buildColumnDriftHealOps(
         .get(tableName) as { sql?: string } | undefined;
       const ddl = ddlRow?.sql?.trim();
       if (ddl) {
+        // The table may be missing because an earlier rebuild was interrupted,
+        // in which case its scaffolding is still there holding a stale copy.
+        ops.push(...staleRebuildCleanupOps(tableName));
         const statement = ddl.toLowerCase().includes("if not exists")
           ? ddl
           : ddl.replace(/^create table/i, "CREATE TABLE IF NOT EXISTS");
@@ -176,6 +213,13 @@ async function buildColumnDriftHealOps(
     // drifts that way needs a full rebuild. Emitting add_column ops here (or
     // nothing at all) leaves the table permanently drifted.
     if (incompatibleColumns(localCols, remoteCols).length > 0) {
+      if (rebuilds >= MAX_REBUILDS_PER_PASS) {
+        // Leave the rest for the next pass rather than building a payload too
+        // large to finish; a truncated payload heals nothing and is retried
+        // whole, so batching them makes convergence slower, not faster.
+        continue;
+      }
+      rebuilds += 1;
       ops.push(...buildRemoteTableRebuildOps(tableName, localAll, remoteAll));
       continue;
     }
@@ -291,7 +335,10 @@ export async function healSchemaDriftIfNeeded(
   if (!remoteHandle2) {
     return 0;
   }
-  const localDb2 = new Database(dbPath, { readonly: true, fileMustExist: true });
+  const localDb2 = new Database(dbPath, {
+    readonly: true,
+    fileMustExist: true,
+  });
   let ops: JobMigrationSchemaOp[] = [];
   try {
     ops = await buildColumnDriftHealOps(


### PR DESCRIPTION
Follow-up to #101. That PR made drift healing rebuild a table when a PRIMARY KEY or column type differs. The rebuild's final swap had a window that could destroy the table outright.

## The window

The rebuild ended with:

```sql
DROP TABLE "t";
ALTER TABLE "t__papr_rebuild" RENAME TO "t";
```

The remote applies statements one at a time and the run is capped by a timeout. If it ends between those two, the real table is already gone and its replacement was never installed — the table is simply missing from the replica, and the web app returns 500 `no such table` until a later sync recreates it.

On a slow link this reproduced repeatedly, with a different table vanishing on each attempt.

## The fix

Swap by renaming, never by dropping the live table:

```sql
DROP TABLE IF EXISTS "t__papr_old";
ALTER TABLE "t" RENAME TO "t__papr_old";      -- data still reachable
ALTER TABLE "t__papr_rebuild" RENAME TO "t";  -- new table live
DROP TABLE IF EXISTS "t__papr_old";           -- reclaim
```

The rows stay reachable throughout. The only gap is between two metadata-only renames, and a run that dies inside it leaves the data in `__papr_old` rather than deleting it.

## Supporting changes

**One rebuild per pass.** Rebuilds copy every row and the remote apply is time-capped, so several in one payload let a slow table starve the rest. Since the payload is retried whole, batching made convergence *slower* — a truncated payload heals nothing and starts over. One per pass converges steadily.

**Clear stale scaffolding before recreating a missing table.** A table can be missing precisely because an earlier rebuild was interrupted, in which case `__papr_rebuild` / `__papr_old` are still present holding a stale copy. Both are now dropped before the `CREATE TABLE IF NOT EXISTS`.

## Verification

- `tests/turso-schema-migration.test.ts` — 8 passed
- `tests/cloud-publish-drift.test.ts` — 24 passed
- `tsc -p tsconfig.gateway.json` — clean
- `oxfmt --check` — clean (also normalized two pre-existing lines in this file)

The failure this fixes is timing-dependent on a slow remote, so it is not covered by a unit test; the change is a reordering of the emitted DDL, which the existing tests exercise for shape.

Made with [Cursor](https://cursor.com)