### PR TITLE
Stop the gateway OOM caused by an unbounded Sync V3 outbox read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4772,4 +4772,63 @@ if (result.valid) {
 
 ---
 
+### Issue 71: Gateway OOM — Sync V3 Writer Outbox Read Unbounded ✅ FIXED
+**Added:** 2026-08-23
+**Severity:** CRITICAL — gateway died on every launch
+**Problem:** The gateway hit a V8 heap OOM roughly 70 seconds after each start. The allocation that killed it was `fs.readFile(outboxPath(), "utf8")` in `SyncOutbox.readAllLines()` against a **1.6GB** `sync-outbox.jsonl` — 869 entries, 868 still pending, with three individual lines around 520MB each. `appSyncV3StatusReport` called into the outbox several times per app shortly after startup, which is what placed the read ~70s in rather than at boot.
+**Root Causes:** Four compounding problems, not one:
+1. **No size cap on an entry** — a writer op carries the bytes of every file it touches, and the Papr Data Room app keeps uploaded PDFs and images inside its app directory
+2. **Binary read as UTF-8 JSON** — a JPEG read as `utf8` both bloats (invalid sequences become U+FFFD, 3 bytes each) and corrupts, so the blob was large *and* useless
+3. **A crash did not count as an attempt** — `markOutboxInflight` left `attempts` untouched, so the entry that killed the process was retried forever and never dead-lettered
+4. **Nothing coalesced duplicates** — every debounced flush appended a fresh op for the same app and paths without retiring the older pending ones
+
+Head-of-line blocking with a poison pill at the front: the queue could only grow, and reading it to find out what to do was itself the crash.
+
+**Solution — Layer 1, gateway guardrails:**
+1. **Bounded reads** (`syncV3/outboxFile.ts`, new) — `streamJsonlLines` walks bytes and only decodes a line once it is complete *and* under the cap. An oversized line is never turned into a string; its bytes stream to a `.oversized` quarantine file so the entries behind it drain and the payload stays on disk. `MAX_OUTBOX_LINE_BYTES` = 16MB (one op, set well above the collector's 6MB batch budget so JSON escaping cannot turn an acceptable batch into an unwritable line), `MAX_OUTBOX_FILE_BYTES` = 64MB (whole queue).
+2. **Cap at enqueue** — `appendOutboxEntry` throws `OutboxEntryTooLargeError` rather than writing a line that can never be read back.
+3. **A crash counts as an attempt** — `markOutboxInflight` increments `attempts`, so a poison pill reaches the dead-letter threshold.
+4. **Dead-lettering strips payloads** — keeps `droppedFileCount` + `droppedFilePaths` instead of `files[].content`.
+5. **Coalescing** — a new op supersedes older pending ops for the same app covering the same paths.
+6. **File budget backstop** — `trimToFileBudget` sheds the oldest work past 64MB. Dropped ops are recollectible from the filesystem, so this costs a re-scan, not data.
+7. **One read per status report** — `appSyncV3StatusReport` calls `listOutboxEntries` once and filters, instead of three reads per app. Same bounded read replaced the unbounded one in `metadataOutbox.ts`.
+
+**Solution — Layer 2, keep the bytes out:**
+1. **Correct never-track matching** — `matchesNeverTrackPathspec` matched by substring, so `*.db` excluded `sandbox.ts` and `*.bak.*` excluded anything containing `bak`; legitimate source files were silently dropped from sync. `isNeverTrackRepoPath` anchors matching (extensions against the basename suffix, directory specs against path segments). Added `*.db-journal` to `NEVER_TRACK_PATHSPECS`.
+2. **Exclude before reading** — the walkers in `collectAppOpFiles` test `isNeverTrackRepoPath` while walking, so a 500MB `database.db` is skipped by name and never read. `candidateToOpFile` checks `stat.size` *before* `fs.readFile`.
+3. **Aggregate batch budget** — per-file limits do not bound a batch (a thousand 5MB files still overflow). `MAX_OP_BATCH_CONTENT_BYTES` = 6MB caps total content per op; the remainder is counted as `deferred` and propagates through `PushAppViaWriterResult` → `FinalizeAppRepoMutationResult` → `cloudAppWriterDebouncedPush`, which re-queues the app. A large app syncs across several flushes instead of one unwritable op.
+4. OID cache is read once per flush rather than once per file.
+
+**Results (real production outbox, reconstructed in an isolated workspace):**
+
+| | Before | After |
+|---|---|---|
+| Reading the queue | OOM, process dies | completes in 2.3s |
+| Peak heap growth | unbounded — a 1.5GB string | **98MB** |
+| Entries recovered | 0 (crash) | **303**, all pending |
+| Queue on disk | 1521MB | **32MB** |
+| Oversized bytes | blocking the queue | 1489MB quarantined |
+
+**Files Created:**
+- `src/gateway/services/syncV3/outboxFile.ts` — streaming bounded JSONL reads, quarantine, compaction
+- `tests/sync-outbox-guardrails.test.ts` — 15 tests (streaming, enqueue cap, attempts, stripping, coalescing, recovery)
+- `tests/never-track-repo-path.test.ts` — 9 tests (anchored matching; `sandbox.ts` is *not* excluded)
+- `tests/sync-outbox-recovery-fixture.test.ts` — full recovery against a real oversized outbox (skipped unless `OUTBOX_FIXTURE` is set)
+- `docs/SYNC_V3_OUTBOX_GUARDRAILS.md` — complete documentation
+**Files Changed:**
+- `syncV3/SyncOutbox.ts` — bounded reads, enqueue cap, attempts on inflight, payload stripping, coalescing, file budget
+- `syncV3/metadataOutbox.ts` — bounded reads
+- `syncV3/appSyncV3StatusReport.ts` — single read per app
+- `syncV3/collectAppOpFiles.ts` — exclusion while walking, size check before read, batch budget, cached OIDs
+- `syncV3/pushAppViaWriterOps.ts`, `pushAppWriterOpsCore.ts`, `finalizeAppRepoMutation.ts` — `deferred` count
+- `cloudAgentGateway/cloudAppWriterDebouncedPush.ts` — re-queue apps with deferred files
+- `appRepoWriter/abuseFilter.ts` — `isNeverTrackRepoPath` replaces substring matching
+- `cloudSync/repoHygiene.ts` — added `*.db-journal`
+**Testing:** `npx vitest run tests/sync-outbox-guardrails.test.ts tests/never-track-repo-path.test.ts tests/collect-app-op-files.test.ts --project unit-backend` (30 tests). For the real-data path, set `OUTBOX_FIXTURE` to a `:`-joined list of outbox files.
+**App authors:** guardrails stop the crash but do not make large assets sync — an app keeping uploads in its own directory will see them rejected. Store them with App Files and keep the reference in SQLite.
+**Prevention:** Never `fs.readFile` a file whose size is controlled by user data — stream it, bound it, or check `stat.size` first. Cap a queue entry at enqueue; a line that cannot be read back is worse than a rejected write. Charge an attempt when work is picked up, not when it fails. Per-item limits do not bound a batch — add an aggregate budget and a way to defer the remainder. Anchor glob matching.
+**See:** `docs/SYNC_V3_OUTBOX_GUARDRAILS.md`
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**

--- a/docs/SYNC_V3_OUTBOX_GUARDRAILS.md
+++ b/docs/SYNC_V3_OUTBOX_GUARDRAILS.md
@@ -1,0 +1,198 @@
+# Sync V3 Outbox Guardrails
+
+**Added:** 2026-08-23
+**Severity of the bug this fixes:** CRITICAL — gateway OOM on every launch
+
+## The crash
+
+The gateway died with a V8 heap OOM roughly 70 seconds after every start. The
+allocation that killed it was a single string:
+
+```
+FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
+```
+
+The file behind it was the Sync V3 writer outbox:
+
+```
+~/Papr/orgs/<org>/namespaces/<ns>/data/sync-outbox.jsonl   1.6 GB
+```
+
+869 entries, 868 of them still pending, and three individual lines of roughly
+520 MB each. `SyncOutbox.readAllLines()` did this:
+
+```ts
+const raw = await fs.readFile(outboxPath(), "utf8"); // 1.6 GB as one JS string
+```
+
+`appSyncV3StatusReport` called into the outbox several times per app shortly
+after startup, which is what put the read ~70 seconds in rather than at boot.
+
+## Why the file grew that large
+
+Four separate problems compounded:
+
+1. **Entries carried file contents inline with no size cap.** A writer op stores
+   the bytes of every file it touches. The Papr Data Room app keeps uploaded
+   PDFs and images inside its app directory, so a single op could carry hundreds
+   of megabytes.
+2. **Binary files were encoded as UTF-8 JSON strings.** A JPEG read as `utf8`
+   both bloats (invalid sequences become U+FFFD, 3 bytes each) and corrupts, so
+   the blob was large *and* useless.
+3. **A crash did not count as an attempt.** `markOutboxInflight` left `attempts`
+   untouched, so an entry that killed the process was retried forever and never
+   reached the dead-letter threshold.
+4. **Nothing coalesced duplicate work.** Every debounced flush appended a fresh
+   op for the same app and the same paths; none of the older pending ops were
+   retired.
+
+The result was head-of-line blocking with a poison pill at the front: the queue
+could only grow, and reading it to find out what to do was itself the crash.
+
+## The fix
+
+Two layers. Guardrails so the gateway survives and drains whatever is already
+queued, then exclusions so the offending bytes never enter the queue again.
+
+### Layer 1 — Gateway guardrails
+
+**Bounded reads** (`src/gateway/services/syncV3/outboxFile.ts`, new)
+
+`streamJsonlLines` walks the file as bytes and only decodes a line once it is
+complete *and* known to be under the cap. An oversized line is never turned into
+a string: its bytes are handed to a callback as they arrive and dropped. Peak
+memory is one stream chunk regardless of file size.
+
+`readJsonlBounded` returns the lines under the cap plus a report of the oversized
+ones. `compactJsonlDroppingOversized` rewrites the queue without them, streaming
+their bytes into a `.oversized` sibling file so nothing is deleted.
+
+Two limits:
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `MAX_OUTBOX_LINE_BYTES` | 16 MB | One queued op. Set well above the collector's 6 MB batch budget so JSON escaping cannot turn an acceptable batch into an unwritable line. |
+| `MAX_OUTBOX_FILE_BYTES` | 64 MB | The whole queue. Above this, reading every entry to update one is too costly. |
+
+**Cap at enqueue** (`SyncOutbox.ts`)
+
+`appendOutboxEntry` rejects anything over `MAX_OUTBOX_LINE_BYTES` with
+`OutboxEntryTooLargeError` rather than writing a line that can never be read
+back. The message points at App Files, which is where large assets belong.
+
+**A crash counts as an attempt** (`SyncOutbox.ts`)
+
+`markOutboxInflight` now increments `attempts`. An entry that kills the process
+is charged for it, so a poison pill reaches the dead-letter threshold instead of
+blocking the queue forever.
+
+**Dead-lettering strips payloads** (`SyncOutbox.ts`)
+
+`markOutboxDeadLetter` drops `files[].content` and keeps
+`droppedFileCount` + `droppedFilePaths`. A dead entry stays diagnosable without
+holding megabytes on disk.
+
+**Coalescing** (`SyncOutbox.ts`)
+
+When a new op covers the same paths as older pending ops for the same app, those
+older entries are marked superseded. Repeated debounced flushes now replace
+rather than accumulate.
+
+**File budget backstop** (`SyncOutbox.ts`)
+
+If the queue still passes `MAX_OUTBOX_FILE_BYTES`, `trimToFileBudget` sheds the
+oldest queued work. Dropped ops are recollectible — the collector rebuilds them
+from the filesystem on the next flush — so this costs a re-scan, not data.
+
+**One read per status report** (`appSyncV3StatusReport.ts`)
+
+`listOutboxEntries` is called once and filtered for pending/inflight/dead-letter
+instead of three separate reads per app.
+
+The same bounded read replaced the unbounded one in `metadataOutbox.ts`.
+
+### Layer 2 — Keep the bytes out
+
+**Correct never-track matching** (`appRepoWriter/abuseFilter.ts`)
+
+`matchesNeverTrackPathspec` matched by substring, so `*.db` excluded
+`sandbox.ts` and `*.bak.*` excluded anything containing `bak`. Legitimate source
+files were silently dropped from sync. `isNeverTrackRepoPath` replaces it with
+anchored matching: extensions against the basename's suffix, directory specs
+against path segments.
+
+`*.db-journal` was added to `NEVER_TRACK_PATHSPECS` alongside `-wal` and `-shm`.
+
+**Exclude before reading** (`syncV3/collectAppOpFiles.ts`)
+
+The walkers now test `isNeverTrackRepoPath` while walking, so a 500 MB
+`database.db` is skipped by name and never read into memory. `candidateToOpFile`
+checks `stat.size` *before* `fs.readFile`, so an oversized file is rejected
+rather than loaded and then discarded.
+
+**Aggregate batch budget** (`syncV3/collectAppOpFiles.ts`)
+
+Per-file limits do not bound a batch: a thousand 5 MB files still overflow.
+`MAX_OP_BATCH_CONTENT_BYTES` (6 MB) caps the total content in one op. Files past
+the budget are counted as `deferred` and picked up by the next flush.
+
+`deferred` propagates through `PushAppViaWriterResult` and
+`FinalizeAppRepoMutationResult` to `cloudAppWriterDebouncedPush`, which re-queues
+any app that reported deferred files. A large app therefore syncs across several
+flushes instead of in one op that cannot be written.
+
+The OID cache is now read once per flush rather than once per file.
+
+## Results
+
+Verified against the real production outbox, reconstructed in an isolated
+workspace (`tests/sync-outbox-recovery-fixture.test.ts`):
+
+| | Before | After |
+|---|---|---|
+| Reading the queue | OOM, process dies | completes in 2.3 s |
+| Peak heap growth | unbounded — a 1.5 GB string | 98 MB |
+| Entries recovered | 0 (crash) | 303, all pending |
+| Queue on disk | 1521 MB | 32 MB |
+| Oversized bytes | blocking the queue | 1489 MB quarantined to `.oversized` |
+
+Three lines accounted for the 1489 MB. The 303 entries behind them were
+unreachable before this change and drain normally after it.
+
+## Tests
+
+| File | Covers |
+|---|---|
+| `tests/sync-outbox-guardrails.test.ts` | streaming reads, oversized detection, quarantining, enqueue cap, crash-counts-as-attempt, payload stripping, coalescing, recovery from a pre-existing oversized line |
+| `tests/never-track-repo-path.test.ts` | anchored matching; `sandbox.ts` and friends are *not* excluded |
+| `tests/collect-app-op-files.test.ts` | databases and `.bak` copies never read, oversized file skipped before read, batch budget defers the remainder |
+| `tests/sync-outbox-recovery-fixture.test.ts` | full recovery against a reconstructed production outbox (skipped unless `OUTBOX_FIXTURE` is set) |
+
+```bash
+npx vitest run tests/sync-outbox-guardrails.test.ts \
+  tests/never-track-repo-path.test.ts \
+  tests/collect-app-op-files.test.ts --project unit-backend
+
+# Against a real oversized outbox (paths joined by ':'):
+OUTBOX_FIXTURE=/path/sync-outbox.jsonl.oversized:/path/sync-outbox.jsonl \
+  npx vitest run tests/sync-outbox-recovery-fixture.test.ts --project unit-backend
+```
+
+## What app authors should do
+
+Guardrails stop the crash; they do not make large assets sync. An app that keeps
+uploads inside its own directory will see them rejected as over the limit. Store
+them with App Files and keep the reference in SQLite. The Papr Data Room app is
+the first case and adopts the files SDK next.
+
+## Prevention
+
+- Never `fs.readFile` a file whose size is controlled by user data. Stream it, or
+  bound it, or check `stat.size` first.
+- Cap a queue entry at enqueue. A line that cannot be read back is worse than a
+  rejected write.
+- Charge an attempt when work is picked up, not when it fails. A crash mid-push
+  otherwise retries forever.
+- Per-item limits do not bound a batch; add an aggregate budget and a way to
+  defer the remainder.
+- Anchor glob matching. Substring matching on `*.db` quietly drops `sandbox.ts`.

--- a/src/gateway/services/appRepoWriter/abuseFilter.ts
+++ b/src/gateway/services/appRepoWriter/abuseFilter.ts
@@ -2,8 +2,6 @@
  * Reject abusive file ops before they reach git (writer door).
  */
 
-import * as path from "node:path";
-
 import {
   MAX_TRACKED_FILE_BYTES,
   NEVER_TRACK_PATHSPECS,
@@ -18,36 +16,52 @@ function normalizeRepoPath(filePath: string): string {
   return filePath.replace(/\\/g, "/").replace(/^\.\/+/, "");
 }
 
-function matchesNeverTrackPathspec(repoPath: string): boolean {
-  const normalized = normalizeRepoPath(repoPath);
-  const base = path.posix.basename(normalized).toLowerCase();
+/**
+ * Match a repo path against the never-track pathspecs.
+ *
+ * Extension specs are anchored to the end of the basename. Matching them as a
+ * bare substring instead — which this did — silently dropped ordinary source
+ * files from sync: `*.db` matched `sandbox.ts`, `*.mov` matched `remove.ts`,
+ * and `*.zip` matched `zipcode.ts`.
+ */
+export function isNeverTrackRepoPath(repoPath: string): boolean {
+  const normalized = normalizeRepoPath(repoPath).toLowerCase();
+  const segments = normalized.split("/");
+  const base = segments[segments.length - 1] ?? "";
+  const dirSegments = segments.slice(0, -1);
 
   for (const spec of NEVER_TRACK_PATHSPECS) {
-    const trimmed = spec.replace(/^\*\./, "");
-    if (spec.startsWith("**/")) {
-      if (normalized.includes(spec.slice(3))) {
+    const lower = spec.toLowerCase();
+
+    if (lower.endsWith("/")) {
+      const dirName = lower.replace(/^\*\*\//, "").slice(0, -1);
+      if (dirSegments.includes(dirName)) {
         return true;
       }
       continue;
     }
-    if (spec.endsWith("/")) {
-      if (normalized.startsWith(spec) || normalized.includes(`/${spec}`)) {
+
+    if (lower.startsWith("*.")) {
+      const suffix = lower.slice(1);
+      // "*.bak.*" — an infix such as `db.bak.2026-01-01`.
+      if (suffix.endsWith(".*")) {
+        if (base.includes(suffix.slice(0, -1))) {
+          return true;
+        }
+        continue;
+      }
+      if (base.endsWith(suffix)) {
         return true;
       }
       continue;
     }
-    if (spec.startsWith("*.")) {
-      if (base.endsWith(trimmed) || base.includes(trimmed)) {
-        return true;
-      }
+
+    if (base === lower) {
+      return true;
     }
   }
 
-  if (base.startsWith("tmp_pack_")) {
-    return true;
-  }
-
-  return false;
+  return base.startsWith("tmp_pack_");
 }
 
 export function validateOpFileForWriter(input: {
@@ -60,13 +74,12 @@ export function validateOpFileForWriter(input: {
     return { path: input.path, reason: "invalid path" };
   }
 
-  if (matchesNeverTrackPathspec(repoPath)) {
+  if (isNeverTrackRepoPath(repoPath)) {
     return { path: repoPath, reason: "path blocked by repo hygiene rules" };
   }
 
   if (input.content !== null) {
-    const bytes =
-      input.byteLength ?? Buffer.byteLength(input.content, "utf8");
+    const bytes = input.byteLength ?? Buffer.byteLength(input.content, "utf8");
     if (bytes > MAX_TRACKED_FILE_BYTES) {
       return {
         path: repoPath,
@@ -78,9 +91,9 @@ export function validateOpFileForWriter(input: {
   return null;
 }
 
-export function filterAbusiveOpFiles<T extends { path: string; content: string | null }>(
-  files: readonly T[],
-): { accepted: T[]; rejected: AbuseRejection[] } {
+export function filterAbusiveOpFiles<
+  T extends { path: string; content: string | null },
+>(files: readonly T[]): { accepted: T[]; rejected: AbuseRejection[] } {
   const accepted: T[] = [];
   const rejected: AbuseRejection[] = [];
   for (const file of files) {

--- a/src/gateway/services/cloudAgentGateway/cloudAppWriterDebouncedPush.ts
+++ b/src/gateway/services/cloudAgentGateway/cloudAppWriterDebouncedPush.ts
@@ -93,12 +93,25 @@ function recordPushedApps(appIds: readonly string[]): void {
   }
 }
 
-function requeueFailedApps(failures: readonly CloudAppWriterFlushFailure[]): void {
+function requeueFailedApps(
+  failures: readonly CloudAppWriterFlushFailure[],
+): void {
   if (moduleStopped || failures.length === 0) {
     return;
   }
   for (const failure of failures) {
     moduleDirtyApps.add(failure.appId);
+  }
+  scheduleModuleFlush();
+}
+
+/** Queue apps whose flush was truncated by the batch budget. */
+function requeueIncompleteApps(appIds: readonly string[]): void {
+  if (moduleStopped || appIds.length === 0) {
+    return;
+  }
+  for (const appId of appIds) {
+    moduleDirtyApps.add(appId);
   }
   scheduleModuleFlush();
 }
@@ -113,6 +126,7 @@ async function executeWriterFlush(
   const paprDir = getPaprRoot();
   const pushedAppIds: string[] = [];
   const failed: CloudAppWriterFlushFailure[] = [];
+  const incomplete: string[] = [];
 
   for (const appId of appIds) {
     try {
@@ -127,6 +141,15 @@ async function executeWriterFlush(
             (result.commitSha ? ` @ ${result.commitSha.slice(0, 8)}` : ""),
         );
       }
+      // A flush capped by the batch budget sent only part of the app. Queue it
+      // again so the remainder follows instead of waiting for the next edit.
+      if (result.deferred > 0) {
+        incomplete.push(appId);
+        console.log(
+          `[CloudAppWriterDebouncedPush] ${appId} has ${result.deferred} ` +
+            `file(s) left — re-queued`,
+        );
+      }
     } catch (error) {
       failed.push({
         appId,
@@ -137,6 +160,7 @@ async function executeWriterFlush(
 
   recordPushedApps(pushedAppIds);
   requeueFailedApps(failed);
+  requeueIncompleteApps(incomplete);
 
   return { pushedAppIds, failed };
 }

--- a/src/gateway/services/cloudSync/repoHygiene.ts
+++ b/src/gateway/services/cloudSync/repoHygiene.ts
@@ -38,6 +38,7 @@ export const NEVER_TRACK_PATHSPECS = [
   "*.db",
   "*.db-wal",
   "*.db-shm",
+  "*.db-journal",
   "*.sqlite",
   "*.sqlite3",
   "*.bak",

--- a/src/gateway/services/syncV3/SyncOutbox.ts
+++ b/src/gateway/services/syncV3/SyncOutbox.ts
@@ -1,5 +1,19 @@
 /**
  * Persist queued writer ops for offline retry (Sync V3 Phase 2).
+ *
+ * Entries carry file contents inline, so this queue is only safe while every
+ * entry stays small and the file stays drainable. Three guards keep it that way:
+ *
+ *  - **Bounded reads.** Lines stream and oversized ones are quarantined rather
+ *    than parsed. A 1.6GB outbox previously aborted the gateway on launch.
+ *  - **A cap at enqueue.** An op too large to push is rejected here instead of
+ *    being written to disk and retried forever.
+ *  - **Attempts advance on inflight.** An entry that kills the process mid-push
+ *    still counts a try, so a poison entry dead-letters instead of blocking the
+ *    queue head on every launch.
+ *
+ * Dead-lettered entries keep their paths but drop their payload: they are never
+ * replayed, and retaining the bytes was itself a source of growth.
  */
 
 import { randomUUID } from "node:crypto";
@@ -10,6 +24,12 @@ import type { AppRepoOpFile } from "../../../core/types/appRepoWriterOps.js";
 import { SYNC_OUTBOX_FILENAME } from "../../../core/types/appRepoWriterOps.js";
 import { writeFileAtomic } from "../../../core/utils/atomicJsonWrite.js";
 import { getPaprRoot } from "../../../core/utils/paprRoot.js";
+import {
+  compactJsonlDroppingOversized,
+  MAX_OUTBOX_FILE_BYTES,
+  MAX_OUTBOX_LINE_BYTES,
+  readJsonlBounded,
+} from "./outboxFile.js";
 
 export type SyncOutboxEntryStatus =
   | "pending"
@@ -31,19 +51,34 @@ export interface SyncOutboxEntry {
   attempts: number;
   lastError?: string;
   commitSha?: string;
+  /** Set when a dead-lettered entry's payload was dropped. */
+  droppedFileCount?: number;
+  droppedFilePaths?: string[];
+}
+
+/** An op too large to ever push. Permanent — never queue it. */
+export class OutboxEntryTooLargeError extends Error {
+  readonly byteLength: number;
+  readonly limit: number;
+
+  constructor(byteLength: number, limit: number) {
+    super(
+      `Writer op is ${Math.round(byteLength / (1024 * 1024))}MB, over the ` +
+        `${Math.round(limit / (1024 * 1024))}MB queue limit. Store large ` +
+        `assets with App Files so the bytes go to object storage instead.`,
+    );
+    this.name = "OutboxEntryTooLargeError";
+    this.byteLength = byteLength;
+    this.limit = limit;
+  }
 }
 
 function outboxPath(): string {
   return path.join(getPaprRoot(), "data", SYNC_OUTBOX_FILENAME);
 }
 
-async function readAllLines(): Promise<string[]> {
-  try {
-    const raw = await fs.readFile(outboxPath(), "utf8");
-    return raw.split("\n").filter((line) => line.trim().length > 0);
-  } catch {
-    return [];
-  }
+function quarantinePath(): string {
+  return `${outboxPath()}.oversized`;
 }
 
 async function writeAllEntries(entries: SyncOutboxEntry[]): Promise<void> {
@@ -56,22 +91,117 @@ async function writeAllEntries(entries: SyncOutboxEntry[]): Promise<void> {
   await writeFileAtomic(filePath, body);
 }
 
+/**
+ * Read the queue without letting a single entry bound memory.
+ *
+ * Oversized lines are moved out of the file on first sight: they cannot be
+ * pushed, and leaving them in place would re-block every later read.
+ */
 export async function listOutboxEntries(
   appId?: string,
 ): Promise<SyncOutboxEntry[]> {
-  const lines = await readAllLines();
-  const entries: SyncOutboxEntry[] = [];
+  const { lines, oversized } = await readJsonlBounded(outboxPath());
+
+  if (oversized.length > 0) {
+    const result = await compactJsonlDroppingOversized(outboxPath(), {
+      quarantinePath: quarantinePath(),
+    });
+    console.warn(
+      `[SyncOutbox] Quarantined ${result.quarantinedLines} oversized ` +
+        `entr${result.quarantinedLines === 1 ? "y" : "ies"} ` +
+        `(${Math.round(result.quarantinedBytes / (1024 * 1024))}MB) to ` +
+        `${quarantinePath()}. These ops were too large to push; store large ` +
+        `assets with App Files instead.`,
+    );
+  }
+
+  const all: SyncOutboxEntry[] = [];
+  let totalBytes = 0;
   for (const line of lines) {
     try {
-      const entry = JSON.parse(line) as SyncOutboxEntry;
-      if (!appId || entry.appId === appId) {
-        entries.push(entry);
-      }
+      all.push(JSON.parse(line) as SyncOutboxEntry);
+      totalBytes += Buffer.byteLength(line, "utf8");
     } catch {
       /* skip corrupt line */
     }
   }
-  return entries;
+
+  const trimmed =
+    totalBytes > MAX_OUTBOX_FILE_BYTES ? await trimToFileBudget(all) : all;
+
+  return appId ? trimmed.filter((entry) => entry.appId === appId) : trimmed;
+}
+
+/**
+ * Shed the oldest queued work once the queue outgrows its budget.
+ *
+ * Safe to drop because the queue is a retry aid, not the source of truth: a
+ * flush re-collects from the local filesystem, and the OID cache only advances
+ * on ack, so anything dropped here is collected again on the next flush. Left
+ * unbounded, a long offline stretch across several apps can queue gigabytes
+ * that no single process can then read.
+ */
+async function trimToFileBudget(
+  entries: readonly SyncOutboxEntry[],
+): Promise<SyncOutboxEntry[]> {
+  const budget = Math.floor(MAX_OUTBOX_FILE_BYTES / 2);
+  const kept: SyncOutboxEntry[] = [];
+  let bytes = 0;
+
+  // Newest first: recent entries reflect current disk state.
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    const size = Buffer.byteLength(JSON.stringify(entry), "utf8");
+    if (bytes + size > budget && kept.length > 0) {
+      continue;
+    }
+    kept.unshift(entry);
+    bytes += size;
+  }
+
+  const dropped = entries.length - kept.length;
+  if (dropped > 0) {
+    console.warn(
+      `[SyncOutbox] Queue exceeded ${Math.round(
+        MAX_OUTBOX_FILE_BYTES / (1024 * 1024),
+      )}MB — dropped ${dropped} older queued op${dropped === 1 ? "" : "s"}. ` +
+        `Their files are re-collected on the next flush.`,
+    );
+    await writeAllEntries(kept);
+  }
+  return kept;
+}
+
+/**
+ * Drop pending entries this one supersedes.
+ *
+ * Each flush re-collects from disk, and the OID cache only advances on ack, so
+ * an app that cannot reach the writer re-queues the same files on every flush.
+ * That is how one queue reached 869 entries, most of them duplicates of each
+ * other. An older pending entry whose paths are all covered here carries stale
+ * content for those paths, so keeping it has no value.
+ *
+ * Only `pending` entries are considered: an `inflight` entry may already be
+ * committed on the server, and a dead letter is a record, not work.
+ */
+function supersededPendingIds(
+  entries: readonly SyncOutboxEntry[],
+  appId: string,
+  paths: ReadonlySet<string>,
+): Set<string> {
+  const superseded = new Set<string>();
+  for (const entry of entries) {
+    if (entry.appId !== appId || entry.status !== "pending") {
+      continue;
+    }
+    if (
+      entry.files.length > 0 &&
+      entry.files.every((file) => paths.has(file.path))
+    ) {
+      superseded.add(entry.id);
+    }
+  }
+  return superseded;
 }
 
 export async function appendOutboxEntry(input: {
@@ -95,9 +225,31 @@ export async function appendOutboxEntry(input: {
     attempts: 0,
   };
 
+  const line = `${JSON.stringify(entry)}\n`;
+  const byteLength = Buffer.byteLength(line, "utf8");
+  if (byteLength > MAX_OUTBOX_LINE_BYTES) {
+    throw new OutboxEntryTooLargeError(byteLength, MAX_OUTBOX_LINE_BYTES);
+  }
+
   const filePath = outboxPath();
   await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, "utf8");
+
+  const existing = await listOutboxEntries();
+  const superseded = supersededPendingIds(
+    existing,
+    input.appId,
+    new Set(input.files.map((file) => file.path)),
+  );
+
+  if (superseded.size === 0) {
+    await fs.appendFile(filePath, line, "utf8");
+    return entry;
+  }
+
+  await writeAllEntries([
+    ...existing.filter((item) => !superseded.has(item.id)),
+    entry,
+  ]);
   return entry;
 }
 
@@ -125,8 +277,23 @@ async function updateEntry(
   return updated;
 }
 
+/**
+ * Claim an entry for a push attempt.
+ *
+ * The attempt counter advances here rather than on failure so that an entry
+ * which takes the process down mid-push still burns a try. Otherwise it stays
+ * at zero attempts forever and blocks the queue head on every launch.
+ */
 export async function markOutboxInflight(entryId: string): Promise<void> {
-  await updateEntry(entryId, { status: "inflight" });
+  const entries = await listOutboxEntries();
+  const entry = entries.find((item) => item.id === entryId);
+  if (!entry) {
+    return;
+  }
+  await updateEntry(entryId, {
+    status: "inflight",
+    attempts: entry.attempts + 1,
+  });
 }
 
 export async function markOutboxAcked(
@@ -140,26 +307,32 @@ export async function markOutboxFailed(
   entryId: string,
   errorMessage: string,
 ): Promise<void> {
-  const entries = await listOutboxEntries();
-  const entry = entries.find((item) => item.id === entryId);
-  if (!entry) {
-    return;
-  }
   await updateEntry(entryId, {
     status: "pending",
-    attempts: entry.attempts + 1,
     lastError: errorMessage.slice(0, 500),
   });
 }
 
-/** Permanent reject — do not block subsequent pushes for this app. */
+/**
+ * Permanent reject — do not block subsequent pushes for this app.
+ *
+ * The payload is dropped because a dead letter is never replayed, and keeping
+ * the inline contents of every rejected op is how the queue grew unbounded.
+ */
 export async function markOutboxDeadLetter(
   entryId: string,
   errorMessage: string,
 ): Promise<void> {
+  const entries = await listOutboxEntries();
+  const entry = entries.find((item) => item.id === entryId);
   await updateEntry(entryId, {
     status: "dead_letter",
     lastError: errorMessage.slice(0, 500),
+    files: [],
+    droppedFileCount: entry?.droppedFileCount ?? entry?.files.length ?? 0,
+    droppedFilePaths:
+      entry?.droppedFilePaths ??
+      entry?.files.slice(0, 20).map((file) => file.path),
   });
 }
 
@@ -180,4 +353,5 @@ export async function listDeadLetterOutboxEntries(
 /** Test-only — reset outbox file. */
 export async function clearSyncOutboxForTests(): Promise<void> {
   await fs.rm(outboxPath(), { force: true });
+  await fs.rm(quarantinePath(), { force: true });
 }

--- a/src/gateway/services/syncV3/appSyncV3StatusReport.ts
+++ b/src/gateway/services/syncV3/appSyncV3StatusReport.ts
@@ -4,11 +4,7 @@
 
 import type { SyncStateManager } from "../cloudSync/syncState.js";
 import { shouldAutoUploadApp } from "../cloudUploadMode.js";
-import {
-  listDeadLetterOutboxEntries,
-  listOutboxEntries,
-  listPendingOutboxEntries,
-} from "./SyncOutbox.js";
+import { listOutboxEntries } from "./SyncOutbox.js";
 import { listRecentWriterConflicts } from "./writerConflict.js";
 import {
   formatFlushQueueDetail,
@@ -172,15 +168,21 @@ export async function buildAppSyncV3Report(
   const autoUpload = shouldAutoUploadApp(appId, paprDir);
   const manualUploadHold = !autoUpload && hasLocalChanges;
 
+  // One read, three views. Reading the queue three times per app meant the
+  // whole file was parsed once per report — and the reports run on launch.
   const outboxEntries = await listOutboxEntries(appId);
-  const pendingWriterOps = outboxEntries.filter((e) => e.status === "pending").length;
-  const inflightWriterOps = outboxEntries.filter((e) => e.status === "inflight").length;
+  const pendingOutbox = outboxEntries.filter((e) => e.status === "pending");
+  const deadLetterOutbox = outboxEntries.filter(
+    (e) => e.status === "dead_letter",
+  );
+  const pendingWriterOps = pendingOutbox.length;
+  const inflightWriterOps = outboxEntries.filter(
+    (e) => e.status === "inflight",
+  ).length;
   const deadLetterWriterOps = outboxEntries.filter(
     (e) => e.status === "dead_letter" || e.status === "failed",
   ).length;
 
-  const deadLetterOutbox = await listDeadLetterOutboxEntries(appId);
-  const pendingOutbox = await listPendingOutboxEntries(appId);
   const conflicts = listRecentWriterConflicts(appId);
   const folderDeadLetter = stateManager.data.deadLetter?.[relativePath];
 
@@ -213,10 +215,7 @@ export async function buildAppSyncV3Report(
     options.flushErrorMessage
   ) {
     status = "failed";
-  } else if (
-    options.coordinatorUploading ||
-    inflightWriterOps > 0
-  ) {
+  } else if (options.coordinatorUploading || inflightWriterOps > 0) {
     status = "uploading";
   } else if (
     !alreadySyncedOnWeb &&

--- a/src/gateway/services/syncV3/collectAppOpFiles.ts
+++ b/src/gateway/services/syncV3/collectAppOpFiles.ts
@@ -10,8 +10,16 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 
 import type { AppRepoOpFile } from "../../../core/types/appRepoWriterOps.js";
-import { filterAbusiveOpFiles } from "../appRepoWriter/abuseFilter.js";
+import {
+  filterAbusiveOpFiles,
+  isNeverTrackRepoPath,
+} from "../appRepoWriter/abuseFilter.js";
 import { resolveAppDependentJobIds } from "../cloudSync/resolveAppDependentJobs.js";
+import {
+  formatGitSyncSizeLimitMb,
+  isTooLargeForGitSync,
+  MAX_GIT_SYNC_FILE_BYTES,
+} from "../cloudSync/gitSyncLimits.js";
 import {
   DATABASES_REGISTRY_FILENAME,
   type DatabaseRecord,
@@ -20,7 +28,7 @@ import {
 } from "../DatabaseRegistryService.js";
 import { parseMonolithicJobJson } from "../jobs/jobRuntimeFields.js";
 import { computeBlobOidForContent } from "./computeParentHash.js";
-import { getCachedBlobOid } from "./OidCache.js";
+import { readOidCache } from "./OidCache.js";
 
 const SKIP_DIR_NAMES = new Set([
   "node_modules",
@@ -31,15 +39,24 @@ const SKIP_DIR_NAMES = new Set([
   "venv",
 ]);
 
-const JOB_SKIP_DIR_NAMES = new Set([
-  ...SKIP_DIR_NAMES,
-  "data",
-  "logs",
-]);
+const JOB_SKIP_DIR_NAMES = new Set([...SKIP_DIR_NAMES, "data", "logs"]);
 
 const JOB_SKIP_FILE_NAMES = new Set(["job.runtime.json"]);
 
 const JOB_SKIP_EXTENSIONS = new Set([".db", ".pyc", ".log", ".wal", ".shm"]);
+
+/**
+ * Ceiling on the content a single flush may carry.
+ *
+ * One flush becomes one outbox line and one writer request. Without a ceiling,
+ * an app folder holding a few hundred assets produced a ~400MB op that could
+ * neither be pushed nor held in memory, and every retry rebuilt it. Files past
+ * the budget are deferred to the next flush, so a large app converges over
+ * several passes instead of failing on all of them.
+ *
+ * Sized below the outbox line cap to leave room for JSON escaping.
+ */
+export const MAX_OP_BATCH_CONTENT_BYTES = 6 * 1024 * 1024;
 
 interface WalkCandidate {
   repoPath: string;
@@ -72,7 +89,14 @@ async function walkAppFiles(appDir: string): Promise<string[]> {
         continue;
       }
       if (entry.isFile()) {
-        results.push(rel.replace(/\\/g, "/"));
+        const repoPath = rel.replace(/\\/g, "/");
+        // Excluded here rather than after reading: this walk covers app
+        // folders that hold SQLite databases and their `.bak` copies, and
+        // reading one of those as a string is what exhausted the heap.
+        if (isNeverTrackRepoPath(repoPath)) {
+          continue;
+        }
+        results.push(repoPath);
       }
     }
   }
@@ -81,7 +105,10 @@ async function walkAppFiles(appDir: string): Promise<string[]> {
   return results.sort();
 }
 
-async function walkJobFiles(jobDir: string, jobId: string): Promise<WalkCandidate[]> {
+async function walkJobFiles(
+  jobDir: string,
+  jobId: string,
+): Promise<WalkCandidate[]> {
   const results: WalkCandidate[] = [];
 
   async function walk(currentDir: string, prefix: string): Promise<void> {
@@ -117,6 +144,9 @@ async function walkJobFiles(jobDir: string, jobId: string): Promise<WalkCandidat
       }
 
       const repoPath = `jobs/${jobId}/${rel.replace(/\\/g, "/")}`;
+      if (isNeverTrackRepoPath(repoPath)) {
+        continue;
+      }
       if (entry.name === "job.json") {
         results.push({
           repoPath,
@@ -231,33 +261,61 @@ async function collectSchemaOwnerMigrationCandidates(
   return candidates;
 }
 
+type CandidateOutcome =
+  | { kind: "op"; file: AppRepoOpFile; byteLength: number }
+  | { kind: "unchanged" }
+  | { kind: "rejected"; reason: string };
+
 async function candidateToOpFile(
-  appId: string,
   candidate: WalkCandidate,
-): Promise<AppRepoOpFile | null> {
+  cachedOids: Readonly<Record<string, string>>,
+): Promise<CandidateOutcome> {
   let stat;
   try {
     stat = await fs.stat(candidate.fullPath);
   } catch {
-    return null;
+    return { kind: "unchanged" };
   }
   if (!stat.isFile()) {
-    return null;
+    return { kind: "unchanged" };
+  }
+
+  // Checked before the read, not after. The writer rejects oversized files
+  // anyway, and reading one first only to discard it is how a single large
+  // asset took down the process.
+  if (!candidate.readContent && isTooLargeForGitSync(stat.size)) {
+    return {
+      kind: "rejected",
+      reason: `over ${formatGitSyncSizeLimitMb()} — store it with App Files`,
+    };
   }
 
   const content = candidate.readContent
     ? await candidate.readContent()
     : await fs.readFile(candidate.fullPath, "utf8");
+
+  const byteLength = Buffer.byteLength(content, "utf8");
+  if (byteLength > MAX_GIT_SYNC_FILE_BYTES) {
+    return {
+      kind: "rejected",
+      reason: `over ${formatGitSyncSizeLimitMb()} — store it with App Files`,
+    };
+  }
+
   const currentOid = await computeBlobOidForContent(content);
-  const cachedOid = await getCachedBlobOid(appId, candidate.repoPath);
+  const cachedOid = cachedOids[candidate.repoPath] ?? null;
   if (cachedOid === currentOid) {
-    return null;
+    return { kind: "unchanged" };
   }
 
   return {
-    path: candidate.repoPath,
-    content,
-    parentHash: cachedOid ?? "",
+    kind: "op",
+    byteLength,
+    file: {
+      path: candidate.repoPath,
+      content,
+      parentHash: cachedOid ?? "",
+    },
   };
 }
 
@@ -265,6 +323,8 @@ export interface CollectAppOpFilesResult {
   files: AppRepoOpFile[];
   rejected: Array<{ path: string; reason: string }>;
   skippedUnchanged: number;
+  /** Changed files held back by the batch budget; sent on a later flush. */
+  deferred: number;
 }
 
 /**
@@ -284,22 +344,54 @@ export async function collectAppOpFiles(
   }));
 
   candidates.push(...(await collectLinkedJobCandidates(paprDir, appId)));
-  candidates.push(...(await collectSchemaOwnerMigrationCandidates(paprDir, appId)));
+  candidates.push(
+    ...(await collectSchemaOwnerMigrationCandidates(paprDir, appId)),
+  );
+
+  // Loaded once per flush. Reading it per file meant parsing the whole cache
+  // several hundred times for one app.
+  const cachedOids = (await readOidCache()).apps[appId] ?? {};
 
   const opCandidates: AppRepoOpFile[] = [];
+  const skipped: Array<{ path: string; reason: string }> = [];
   let skippedUnchanged = 0;
+  let deferred = 0;
+  let batchBytes = 0;
 
   for (const candidate of candidates) {
-    const opFile = await candidateToOpFile(appId, candidate);
-    if (!opFile) {
+    if (batchBytes >= MAX_OP_BATCH_CONTENT_BYTES) {
+      deferred += 1;
+      continue;
+    }
+
+    const outcome = await candidateToOpFile(candidate, cachedOids);
+    if (outcome.kind === "unchanged") {
       skippedUnchanged += 1;
       continue;
     }
-    opCandidates.push(opFile);
+    if (outcome.kind === "rejected") {
+      skipped.push({ path: candidate.repoPath, reason: outcome.reason });
+      continue;
+    }
+
+    opCandidates.push(outcome.file);
+    batchBytes += outcome.byteLength;
+  }
+
+  if (deferred > 0) {
+    console.warn(
+      `[collectAppOpFiles] ${appId}: batch budget reached — sending ` +
+        `${opCandidates.length} files, deferring ${deferred} to the next flush.`,
+    );
   }
 
   const { accepted, rejected } = filterAbusiveOpFiles(opCandidates);
-  return { files: accepted, rejected, skippedUnchanged };
+  return {
+    files: accepted,
+    rejected: [...skipped, ...rejected],
+    skippedUnchanged,
+    deferred,
+  };
 }
 
 /** Recompute parentHash from OID cache before outbox replay. */
@@ -307,10 +399,11 @@ export async function refreshOpParentHashes(
   appId: string,
   files: AppRepoOpFile[],
 ): Promise<AppRepoOpFile[]> {
+  const cachedOids = (await readOidCache()).apps[appId] ?? {};
   const refreshed: AppRepoOpFile[] = [];
   for (const file of files) {
-    const cachedOid = await getCachedBlobOid(appId, file.path);
-    let content = file.content;
+    const cachedOid = cachedOids[file.path] ?? null;
+    const content = file.content;
     if (content !== null) {
       const oid = await computeBlobOidForContent(content);
       if (cachedOid === oid) {

--- a/src/gateway/services/syncV3/finalizeAppRepoMutation.ts
+++ b/src/gateway/services/syncV3/finalizeAppRepoMutation.ts
@@ -32,6 +32,8 @@ export interface FinalizeAppRepoMutationResult {
   commitSha?: string;
   catalogSynced: boolean;
   catalogError?: string;
+  /** Files held back by the batch budget — this app needs another flush. */
+  deferred: number;
 }
 
 export async function finalizeAppRepoMutation(
@@ -39,9 +41,8 @@ export async function finalizeAppRepoMutation(
   appId: string,
   options: FinalizeAppRepoMutationOptions,
 ): Promise<FinalizeAppRepoMutationResult> {
-  const { prepareAppForCloudGitSync } = await import(
-    "../cloudSync/prepareAppsForCloud.js"
-  );
+  const { prepareAppForCloudGitSync } =
+    await import("../cloudSync/prepareAppsForCloud.js");
   await prepareAppForCloudGitSync(paprDir, appId);
   await reconcilePlatformCatalogManifest(paprDir, appId);
 
@@ -84,7 +85,9 @@ export async function finalizeAppRepoMutation(
 
   if (pushResult.commitSha) {
     const { uploadAppDbConfigToCloud } = await import("./appDbConfigUpload.js");
-    void uploadAppDbConfigToCloud(paprDir, appId, pushResult.commitSha).catch(() => {});
+    void uploadAppDbConfigToCloud(paprDir, appId, pushResult.commitSha).catch(
+      () => {},
+    );
   }
 
   return {
@@ -93,5 +96,6 @@ export async function finalizeAppRepoMutation(
     commitSha: pushResult.commitSha,
     catalogSynced,
     catalogError,
+    deferred: pushResult.deferred,
   };
 }

--- a/src/gateway/services/syncV3/metadataOutbox.ts
+++ b/src/gateway/services/syncV3/metadataOutbox.ts
@@ -12,6 +12,7 @@ import type { CloudAppMetaFile } from "../cloudSync/cloudAppMeta.js";
 import type { DatabasesRegistryFile } from "../DatabaseRegistryService.js";
 import type { JobConfigSlice } from "../jobs/jobRuntimeFields.js";
 import type { AppDbConfigPayload } from "./appDbConfigUpload.js";
+import { readJsonlBounded } from "./outboxFile.js";
 
 const OUTBOX_FILENAME = "metadata-outbox.jsonl";
 const MAX_ATTEMPTS = 8;
@@ -39,24 +40,28 @@ function outboxPath(): string {
   return path.join(getPaprRoot(), "data", OUTBOX_FILENAME);
 }
 
+/**
+ * Entries embed whole registries, so a stuck queue can outgrow V8's string
+ * ceiling. Reading streams line by line and skips anything oversized rather
+ * than materialising the file.
+ */
 async function readEntries(): Promise<MetadataOutboxEntry[]> {
-  try {
-    const raw = await fs.readFile(outboxPath(), "utf8");
-    const entries: MetadataOutboxEntry[] = [];
-    for (const line of raw.split("\n")) {
-      if (!line.trim()) {
-        continue;
-      }
-      try {
-        entries.push(JSON.parse(line) as MetadataOutboxEntry);
-      } catch {
-        /* skip corrupt line */
-      }
-    }
-    return entries;
-  } catch {
-    return [];
+  const { lines, oversized } = await readJsonlBounded(outboxPath());
+  if (oversized.length > 0) {
+    console.warn(
+      `[metadataOutbox] Skipped ${oversized.length} oversized entr` +
+        `${oversized.length === 1 ? "y" : "ies"} — too large to upload.`,
+    );
   }
+  const entries: MetadataOutboxEntry[] = [];
+  for (const line of lines) {
+    try {
+      entries.push(JSON.parse(line) as MetadataOutboxEntry);
+    } catch {
+      /* skip corrupt line */
+    }
+  }
+  return entries;
 }
 
 async function writeEntries(entries: MetadataOutboxEntry[]): Promise<void> {
@@ -74,7 +79,10 @@ export async function enqueueMetadataOutboxEntry(
 ): Promise<void> {
   const entries = await readEntries();
   const filtered = entries.filter((existing) => {
-    if (existing.kind !== entry.kind || existing.updatedAt !== entry.updatedAt) {
+    if (
+      existing.kind !== entry.kind ||
+      existing.updatedAt !== entry.updatedAt
+    ) {
       return true;
     }
     if (
@@ -121,7 +129,10 @@ async function bumpAttempt(entryId: string, lastError: string): Promise<void> {
   await writeEntries(next.filter((entry) => entry.attempts < MAX_ATTEMPTS));
 }
 
-export async function flushMetadataOutbox(): Promise<{ flushed: number; failed: number }> {
+export async function flushMetadataOutbox(): Promise<{
+  flushed: number;
+  failed: number;
+}> {
   const entries = await readEntries();
   if (entries.length === 0) {
     return { flushed: 0, failed: 0 };
@@ -132,7 +143,8 @@ export async function flushMetadataOutbox(): Promise<{ flushed: number; failed: 
     uploadDatabasesRegistryToCloudDirect,
     uploadAppRuntimeMetaToCloudDirect,
   } = await import("./MetadataRegistryClient.js");
-  const { uploadAppDbConfigToCloudDirect } = await import("./appDbConfigUpload.js");
+  const { uploadAppDbConfigToCloudDirect } =
+    await import("./appDbConfigUpload.js");
 
   let flushed = 0;
   let failed = 0;
@@ -143,19 +155,28 @@ export async function flushMetadataOutbox(): Promise<{ flushed: number; failed: 
       if (entry.kind === "jobs" && entry.jobs) {
         ok = await uploadJobsIndexToCloudDirect(entry.jobs, entry.updatedAt);
       } else if (entry.kind === "databases" && entry.registry) {
-        ok = await uploadDatabasesRegistryToCloudDirect(entry.registry, entry.updatedAt);
+        ok = await uploadDatabasesRegistryToCloudDirect(
+          entry.registry,
+          entry.updatedAt,
+        );
       } else if (
         entry.kind === "app-runtime-meta" &&
         entry.appId &&
         entry.appRuntimeMeta
       ) {
-        ok = await uploadAppRuntimeMetaToCloudDirect(entry.appId, entry.appRuntimeMeta);
+        ok = await uploadAppRuntimeMetaToCloudDirect(
+          entry.appId,
+          entry.appRuntimeMeta,
+        );
       } else if (
         entry.kind === "app-db-config" &&
         entry.appId &&
         entry.appDbConfig
       ) {
-        ok = await uploadAppDbConfigToCloudDirect(entry.appId, entry.appDbConfig);
+        ok = await uploadAppDbConfigToCloudDirect(
+          entry.appId,
+          entry.appDbConfig,
+        );
       }
       if (ok) {
         await removeEntry(entry.id);

--- a/src/gateway/services/syncV3/outboxFile.ts
+++ b/src/gateway/services/syncV3/outboxFile.ts
@@ -1,0 +1,242 @@
+/**
+ * Bounded reads for the Sync V3 outbox files.
+ *
+ * The outboxes are JSONL queues whose entries carry app file contents inline,
+ * so one line can be hundreds of megabytes. Reading them with
+ * `fs.readFile(path, "utf8")` materialises the whole file as a single JS string
+ * and aborts the process once that passes V8's string ceiling: a 1.6GB outbox
+ * killed the gateway on every launch, before any of it could be drained.
+ *
+ * Lines are therefore streamed as bytes and only decoded once a full line is in
+ * hand and known to be under `maxLineBytes`. An oversized line is never turned
+ * into a string — its bytes stream straight to a quarantine file so the entries
+ * behind it can drain and the payload stays on disk for inspection.
+ */
+
+import { createReadStream, createWriteStream, promises as fs } from "node:fs";
+import { pipeline } from "node:stream/promises";
+
+const NEWLINE = 0x0a;
+
+/**
+ * A single queued op. Above this, an entry cannot be pushed anyway.
+ *
+ * Set well above the collector's batch budget so JSON escaping cannot turn an
+ * acceptable batch into an unwritable line.
+ */
+export const MAX_OUTBOX_LINE_BYTES = 16 * 1024 * 1024;
+
+/** Whole queue. Above this, reading every entry to update one is too costly. */
+export const MAX_OUTBOX_FILE_BYTES = 64 * 1024 * 1024;
+
+export interface OversizedLine {
+  /** 1-based line number in the source file. */
+  lineNumber: number;
+  byteLength: number;
+}
+
+export interface StreamJsonlHandlers {
+  maxLineBytes: number;
+  /** Called with each complete line under the cap, newline stripped. */
+  onLine: (line: string, lineNumber: number) => void | Promise<void>;
+  /** Called with raw bytes of an oversized line, in arrival order. */
+  onOversizedChunk?: (chunk: Buffer) => void | Promise<void>;
+  onOversizedEnd?: (info: OversizedLine) => void | Promise<void>;
+}
+
+/**
+ * Walk a JSONL file line by line without ever holding an oversized line in
+ * memory. Bytes of an oversized line are handed to `onOversizedChunk` as they
+ * arrive and then dropped.
+ */
+export async function streamJsonlLines(
+  filePath: string,
+  handlers: StreamJsonlHandlers,
+): Promise<void> {
+  const { maxLineBytes, onLine, onOversizedChunk, onOversizedEnd } = handlers;
+
+  let pending: Buffer[] = [];
+  let pendingBytes = 0;
+  let overflowed = false;
+  let lineNumber = 0;
+
+  const finishLine = async (): Promise<void> => {
+    lineNumber += 1;
+    if (overflowed) {
+      await onOversizedEnd?.({ lineNumber, byteLength: pendingBytes });
+    } else if (pendingBytes > 0) {
+      const text = Buffer.concat(pending).toString("utf8").trim();
+      if (text.length > 0) {
+        await onLine(text, lineNumber);
+      }
+    }
+    pending = [];
+    pendingBytes = 0;
+    overflowed = false;
+  };
+
+  const takeSegment = async (segment: Buffer): Promise<void> => {
+    if (segment.length === 0) {
+      return;
+    }
+    pendingBytes += segment.length;
+    if (overflowed || pendingBytes > maxLineBytes) {
+      // Never accumulate: hand the bytes off and forget them.
+      if (!overflowed) {
+        for (const buffered of pending) {
+          await onOversizedChunk?.(buffered);
+        }
+        pending = [];
+        overflowed = true;
+      }
+      await onOversizedChunk?.(segment);
+      return;
+    }
+    pending.push(segment);
+  };
+
+  const stream = createReadStream(filePath);
+  try {
+    for await (const chunk of stream as AsyncIterable<Buffer>) {
+      let start = 0;
+      let index = chunk.indexOf(NEWLINE, start);
+      while (index !== -1) {
+        await takeSegment(chunk.subarray(start, index));
+        if (overflowed) {
+          await onOversizedChunk?.(Buffer.from([NEWLINE]));
+        }
+        await finishLine();
+        start = index + 1;
+        index = chunk.indexOf(NEWLINE, start);
+      }
+      await takeSegment(chunk.subarray(start));
+    }
+  } catch (err) {
+    stream.destroy();
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+
+  if (pendingBytes > 0 || overflowed) {
+    await finishLine();
+  }
+}
+
+export interface BoundedJsonlRead {
+  lines: string[];
+  oversized: OversizedLine[];
+}
+
+/**
+ * Read every line under the cap, skipping (and reporting) oversized ones.
+ * Use this wherever a full `readFile` would otherwise be unbounded.
+ */
+export async function readJsonlBounded(
+  filePath: string,
+  maxLineBytes = MAX_OUTBOX_LINE_BYTES,
+): Promise<BoundedJsonlRead> {
+  const lines: string[] = [];
+  const oversized: OversizedLine[] = [];
+  await streamJsonlLines(filePath, {
+    maxLineBytes,
+    onLine: (line) => {
+      lines.push(line);
+    },
+    onOversizedEnd: (info) => {
+      oversized.push(info);
+    },
+  });
+  return { lines, oversized };
+}
+
+export interface CompactResult {
+  keptLines: number;
+  quarantinedLines: number;
+  quarantinedBytes: number;
+}
+
+/**
+ * Rewrite a JSONL file without its oversized lines, moving their bytes to
+ * `quarantinePath`. Both writes stream, so peak memory stays at one chunk.
+ */
+export async function compactJsonlDroppingOversized(
+  filePath: string,
+  options: {
+    maxLineBytes?: number;
+    quarantinePath: string;
+  },
+): Promise<CompactResult> {
+  const maxLineBytes = options.maxLineBytes ?? MAX_OUTBOX_LINE_BYTES;
+  const tmpPath = `${filePath}.compact-${process.pid}-${Date.now()}`;
+
+  const kept = createWriteStream(tmpPath, { flags: "w" });
+  const quarantine = createWriteStream(options.quarantinePath, { flags: "a" });
+
+  const result: CompactResult = {
+    keptLines: 0,
+    quarantinedLines: 0,
+    quarantinedBytes: 0,
+  };
+
+  const write = (
+    stream: import("node:fs").WriteStream,
+    data: string | Buffer,
+  ): Promise<void> =>
+    new Promise((resolve, reject) => {
+      stream.write(data, (err) => (err ? reject(err) : resolve()));
+    });
+
+  try {
+    await streamJsonlLines(filePath, {
+      maxLineBytes,
+      onLine: async (line) => {
+        await write(kept, `${line}\n`);
+        result.keptLines += 1;
+      },
+      onOversizedChunk: async (chunk) => {
+        await write(quarantine, chunk);
+      },
+      onOversizedEnd: (info) => {
+        result.quarantinedLines += 1;
+        result.quarantinedBytes += info.byteLength;
+      },
+    });
+  } finally {
+    await Promise.all([closeStream(kept), closeStream(quarantine)]);
+  }
+
+  if (result.quarantinedLines === 0) {
+    await fs.rm(tmpPath, { force: true });
+    return result;
+  }
+
+  await fs.rename(tmpPath, filePath);
+  return result;
+}
+
+function closeStream(stream: import("node:fs").WriteStream): Promise<void> {
+  return new Promise((resolve) => {
+    stream.end(() => resolve());
+  });
+}
+
+/** Byte size of a file, or 0 when it does not exist. */
+export async function fileBytes(filePath: string): Promise<number> {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.size;
+  } catch {
+    return 0;
+  }
+}
+
+/** Copy a file with streams, so size does not bound memory. */
+export async function copyFileStreaming(
+  from: string,
+  to: string,
+): Promise<void> {
+  await pipeline(createReadStream(from), createWriteStream(to));
+}

--- a/src/gateway/services/syncV3/pushAppViaWriterOps.ts
+++ b/src/gateway/services/syncV3/pushAppViaWriterOps.ts
@@ -11,6 +11,11 @@ export interface PushAppViaWriterResult {
   filesSent: number;
   skippedUnchanged: number;
   outboxReplayed: number;
+  /**
+   * Changed files held back by the batch budget. Non-zero means this app has
+   * more to send and needs another flush to converge.
+   */
+  deferred: number;
 }
 
 export async function pushAppViaWriterOps(

--- a/src/gateway/services/syncV3/pushAppWriterOpsCore.ts
+++ b/src/gateway/services/syncV3/pushAppWriterOpsCore.ts
@@ -65,8 +65,13 @@ async function markSyncedPaths(
 export async function pushAppWriterOpsForPaprDir(
   options: PushAppWriterOpsForPaprDirOptions,
 ): Promise<PushAppViaWriterResult> {
-  const { paprDir, appId, message, author = "paprwork-desktop", onSynced } =
-    options;
+  const {
+    paprDir,
+    appId,
+    message,
+    author = "paprwork-desktop",
+    onSynced,
+  } = options;
 
   await ensureAppRepoRecord(appId);
 
@@ -101,9 +106,8 @@ export async function pushAppWriterOpsForPaprDir(
   }
 
   if (!options.skipPrepare) {
-    const { prepareAppForCloudGitSync } = await import(
-      "../cloudSync/prepareAppsForCloud.js"
-    );
+    const { prepareAppForCloudGitSync } =
+      await import("../cloudSync/prepareAppsForCloud.js");
     await prepareAppForCloudGitSync(paprDir, appId);
   }
 
@@ -115,6 +119,7 @@ export async function pushAppWriterOpsForPaprDir(
       filesSent: 0,
       skippedUnchanged: collected.skippedUnchanged,
       outboxReplayed,
+      deferred: collected.deferred,
     };
   }
 
@@ -141,7 +146,8 @@ export async function pushAppWriterOpsForPaprDir(
 
     const record = await getAppRepoRecord(appId);
     if (record && ack.commitSha) {
-      const { fanoutAppRepoCommitted } = await import("./appRepoCommittedFanout.js");
+      const { fanoutAppRepoCommitted } =
+        await import("./appRepoCommittedFanout.js");
       await fanoutAppRepoCommitted({
         appId,
         commitSha: ack.commitSha,
@@ -158,6 +164,7 @@ export async function pushAppWriterOpsForPaprDir(
       filesSent: collected.files.length,
       skippedUnchanged: collected.skippedUnchanged,
       outboxReplayed,
+      deferred: collected.deferred,
     };
   } catch (err) {
     return handleOutboxPushFailure(outboxEntry.id, err, 1);

--- a/tests/collect-app-op-files.test.ts
+++ b/tests/collect-app-op-files.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { dbIdFromPath } from "../src/gateway/services/DatabaseRegistryService.js";
 import {
   collectAppOpFiles,
+  MAX_OP_BATCH_CONTENT_BYTES,
   resolveWriterSyncedLocalPaths,
 } from "../src/gateway/services/syncV3/collectAppOpFiles.js";
 
@@ -78,14 +79,13 @@ describe("collectAppOpFiles", () => {
     fs.mkdirSync(path.join(jobDir, "data"), { recursive: true });
     fs.writeFileSync(path.join(jobDir, "data", "data.db"), "sqlite");
 
-    const dbPath = path.join(paprDir, "data", "databases", "billing", "data.db");
-    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    const dbDir = path.join(paprDir, "data", "databases", "billing");
+    const dbPath = path.join(dbDir, "data.db");
+    fs.mkdirSync(dbDir, { recursive: true });
     fs.writeFileSync(dbPath, "");
-    fs.mkdirSync(path.join(paprDir, "data", "databases", "billing", "migrations"), {
-      recursive: true,
-    });
+    fs.mkdirSync(path.join(dbDir, "migrations"), { recursive: true });
     fs.writeFileSync(
-      path.join(paprDir, "data", "databases", "billing", "migrations", "0001_init.sql"),
+      path.join(dbDir, "migrations", "0001_init.sql"),
       "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT);\n",
     );
 
@@ -152,6 +152,73 @@ describe("collectAppOpFiles", () => {
 
     const { files } = await collectAppOpFiles(paprDir, consumerAppId);
     expect(files.some((file) => file.path.startsWith("databases/"))).toBe(false);
+  });
+
+  it("never reads app-local databases or their backups", async () => {
+    const paprDir = makePaprDir();
+    fs.mkdirSync(path.join(paprDir, "data"), { recursive: true });
+    seedWorkspace(paprDir);
+
+    // The shape that exhausted the heap: a SQLite file and its dated backups
+    // sitting in the app folder, each read as a UTF-8 string before filtering.
+    const appDir = path.join(paprDir, "apps", appId);
+    const big = "x".repeat(1024 * 1024);
+    fs.writeFileSync(path.join(appDir, "database.db"), big);
+    fs.writeFileSync(path.join(appDir, "database.db-wal"), big);
+    fs.writeFileSync(path.join(appDir, "database.db.bak.2026-08-21"), big);
+    fs.mkdirSync(path.join(appDir, "backups"), { recursive: true });
+    fs.writeFileSync(path.join(appDir, "backups", "snapshot.json"), "{}");
+
+    const { files, rejected } = await collectAppOpFiles(paprDir, appId);
+    const paths = files.map((file) => file.path);
+
+    expect(paths).toContain("metadata.json");
+    expect(paths.some((p) => p.includes("database.db"))).toBe(false);
+    expect(paths.some((p) => p.startsWith("backups/"))).toBe(false);
+    // Excluded during the walk, so they are not even reported as rejected.
+    expect(rejected).toEqual([]);
+  });
+
+  it("skips a file over the size limit without sending it", async () => {
+    const paprDir = makePaprDir();
+    fs.mkdirSync(path.join(paprDir, "data"), { recursive: true });
+    seedWorkspace(paprDir);
+
+    fs.writeFileSync(
+      path.join(paprDir, "apps", appId, "huge.txt"),
+      "a".repeat(11 * 1024 * 1024),
+    );
+
+    const { files, rejected } = await collectAppOpFiles(paprDir, appId);
+
+    expect(files.some((file) => file.path === "huge.txt")).toBe(false);
+    expect(rejected).toEqual([
+      { path: "huge.txt", reason: expect.stringContaining("App Files") },
+    ]);
+  });
+
+  it("defers files past the batch budget to a later flush", async () => {
+    const paprDir = makePaprDir();
+    fs.mkdirSync(path.join(paprDir, "data"), { recursive: true });
+    seedWorkspace(paprDir);
+
+    // Eight 1MB assets against a 6MB budget: one op cannot carry them all.
+    const appDir = path.join(paprDir, "apps", appId);
+    for (let index = 0; index < 8; index += 1) {
+      fs.writeFileSync(
+        path.join(appDir, `asset-${index}.txt`),
+        "a".repeat(1024 * 1024),
+      );
+    }
+
+    const { files, deferred } = await collectAppOpFiles(paprDir, appId);
+
+    const totalBytes = files.reduce(
+      (sum, file) => sum + Buffer.byteLength(file.content ?? "", "utf8"),
+      0,
+    );
+    expect(deferred).toBeGreaterThan(0);
+    expect(totalBytes).toBeLessThanOrEqual(MAX_OP_BATCH_CONTENT_BYTES);
   });
 
   it("resolveWriterSyncedLocalPaths marks Jobs and owner migration roots", async () => {

--- a/tests/never-track-repo-path.test.ts
+++ b/tests/never-track-repo-path.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Path exclusions for the writer door.
+ *
+ * These specs decide what never enters app sync. They were matched as bare
+ * substrings, which both worked (SQLite files were excluded) and quietly
+ * misfired: `*.db` matched `sandbox.ts`, `*.mov` matched `remove.ts`. Ordinary
+ * source files were dropped from sync with no error anywhere.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isNeverTrackRepoPath,
+  validateOpFileForWriter,
+} from "../src/gateway/services/appRepoWriter/abuseFilter.js";
+import { MAX_TRACKED_FILE_BYTES } from "../src/gateway/services/cloudSync/repoHygiene.js";
+
+describe("isNeverTrackRepoPath", () => {
+  it("excludes SQLite databases and their sidecars", () => {
+    for (const repoPath of [
+      "database.db",
+      "data/database.db",
+      "data/app.sqlite",
+      "data/app.sqlite3",
+      "data/database.db-wal",
+      "data/database.db-shm",
+      "data/database.db-journal",
+    ]) {
+      expect(isNeverTrackRepoPath(repoPath), repoPath).toBe(true);
+    }
+  });
+
+  it("excludes backup copies, including dated infixes", () => {
+    for (const repoPath of [
+      "database.db.bak",
+      "database.db.bak.capital-one-ventures",
+      "data/registry.json.bak.2026-08-21",
+      "backups/database.db",
+      "data/backups/old.json",
+    ]) {
+      expect(isNeverTrackRepoPath(repoPath), repoPath).toBe(true);
+    }
+  });
+
+  it("excludes archives and media", () => {
+    for (const repoPath of [
+      "assets/bundle.zip",
+      "assets/clip.mp4",
+      "assets/take.mov",
+      "assets/voice.wav",
+      "release.tar.gz",
+    ]) {
+      expect(isNeverTrackRepoPath(repoPath), repoPath).toBe(true);
+    }
+  });
+
+  it("keeps source files whose names merely contain a spec's letters", () => {
+    // Each of these was excluded from sync by substring matching.
+    for (const repoPath of [
+      "src/remove.ts", // *.mov
+      "src/sandbox.ts", // *.db
+      "src/dbutils.ts", // *.db
+      "components/movie.tsx", // *.mov
+      "utils/zipcode.ts", // *.zip
+      "audio/waveform.ts", // *.wav
+      "lib/mp4parse.ts", // *.mp4
+      "index.html",
+      "metadata.json",
+    ]) {
+      expect(isNeverTrackRepoPath(repoPath), repoPath).toBe(false);
+    }
+  });
+
+  it("excludes stranded git repack temp files", () => {
+    expect(isNeverTrackRepoPath("tmp_pack_abc123")).toBe(true);
+  });
+});
+
+describe("validateOpFileForWriter", () => {
+  it("rejects excluded paths", () => {
+    expect(
+      validateOpFileForWriter({ path: "data/database.db", content: "x" }),
+    ).toMatchObject({ reason: expect.stringContaining("hygiene") });
+  });
+
+  it("rejects path traversal", () => {
+    expect(
+      validateOpFileForWriter({ path: "../escape.ts", content: "x" }),
+    ).toMatchObject({ reason: "invalid path" });
+  });
+
+  it("rejects content over the tracked file limit", () => {
+    const rejection = validateOpFileForWriter({
+      path: "big.txt",
+      content: "a".repeat(MAX_TRACKED_FILE_BYTES + 1),
+    });
+    expect(rejection?.reason).toContain("byte limit");
+  });
+
+  it("accepts an ordinary source file", () => {
+    expect(
+      validateOpFileForWriter({ path: "src/remove.ts", content: "export {};" }),
+    ).toBeNull();
+  });
+});

--- a/tests/sync-outbox-guardrails.test.ts
+++ b/tests/sync-outbox-guardrails.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Guardrails that keep the writer outbox drainable.
+ *
+ * A 1.6GB outbox aborted the gateway on every launch: entries carry file
+ * contents inline, one line had grown to ~520MB, and the queue was read whole
+ * with fs.readFile. These tests pin the three properties that prevent it —
+ * bounded reads, a cap at enqueue, and attempts that advance even when a push
+ * never returns.
+ */
+
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getPaprRoot } from "../src/core/utils/paprRoot.js";
+import { SYNC_OUTBOX_FILENAME } from "../src/core/types/appRepoWriterOps.js";
+import {
+  appendOutboxEntry,
+  clearSyncOutboxForTests,
+  listOutboxEntries,
+  listPendingOutboxEntries,
+  markOutboxDeadLetter,
+  markOutboxInflight,
+  OutboxEntryTooLargeError,
+} from "../src/gateway/services/syncV3/SyncOutbox.js";
+import {
+  compactJsonlDroppingOversized,
+  MAX_OUTBOX_LINE_BYTES,
+  readJsonlBounded,
+} from "../src/gateway/services/syncV3/outboxFile.js";
+import { useIsolatedPaprWorkspace } from "./setup/isolatedWorkspace.js";
+
+function outboxPath(): string {
+  return path.join(getPaprRoot(), "data", SYNC_OUTBOX_FILENAME);
+}
+
+async function writeOutboxLines(lines: string[]): Promise<void> {
+  const filePath = outboxPath();
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, lines.map((line) => `${line}\n`).join(""));
+}
+
+describe("readJsonlBounded", () => {
+  useIsolatedPaprWorkspace("outbox-bounded-read");
+
+  afterEach(async () => {
+    await clearSyncOutboxForTests();
+  });
+
+  it("returns lines under the cap and reports oversized ones", async () => {
+    const small = JSON.stringify({ id: "a" });
+    const huge = JSON.stringify({ id: "b", blob: "x".repeat(4096) });
+    await writeOutboxLines([small, huge, small]);
+
+    const { lines, oversized } = await readJsonlBounded(outboxPath(), 1024);
+
+    expect(lines).toEqual([small, small]);
+    expect(oversized).toHaveLength(1);
+    expect(oversized[0].lineNumber).toBe(2);
+    expect(oversized[0].byteLength).toBeGreaterThan(1024);
+  });
+
+  it("reads a line that spans many stream chunks", async () => {
+    // Larger than the 64KB default read chunk, so line assembly is exercised.
+    const long = JSON.stringify({ id: "a", blob: "y".repeat(200_000) });
+    await writeOutboxLines([long]);
+
+    const { lines, oversized } = await readJsonlBounded(outboxPath());
+
+    expect(oversized).toEqual([]);
+    expect(JSON.parse(lines[0])).toEqual(JSON.parse(long));
+  });
+
+  it("handles multi-byte characters split across chunks", async () => {
+    const line = JSON.stringify({ id: "a", blob: "é".repeat(100_000) });
+    await writeOutboxLines([line]);
+
+    const { lines } = await readJsonlBounded(outboxPath());
+
+    expect(JSON.parse(lines[0])).toEqual(JSON.parse(line));
+  });
+
+  it("returns nothing for a missing file", async () => {
+    const result = await readJsonlBounded(
+      path.join(getPaprRoot(), "data", "does-not-exist.jsonl"),
+    );
+    expect(result).toEqual({ lines: [], oversized: [] });
+  });
+
+  it("tolerates a final line without a trailing newline", async () => {
+    const filePath = outboxPath();
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, `${JSON.stringify({ id: "a" })}`);
+
+    const { lines } = await readJsonlBounded(filePath);
+    expect(lines).toHaveLength(1);
+  });
+});
+
+describe("compactJsonlDroppingOversized", () => {
+  useIsolatedPaprWorkspace("outbox-compaction");
+
+  afterEach(async () => {
+    await clearSyncOutboxForTests();
+  });
+
+  it("keeps small lines, moves oversized bytes to quarantine", async () => {
+    const keep = JSON.stringify({ id: "keep" });
+    const drop = JSON.stringify({ id: "drop", blob: "z".repeat(8192) });
+    await writeOutboxLines([keep, drop, keep]);
+    const quarantine = `${outboxPath()}.oversized`;
+
+    const result = await compactJsonlDroppingOversized(outboxPath(), {
+      maxLineBytes: 1024,
+      quarantinePath: quarantine,
+    });
+
+    expect(result.keptLines).toBe(2);
+    expect(result.quarantinedLines).toBe(1);
+
+    const remaining = await fs.readFile(outboxPath(), "utf8");
+    expect(remaining.trim().split("\n")).toEqual([keep, keep]);
+
+    // The payload is preserved on disk rather than discarded.
+    const quarantined = await fs.readFile(quarantine, "utf8");
+    expect(JSON.parse(quarantined.trim())).toEqual(JSON.parse(drop));
+  });
+
+  it("leaves the file untouched when nothing is oversized", async () => {
+    const keep = JSON.stringify({ id: "keep" });
+    await writeOutboxLines([keep]);
+    const before = await fs.readFile(outboxPath(), "utf8");
+
+    const result = await compactJsonlDroppingOversized(outboxPath(), {
+      maxLineBytes: MAX_OUTBOX_LINE_BYTES,
+      quarantinePath: `${outboxPath()}.oversized`,
+    });
+
+    expect(result.quarantinedLines).toBe(0);
+    expect(await fs.readFile(outboxPath(), "utf8")).toBe(before);
+  });
+});
+
+describe("SyncOutbox guardrails", () => {
+  useIsolatedPaprWorkspace("outbox-guardrails");
+
+  afterEach(async () => {
+    await clearSyncOutboxForTests();
+  });
+
+  it("refuses an op too large to push instead of queueing it", async () => {
+    const oversized = "a".repeat(MAX_OUTBOX_LINE_BYTES + 1);
+
+    await expect(
+      appendOutboxEntry({
+        appId: "app-1",
+        files: [{ path: "big.bin", content: oversized, parentHash: "" }],
+        author: "test",
+        message: "too big",
+      }),
+    ).rejects.toThrow(OutboxEntryTooLargeError);
+
+    // Nothing was written, so nothing can be retried forever.
+    expect(await listOutboxEntries("app-1")).toEqual([]);
+  });
+
+  it("counts a claimed push as an attempt", async () => {
+    const entry = await appendOutboxEntry({
+      appId: "app-1",
+      files: [{ path: "a.txt", content: "hello", parentHash: "" }],
+      author: "test",
+      message: "first",
+    });
+    expect(entry.attempts).toBe(0);
+
+    // Simulates a push that never returns: the process dies while inflight.
+    await markOutboxInflight(entry.id);
+    await markOutboxInflight(entry.id);
+
+    const [stored] = await listOutboxEntries("app-1");
+    expect(stored.attempts).toBe(2);
+  });
+
+  it("drops the payload when dead-lettering but keeps the paths", async () => {
+    const entry = await appendOutboxEntry({
+      appId: "app-1",
+      files: [
+        { path: "a.txt", content: "x".repeat(50_000), parentHash: "" },
+        { path: "b.txt", content: "y".repeat(50_000), parentHash: "" },
+      ],
+      author: "test",
+      message: "doomed",
+    });
+
+    await markOutboxDeadLetter(entry.id, "rejected by writer");
+
+    const [stored] = await listOutboxEntries("app-1");
+    expect(stored.status).toBe("dead_letter");
+    expect(stored.files).toEqual([]);
+    expect(stored.droppedFileCount).toBe(2);
+    expect(stored.droppedFilePaths).toEqual(["a.txt", "b.txt"]);
+
+    // A dead letter must not keep occupying the queue's byte budget.
+    const bytes = (await fs.stat(outboxPath())).size;
+    expect(bytes).toBeLessThan(2_000);
+  });
+
+  it("replaces a pending entry the new one supersedes", async () => {
+    const files = [{ path: "a.txt", content: "v1", parentHash: "" }];
+    const first = await appendOutboxEntry({
+      appId: "app-1",
+      files,
+      author: "test",
+      message: "flush 1",
+    });
+    const second = await appendOutboxEntry({
+      appId: "app-1",
+      files: [{ path: "a.txt", content: "v2", parentHash: "" }],
+      author: "test",
+      message: "flush 2",
+    });
+
+    const pending = await listPendingOutboxEntries("app-1");
+    expect(pending.map((entry) => entry.id)).toEqual([second.id]);
+    expect(pending[0].files[0].content).toBe("v2");
+    expect(pending.map((entry) => entry.id)).not.toContain(first.id);
+  });
+
+  it("keeps a pending entry covering paths the new one does not", async () => {
+    const first = await appendOutboxEntry({
+      appId: "app-1",
+      files: [{ path: "a.txt", content: "v1", parentHash: "" }],
+      author: "test",
+      message: "flush 1",
+    });
+    const second = await appendOutboxEntry({
+      appId: "app-1",
+      files: [{ path: "b.txt", content: "v1", parentHash: "" }],
+      author: "test",
+      message: "flush 2",
+    });
+
+    const pending = await listPendingOutboxEntries("app-1");
+    expect(pending.map((entry) => entry.id).sort()).toEqual(
+      [first.id, second.id].sort(),
+    );
+  });
+
+  it("does not supersede entries belonging to another app", async () => {
+    const other = await appendOutboxEntry({
+      appId: "app-2",
+      files: [{ path: "a.txt", content: "v1", parentHash: "" }],
+      author: "test",
+      message: "other app",
+    });
+    await appendOutboxEntry({
+      appId: "app-1",
+      files: [{ path: "a.txt", content: "v2", parentHash: "" }],
+      author: "test",
+      message: "this app",
+    });
+
+    expect((await listPendingOutboxEntries("app-2")).map((e) => e.id)).toEqual([
+      other.id,
+    ]);
+  });
+
+  it("does not supersede an entry already inflight", async () => {
+    const inflight = await appendOutboxEntry({
+      appId: "app-1",
+      files: [{ path: "a.txt", content: "v1", parentHash: "" }],
+      author: "test",
+      message: "inflight",
+    });
+    await markOutboxInflight(inflight.id);
+
+    await appendOutboxEntry({
+      appId: "app-1",
+      files: [{ path: "a.txt", content: "v2", parentHash: "" }],
+      author: "test",
+      message: "next",
+    });
+
+    const all = await listOutboxEntries("app-1");
+    expect(all).toHaveLength(2);
+    expect(all.find((entry) => entry.id === inflight.id)?.status).toBe(
+      "inflight",
+    );
+  });
+
+  it("quarantines an oversized line already on disk so the queue drains", async () => {
+    const good = await appendOutboxEntry({
+      appId: "app-1",
+      files: [{ path: "a.txt", content: "hello", parentHash: "" }],
+      author: "test",
+      message: "good",
+    });
+
+    // An entry written before the cap existed — the shape that jammed the queue.
+    const poison = JSON.stringify({
+      id: "poison",
+      appId: "app-1",
+      idempotencyKey: "k",
+      files: [
+        {
+          path: "huge.pdf",
+          content: "p".repeat(MAX_OUTBOX_LINE_BYTES + 1),
+          parentHash: "",
+        },
+      ],
+      author: "test",
+      message: "poison",
+      status: "pending",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      attempts: 0,
+    });
+    await fs.appendFile(outboxPath(), `${poison}\n`);
+
+    const pending = await listPendingOutboxEntries("app-1");
+
+    expect(pending.map((entry) => entry.id)).toEqual([good.id]);
+    // Compacted out of the queue, retained on disk for inspection.
+    const quarantined = await fs.stat(`${outboxPath()}.oversized`);
+    expect(quarantined.size).toBeGreaterThan(MAX_OUTBOX_LINE_BYTES);
+    expect((await fs.stat(outboxPath())).size).toBeLessThan(2_000);
+  });
+});

--- a/tests/sync-outbox-recovery-fixture.test.ts
+++ b/tests/sync-outbox-recovery-fixture.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Recovery check against a real oversized outbox.
+ *
+ * The other guardrail tests use synthetic files. This one runs the real read
+ * path over a copy of a production queue, because the failure it prevents only
+ * showed up at production scale: a 1.6GB outbox whose three largest lines were
+ * ~496MB each, read whole with fs.readFile, aborting the gateway on launch.
+ *
+ * Skipped unless pointed at fixture files, so it is opt-in rather than
+ * environment-dependent:
+ *
+ *   OUTBOX_FIXTURE="/path/to/sync-outbox.jsonl.oversized:/path/to/sync-outbox.jsonl" \
+ *     npx vitest run tests/sync-outbox-recovery-fixture.test.ts --project unit-backend
+ *
+ * Paths are colon-separated and concatenated in order, so a quarantine file and
+ * a queue file can be recombined into the original condition. They are only
+ * read; all writes land in the isolated workspace.
+ */
+
+import { createReadStream, createWriteStream, promises as fs } from "node:fs";
+import * as path from "node:path";
+import { pipeline } from "node:stream/promises";
+import { describe, expect, it } from "vitest";
+
+import { getPaprRoot } from "../src/core/utils/paprRoot.js";
+import { SYNC_OUTBOX_FILENAME } from "../src/core/types/appRepoWriterOps.js";
+import {
+  listOutboxEntries,
+  listPendingOutboxEntries,
+} from "../src/gateway/services/syncV3/SyncOutbox.js";
+import {
+  MAX_OUTBOX_FILE_BYTES,
+  MAX_OUTBOX_LINE_BYTES,
+} from "../src/gateway/services/syncV3/outboxFile.js";
+import { useIsolatedPaprWorkspace } from "./setup/isolatedWorkspace.js";
+
+const fixtures = (process.env.OUTBOX_FIXTURE ?? "")
+  .split(":")
+  .map((entry) => entry.trim())
+  .filter((entry) => entry.length > 0);
+
+const mb = (bytes: number): string => `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+
+async function sizeOf(filePath: string): Promise<number> {
+  try {
+    return (await fs.stat(filePath)).size;
+  } catch {
+    return 0;
+  }
+}
+
+describe.skipIf(fixtures.length === 0)("outbox recovery on real data", () => {
+  useIsolatedPaprWorkspace("outbox-recovery");
+
+  it("drains an oversized production queue without loading it", async () => {
+    const outboxPath = path.join(getPaprRoot(), "data", SYNC_OUTBOX_FILENAME);
+    await fs.mkdir(path.dirname(outboxPath), { recursive: true });
+
+    let sourceBytes = 0;
+    for (const fixture of fixtures) {
+      sourceBytes += await sizeOf(fixture);
+      await pipeline(
+        createReadStream(fixture),
+        createWriteStream(outboxPath, { flags: "a" }),
+      );
+    }
+
+    const before = process.memoryUsage().heapUsed;
+    const started = Date.now();
+    const entries = await listOutboxEntries();
+    const elapsedMs = Date.now() - started;
+    const heapGrowth = process.memoryUsage().heapUsed - before;
+    const pending = await listPendingOutboxEntries();
+
+    const afterBytes = await sizeOf(outboxPath);
+    const quarantineBytes = await sizeOf(`${outboxPath}.oversized`);
+
+    console.log(
+      `\n  queue ${mb(sourceBytes)} → ${mb(afterBytes)} ` +
+        `(quarantined ${mb(quarantineBytes)}) in ${elapsedMs}ms, ` +
+        `heap +${mb(heapGrowth)}\n  ${entries.length} entries kept, ` +
+        `${pending.length} pending\n`,
+    );
+
+    // The queue is readable and bounded.
+    expect(afterBytes).toBeLessThanOrEqual(MAX_OUTBOX_FILE_BYTES);
+    expect(entries.length).toBeGreaterThan(0);
+
+    // No payload large enough to abort a read survives in the queue.
+    for (const entry of entries) {
+      for (const file of entry.files) {
+        expect(
+          Buffer.byteLength(file.content ?? "", "utf8"),
+        ).toBeLessThanOrEqual(MAX_OUTBOX_LINE_BYTES);
+      }
+    }
+
+    // Oversized payloads are moved aside, not deleted.
+    if (sourceBytes > MAX_OUTBOX_LINE_BYTES) {
+      expect(quarantineBytes).toBeGreaterThan(0);
+    }
+
+    // Reading must not scale with file size — that was the whole failure.
+    expect(heapGrowth).toBeLessThan(sourceBytes);
+  });
+});


### PR DESCRIPTION
## What broke

The gateway died with a V8 heap OOM roughly 70 seconds after every launch. The allocation that killed it was one string:

```ts
const raw = await fs.readFile(outboxPath(), "utf8"); // 1.6 GB
```

`~/Papr/orgs/<org>/namespaces/<ns>/data/sync-outbox.jsonl` had reached 1.6 GB — 869 entries, 868 still pending, with three individual lines near 520 MB each. `appSyncV3StatusReport` called into the outbox several times per app shortly after startup, which is what put the read ~70 s in rather than at boot. Reading the queue to decide what to do was itself the crash, so the queue could only grow.

## Why it grew

Four problems compounded:

1. **Entries carry file contents inline with no size cap.** The Papr Data Room app keeps uploaded PDFs and images inside its app directory, so one op could carry hundreds of megabytes.
2. **Binaries were read as UTF-8 JSON strings.** A JPEG read as `utf8` both bloats (invalid sequences become U+FFFD, 3 bytes each) and corrupts — large *and* useless.
3. **A crash did not count as an attempt.** `markOutboxInflight` left `attempts` untouched, so the entry that killed the process was retried forever and never dead-lettered.
4. **Nothing coalesced duplicates.** Every debounced flush appended a fresh op for the same app and paths without retiring older pending ones.

Head-of-line blocking with a poison pill at the front.

## Layer 1 — Gateway guardrails

New `syncV3/outboxFile.ts`: `streamJsonlLines` walks the file as bytes and only decodes a line once it is complete *and* known to be under the cap. An oversized line is never turned into a string — its bytes stream into a `.oversized` quarantine file so the entries behind it drain and the payload stays on disk. Peak memory is one stream chunk regardless of file size.

| Constant | Value | Meaning |
|---|---|---|
| `MAX_OUTBOX_LINE_BYTES` | 16 MB | One queued op. Set well above the collector's 6 MB batch budget so JSON escaping cannot turn an acceptable batch into an unwritable line. |
| `MAX_OUTBOX_FILE_BYTES` | 64 MB | Whole queue. Above this, reading every entry to update one is too costly. |

In `SyncOutbox.ts`:

- **Cap at enqueue** — `OutboxEntryTooLargeError` instead of writing a line that can never be read back.
- **A crash counts as an attempt** — `markOutboxInflight` increments `attempts`, so a poison pill reaches the dead-letter threshold.
- **Dead-lettering strips payloads** — keeps `droppedFileCount` + `droppedFilePaths`, drops `files[].content`.
- **Coalescing** — a new op supersedes older pending ops for the same app covering the same paths.
- **File budget backstop** — `trimToFileBudget` sheds the oldest work past 64 MB. Dropped ops are recollectible from the filesystem, so this costs a re-scan, not data.

`appSyncV3StatusReport` now reads the outbox once per app and filters, instead of three separate reads. Same bounded read replaced the unbounded one in `metadataOutbox.ts`.

## Layer 2 — Keep the bytes out

**A data-loss bug in the never-track matcher.** `matchesNeverTrackPathspec` compared by substring, so `*.db` excluded `sandbox.ts` and `*.bak.*` excluded anything containing `bak` — legitimate source files were silently dropped from sync. `isNeverTrackRepoPath` anchors matching: extensions against the basename suffix, directory specs against path segments. Added `*.db-journal` alongside `-wal` and `-shm`.

**Exclude before reading.** The walkers in `collectAppOpFiles` test `isNeverTrackRepoPath` while walking, so a 500 MB `database.db` is skipped by name and never read into memory. `candidateToOpFile` checks `stat.size` *before* `fs.readFile`.

**Aggregate batch budget.** Per-file limits do not bound a batch — a thousand 5 MB files still overflow. `MAX_OP_BATCH_CONTENT_BYTES` (6 MB) caps total content in one op; the remainder is counted as `deferred` and propagates through `PushAppViaWriterResult` → `FinalizeAppRepoMutationResult` → `cloudAppWriterDebouncedPush`, which re-queues the app. A large app syncs across several flushes instead of one unwritable op.

The OID cache is now read once per flush rather than once per file.

## Results

Against the real production outbox, reconstructed in an isolated workspace:

| | Before | After |
|---|---|---|
| Reading the queue | OOM, process dies | completes in 2.3 s |
| Peak heap growth | unbounded — a 1.5 GB string | **98 MB** |
| Entries recovered | 0 (crash) | **303**, all pending |
| Queue on disk | 1521 MB | **32 MB** |
| Oversized bytes | blocking the queue | 1489 MB quarantined |

Three lines accounted for the 1489 MB; the 303 entries behind them were unreachable before this change.

## Test plan

- [x] `npx vitest run tests/sync-outbox-guardrails.test.ts tests/never-track-repo-path.test.ts tests/collect-app-op-files.test.ts --project unit-backend` — 30 passed
- [x] Recovery against the real oversized outbox via `OUTBOX_FIXTURE` — passed (numbers above)
- [x] `npm run type-check` — clean
- [x] `npm run check:loc` — largest touched file is 440 lines
- [ ] Launch the app with the real outbox present and confirm the gateway starts and the queue drains

## Note for app authors

Guardrails stop the crash; they do not make large assets sync. An app that keeps uploads inside its own directory will now see them rejected as over the limit. Store them with App Files and keep the reference in SQLite. The Papr Data Room app is the first case and adopts the files SDK next.

## Docs

- `docs/SYNC_V3_OUTBOX_GUARDRAILS.md`
- `CLAUDE.md` — Issue 71

Made with [Cursor](https://cursor.com)