### PR TITLE
Serve the App Files SDK as ESM so mini-apps can import it

### DIFF
--- a/src/gateway/utils/registerPaprMiniAppSdkRoutes.ts
+++ b/src/gateway/utils/registerPaprMiniAppSdkRoutes.ts
@@ -71,8 +71,14 @@ export function registerPaprMiniAppSdkRoutes(app: Express): void {
   );
   // Served from the same place in both runtimes, so `papr.files.*` is one
   // import that behaves identically on desktop and apps.papr.ai.
+  //
+  // ESM, not the iife default: this module is consumed as
+  // `import { papr } from '/__papr__/papr-files.js'` and exports no window
+  // global, so an iife bundle exposes nothing. The import then throws
+  // "does not provide an export named 'papr'" — a module-level SyntaxError
+  // that aborts the whole app bundle, so the mini-app renders blank.
   app.get("/__papr__/papr-files.js", (req, res) =>
-    serveSdkFile("papr-files.ts", req, res),
+    serveSdkFile("papr-files.ts", req, res, "esm"),
   );
   app.get("/__papr__/papr-markdown.js", (req, res) =>
     serveSdkFile("papr-markdown.ts", req, res),


### PR DESCRIPTION
## Symptom

A mini-app that uses `papr.files.*` renders **completely blank**. No content, no partial UI, nothing — the only clue is in the devtools console:

```
Uncaught SyntaxError: The requested module '/__papr__/papr-files.js'
does not provide an export named 'papr'        ← dist/app.js:3
```

This is easy to misread as data loss. On the app I was debugging, the database was fine the whole time (654 rows, `integrity_check ok`) and `/api/db/query` returned correct rows — the UI just never executed.

## Cause

```ts
app.get("/__papr__/papr-files.js", (req, res) =>
  serveSdkFile("papr-files.ts", req, res),      // format defaults to "iife"
);
```

`serveSdkFile` defaults to `iife`, but this module is consumed as an ES import — its own docblock and `SystemPrompt.ts` both tell app authors to write:

```ts
import { papr } from '/__papr__/papr-files.js';
```

`papr-files.ts` exports `export const papr = {...}` (line 168) and sets **no** window global, so an iife bundle exposes nothing whatsoever to the importer.

Because a failed import is a **module-level SyntaxError**, the whole app bundle is aborted before any of it runs. Hence a blank screen rather than a broken file-picker.

The sibling ESM modules pass the argument explicitly:

```ts
serveSdkFile("papr-job-events.ts", req, res, "esm");
serveSdkFile("papr-preview-lifecycle.ts", req, res, "esm");
```

This route was just missing it.

## Verification

Bundling the same entrypoint both ways:

```
iife  -> no export statement anywhere
esm   -> export { papr_files_default as default, papr };
```

`tsc -p tsconfig.gateway.json` — 0 errors.

## Scope: only this route

I checked every other SDK route rather than changing them all:

| Module | exports | window global | verdict |
|---|---|---|---|
| `papr-files` | 1 | no | **broken — fixed here** |
| `papr-auth-guard` | 0 | yes | iife correct |
| `papr-version-check` | 0 | no | side-effect script, iife correct |
| `papr-agent-chat` | 1 | yes | iife correct |
| `papr-markdown` | 1 | no | bundled via relative import, never fetched |
| `papr-auth-ui` | 9 | no | bundled via relative import, never fetched |
| `papr-agent-chat-plan` | 2 | no | bundled via relative import, never fetched |

The last three are pulled in at build time (`import ... from "./papr-markdown.js"` inside `papr-agent-chat.ts` / `papr-auth-guard.ts`) and are never imported over HTTP by an app, so their export shape never reaches a browser import.

## Not a regression

`git log -S` shows the route has been `iife` since it was introduced in `6303cd3` (*feat(app-files): durable resume + mini-app SDK (Phase 4)*). The App Files SDK has therefore **never** been usable from a mini-app — any app that adopted it would have gone blank immediately.

## Review note

Two things that made this cost far more time than a one-word diff should:

1. `serveSdkFile`'s `format` parameter defaults to `iife`, so getting it wrong is silent. Since ESM-vs-iife is decidable from the source (does it export, or set a global?), it may be worth defaulting to `esm` for modules with exports, or making the argument required so each route states its intent.
2. The Content-Type ternary returns the identical string in both branches, implying a distinction that does not exist. Left alone to keep this diff to one line, but it is misleading.