### PR TITLE
Stop table rebuilds from wedging cloud sync forever

### DIFF
--- a/src/gateway/services/jobs/jobMigrationLedgerSync.ts
+++ b/src/gateway/services/jobs/jobMigrationLedgerSync.ts
@@ -29,6 +29,7 @@ import {
   parseCreateIndexStatement,
   parseCreateTableStatement,
   parseDropStatement,
+  parseRenameTableStatement,
   splitSqlStatements,
 } from "./migrationSqlHelpers.js";
 
@@ -106,6 +107,66 @@ function isSupersededDrop(
       created.name === drop.name
     );
   });
+}
+
+/**
+ * Was the object this statement acts on renamed away later in the migration?
+ *
+ * Table rebuilds (the only way to change a column type or add a PRIMARY KEY in
+ * SQLite) are expressed as copy-and-swap:
+ *
+ *   CREATE TABLE t__papr_rebuild (…)      -- new shape
+ *   INSERT INTO t__papr_rebuild SELECT …  -- carry rows over
+ *   ALTER TABLE t RENAME TO t__papr_old
+ *   ALTER TABLE t__papr_rebuild RENAME TO t
+ *   DROP TABLE IF EXISTS t__papr_old
+ *
+ * Verifying statement-by-statement afterwards, the CREATE looks unsatisfied:
+ * `t__papr_rebuild` is gone, because it *became* `t`. That verdict is
+ * permanent — the name can never come back — so cloud sync wedges and every
+ * retry fails identically.
+ *
+ * Only the final state matters, so a statement whose object is renamed away by
+ * a later statement in the same migration is skipped. The rename target is
+ * itself verified when the loop reaches the statement that creates it.
+ */
+function isSupersededByRename(
+  ops: readonly JobMigrationSchemaOp[],
+  index: number,
+): boolean {
+  const op = ops[index];
+  const subject =
+    createdObject(op) ??
+    (op.kind === "sql"
+      ? (() => {
+          const rename = parseRenameTableStatement(op.statement);
+          return rename
+            ? { objectType: "table" as const, name: rename.to }
+            : null;
+        })()
+      : null);
+  if (!subject || subject.objectType !== "table") {
+    return false;
+  }
+  return ops.slice(index + 1).some((later) => {
+    if (later.kind !== "sql") {
+      return false;
+    }
+    const rename = parseRenameTableStatement(later.statement);
+    return rename !== null && rename.from === subject.name;
+  });
+}
+
+/**
+ * A statement is irrelevant to final state when a later statement in the same
+ * migration overwrites its effect. Checking these individually is what made
+ * table rebuilds fail verification forever.
+ */
+function isSuperseded(
+  ops: readonly JobMigrationSchemaOp[],
+  index: number,
+): boolean {
+  return isSupersededDrop(ops, index) || isSupersededByRename(ops, index);
 }
 
 function warnUnverifiable(
@@ -396,7 +457,7 @@ export async function verifyMigrationOnRemote(
   const unverifiable: string[] = [];
   for (let i = 0; i < ops.length; i += 1) {
     const op = ops[i];
-    if (isSupersededDrop(ops, i)) {
+    if (isSuperseded(ops, i)) {
       continue;
     }
     const check = await schemaOpSatisfiedOnRemote(remote, op);
@@ -434,7 +495,7 @@ export async function verifyMigrationOnLocal(
   const unverifiable: string[] = [];
   for (let i = 0; i < ops.length; i += 1) {
     const op = ops[i];
-    if (isSupersededDrop(ops, i)) {
+    if (isSuperseded(ops, i)) {
       continue;
     }
     const check = schemaOpSatisfiedOnLocal(localDb, op);

--- a/src/gateway/services/jobs/migrationSqlHelpers.ts
+++ b/src/gateway/services/jobs/migrationSqlHelpers.ts
@@ -95,6 +95,34 @@ export function parseAddColumnStatement(
   return { table, column };
 }
 
+/**
+ * ALTER TABLE x RENAME TO y — the statement that makes copy-and-swap rebuilds
+ * unverifiable by name lookup.
+ *
+ * A rebuild creates a scratch table, copies rows in, then renames it over the
+ * original. Verifying the CREATE afterwards looks for a table that no longer
+ * exists under that name, so the migration is reported broken even though the
+ * schema is exactly right. Parsing RENAME lets the verifier follow the table
+ * to its final name instead.
+ */
+export function parseRenameTableStatement(
+  statement: string,
+): { from: string; to: string } | null {
+  const match = new RegExp(
+    String.raw`^ALTER\s+TABLE\s+${IDENT}\s+RENAME\s+TO\s+${IDENT}`,
+    "i",
+  ).exec(statement.trim());
+  if (!match) {
+    return null;
+  }
+  const from = firstCapture(match, 1, 5);
+  const to = firstCapture(match, 6, 5);
+  if (!from || !to) {
+    return null;
+  }
+  return { from, to };
+}
+
 /** Strip leading `--` line comments so chunks like `-- header\nCREATE TABLE…` are kept. */
 export function stripLeadingLineComments(sqlChunk: string): string {
   return sqlChunk

--- a/tests/helpers/migrationMockRemote.ts
+++ b/tests/helpers/migrationMockRemote.ts
@@ -100,6 +100,36 @@ export function createMigrationMockRemote(
         return { rows: [], columns: [], rowsAffected: 0 };
       }
 
+      // Table rebuilds swap a scratch table over the original by renaming.
+      const renameMatch =
+        /^ALTER TABLE (?:"([^"]+)"|'([^']+)'|(\S+)) RENAME TO (?:"([^"]+)"|'([^']+)'|(\S+))/i.exec(
+          sql.trim(),
+        );
+      if (renameMatch) {
+        const from = renameMatch[1] ?? renameMatch[2] ?? renameMatch[3];
+        const to = renameMatch[4] ?? renameMatch[5] ?? renameMatch[6];
+        const cols = columnsByTable.get(from!);
+        if (cols) {
+          columnsByTable.delete(from!);
+          columnsByTable.set(to!, cols);
+        }
+        return { rows: [], columns: [], rowsAffected: 0 };
+      }
+
+      const dropTableMatch =
+        /^DROP TABLE(?: IF EXISTS)? (?:"([^"]+)"|'([^']+)'|(\S+))/i.exec(sql.trim());
+      if (dropTableMatch) {
+        const table =
+          dropTableMatch[1] ?? dropTableMatch[2] ?? dropTableMatch[3];
+        columnsByTable.delete(table!);
+        return { rows: [], columns: [], rowsAffected: 0 };
+      }
+
+      const insertSelectMatch = /^INSERT (?:OR IGNORE )?INTO /i.exec(sql.trim());
+      if (insertSelectMatch) {
+        return { rows: [], columns: [], rowsAffected: 0 };
+      }
+
       const addMatch =
         /^ALTER TABLE (?:"([^"]+)"|'([^']+)'|(\S+)) ADD COLUMN (?:"([^"]+)"|'([^']+)'|(\S+))/i.exec(
           sql.trim(),

--- a/tests/job-migration-ledger-sync.test.ts
+++ b/tests/job-migration-ledger-sync.test.ts
@@ -49,4 +49,63 @@ CREATE INDEX IF NOT EXISTS idx_daily_shop_date ON daily_metrics(shop_id, date);`
     );
     expect(satisfied).toBe(false);
   });
+
+  /**
+   * Regression: a table rebuild wedged cloud sync permanently.
+   *
+   * Changing a column type or adding a PRIMARY KEY is impossible with ALTER in
+   * SQLite, so the drift healer emits copy-and-swap. Verified statement by
+   * statement, the CREATE of the scratch table looks unsatisfied — it was
+   * renamed onto the real table name. The verdict can never change, so every
+   * retry failed identically and publish stayed blocked.
+   */
+  it("accepts a table rebuild whose scratch table is renamed into place", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "papr-mig-verify-"));
+    const migrationsDir = path.join(root, "migrations");
+    fs.mkdirSync(migrationsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(migrationsDir, "0002_rebuild.sql"),
+      `DROP TABLE IF EXISTS "expenses__papr_rebuild";
+CREATE TABLE IF NOT EXISTS "expenses__papr_rebuild" ("id" TEXT PRIMARY KEY, "amount_cents" INTEGER);
+INSERT OR IGNORE INTO "expenses__papr_rebuild" ("id") SELECT "id" FROM "expenses";
+DROP TABLE IF EXISTS "expenses__papr_old";
+ALTER TABLE "expenses" RENAME TO "expenses__papr_old";
+ALTER TABLE "expenses__papr_rebuild" RENAME TO "expenses";
+DROP TABLE IF EXISTS "expenses__papr_old";`,
+    );
+
+    // Final state: only `expenses` exists. The scratch and old names are gone,
+    // which is exactly what made the old verifier fail.
+    const remote = createMigrationMockRemote({ expenses: ["id"] }, []);
+
+    const satisfied = await migrationSatisfiedOnRemote(
+      remote,
+      root,
+      "0002_rebuild.sql",
+    );
+    expect(satisfied).toBe(true);
+  });
+
+  it("still fails a rebuild when the final table is missing on remote", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "papr-mig-verify-"));
+    const migrationsDir = path.join(root, "migrations");
+    fs.mkdirSync(migrationsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(migrationsDir, "0002_rebuild.sql"),
+      `CREATE TABLE IF NOT EXISTS "expenses__papr_rebuild" ("id" TEXT PRIMARY KEY);
+ALTER TABLE "expenses__papr_rebuild" RENAME TO "expenses";
+CREATE INDEX IF NOT EXISTS "idx_expenses_id" ON "expenses"("id");`,
+    );
+
+    // The rename target never arrived, so this migration really is broken and
+    // must still be reported unsatisfied — the fix must not blanket-pass.
+    const remote = createMigrationMockRemote({}, []);
+
+    const satisfied = await migrationSatisfiedOnRemote(
+      remote,
+      root,
+      "0002_rebuild.sql",
+    );
+    expect(satisfied).toBe(false);
+  });
 });


### PR DESCRIPTION
## The failure

Publishing a mini-app whose Turso replica had drifted column types failed on **every** attempt with an identical message:

```
Workspace log API failed for replica=d-xxxxxxxx (400):
Migration __schema_drift_heal___1787513115596 verification failed:
1 unsatisfied op(s), 3 unverifiable
```

Pressing **Upload now** again changed nothing. The app could not publish.

## Why it happens

SQLite cannot `ALTER` a column's type or add a `PRIMARY KEY`. When a replica's schema drifts that way — remote has `amount_cents TEXT` where local has `INTEGER`, or is missing a PK — the only way to converge is copy-and-swap, which `buildRemoteTableRebuildOps` emits:

```sql
DROP TABLE IF EXISTS expenses__papr_rebuild
CREATE TABLE expenses__papr_rebuild (…)          -- new shape
INSERT OR IGNORE INTO expenses__papr_rebuild …   -- carry rows over
DROP TABLE IF EXISTS expenses__papr_old
ALTER TABLE expenses RENAME TO expenses__papr_old
ALTER TABLE expenses__papr_rebuild RENAME TO expenses
DROP TABLE IF EXISTS expenses__papr_old
```

Verification runs per statement against final state:

| statement | verdict | why |
|---|---|---|
| `CREATE TABLE expenses__papr_rebuild` | **unsatisfied** | the name is gone — it *became* `expenses` |
| `INSERT … SELECT` | unverifiable | not an introspectable shape |
| `ALTER … RENAME TO` ×2 | unverifiable | RENAME was never parsed |

That's exactly `1 unsatisfied op(s), 3 unverifiable`.

**The verdict is deterministic.** The scratch name can never come back, so no number of retries can clear it. Sync wedges permanently.

Worse, `MAX_REBUILDS_PER_PASS = 1` means a database with N drifted tables needs N sequential passes — each failing identically. A workspace could never converge.

## The fix

`isSupersededDrop` already exists for the drop-and-recreate shape:

```sql
DROP INDEX IF EXISTS idx_a;
CREATE INDEX idx_a ON t (a, b);
```

Rebuilds need the same idea one step further: **a statement whose table a later statement renames away says nothing about final state.**

- `parseRenameTableStatement` — parse `ALTER TABLE x RENAME TO y`, reusing the shared `IDENT` pattern so all quoting styles work
- `isSupersededByRename` — skip an op whose subject table is renamed away later in the same migration
- `isSuperseded` — shared entry point, applied in both the remote and local verify loops

## Not a blanket pass

The rename **target** is still verified when the loop reaches the statement that creates it. A rebuild whose final table never lands still fails — covered by `still fails a rebuild when the final table is missing on remote`.

## Tests

```
✓ returns true when CREATE TABLE and CREATE INDEX ops exist on remote
✓ returns false when CREATE INDEX is missing on remote
✓ accepts a table rebuild whose scratch table is renamed into place   ← new
✓ still fails a rebuild when the final table is missing on remote     ← new
```

`tests/helpers/migrationMockRemote.ts` gained RENAME / DROP TABLE / INSERT handling so the mock models a real swap instead of throwing.

## Paired change

The memory server runs its own copy of this verifier and emits the 400. **Both must ship** — patching only the desktop leaves the server rejecting the payload. Companion PR on `Papr-ai/memory`.