### PR TITLE
Stop closing the Turso client mid drift-scan

### DIFF
--- a/src/gateway/services/TursoSyncBridge.ts
+++ b/src/gateway/services/TursoSyncBridge.ts
@@ -608,6 +608,17 @@ export class TursoSyncBridge {
               pushResult.lastPushedLogId,
             );
           }
+        } else if (pushResult.status === "failed") {
+          // Counting a failed push as "skipped" hid real sync failures
+          // behind a clean-looking summary.
+          summary.failed += 1;
+          if (pushResult.error) {
+            result.error = pushResult.error;
+          }
+          console.warn(
+            `[TursoSyncBridge] scoped push failed for ${syncKey}:`,
+            (pushResult.error ?? "").slice(0, 120),
+          );
         } else {
           summary.skipped += 1;
         }
@@ -833,6 +844,13 @@ export class TursoSyncBridge {
                 undefined,
                 pushResult.lastPushedLogId,
               );
+            }
+          } else if (pushResult.status === "failed") {
+            // A failed push counted as "skipped" made the sync panel look
+            // calm while nothing reached the cloud. Report it as failed.
+            summary.failed += 1;
+            if (pushResult.error) {
+              result.error = pushResult.error;
             }
           } else {
             summary.skipped += 1;

--- a/src/gateway/services/syncV3/backfillMigrationLedgers.ts
+++ b/src/gateway/services/syncV3/backfillMigrationLedgers.ts
@@ -162,6 +162,9 @@ async function countRemoteSyncableTables(
     const result = await remote.execute(
       `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`,
     );
+    // Synchronous mapping over an already-awaited result — safe to return
+    // directly. Any async call here would need `await` so the finally does
+    // not close the client mid-flight.
     return filterSyncableTables(
       result.rows.map((row) => String(row.name ?? "")),
     ).length;

--- a/src/gateway/services/syncV3/schemaDriftHeal.ts
+++ b/src/gateway/services/syncV3/schemaDriftHeal.ts
@@ -378,7 +378,15 @@ async function listDriftedTableNames(
   const localDb = new Database(dbPath, { readonly: true, fileMustExist: true });
   try {
     const tableNames = filterSyncableTables(listUserTables(localDb));
-    return localRemoteUserSchemaDriftTables(
+    // MUST await before the finally closes the client.
+    //
+    // `return promise` inside try/finally resolves the promise AFTER the
+    // finally block runs, so the local DB and the libSQL client were both
+    // closed while the drift scan was still issuing queries against them.
+    // The scan then died with "Client was manually closed" and the whole
+    // push reported failed — on every attempt, for any app whose replica
+    // had drifted.
+    return await localRemoteUserSchemaDriftTables(
       remoteHandle.remote,
       localDb,
       tableNames,

--- a/tests/schema-drift-scan-client-lifetime.test.ts
+++ b/tests/schema-drift-scan-client-lifetime.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression: the Turso client was closed while the drift scan was still
+ * querying it, so every Upload failed with:
+ *
+ *   UNKNOWN: Client was closed: ClientError: Client was manually closed
+ *
+ * Cause: `return someAsyncFn(...)` inside `try { } finally { client.close() }`.
+ * `return promise` (without `await`) hands the promise back to the caller and
+ * runs `finally` immediately — the client is closed while the scan is still
+ * issuing queries. `return await` keeps the frame alive until the scan
+ * finishes, so the close happens after the last query.
+ *
+ * These tests model the lifetime rule directly, without needing a real
+ * libSQL connection.
+ */
+
+interface FakeClient {
+  closed: boolean;
+  execute: () => Promise<string>;
+  close: () => void;
+}
+
+function createFakeClient(): FakeClient {
+  const client: FakeClient = {
+    closed: false,
+    execute: async () => {
+      // Any real round-trip yields to the event loop at least once, which is
+      // what lets a premature finally block run first.
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      if (client.closed) {
+        throw new Error("Client was manually closed");
+      }
+      return "ok";
+    },
+    close: () => {
+      client.closed = true;
+    },
+  };
+  return client;
+}
+
+/** Multi-query scan, like localRemoteUserSchemaDriftTables over N tables. */
+async function scanTables(client: FakeClient, tableCount: number): Promise<string[]> {
+  const seen: string[] = [];
+  for (let i = 0; i < tableCount; i += 1) {
+    seen.push(await client.execute());
+  }
+  return seen;
+}
+
+describe("drift scan client lifetime", () => {
+  it("keeps the client open until the scan finishes (return await)", async () => {
+    const client = createFakeClient();
+
+    async function listDriftedTables(): Promise<string[]> {
+      try {
+        return await scanTables(client, 3);
+      } finally {
+        client.close();
+      }
+    }
+
+    await expect(listDriftedTables()).resolves.toHaveLength(3);
+    expect(client.closed).toBe(true); // still closed afterwards — no leak
+  });
+
+  it("reproduces the failure when the await is missing", async () => {
+    const client = createFakeClient();
+
+    async function listDriftedTablesBuggy(): Promise<string[]> {
+      try {
+        // The exact shape of the bug: no await, so finally runs first.
+        return scanTables(client, 3);
+      } finally {
+        client.close();
+      }
+    }
+
+    await expect(listDriftedTablesBuggy()).rejects.toThrow(
+      "Client was manually closed",
+    );
+  });
+
+  it("closes the client even when the scan throws", async () => {
+    const client = createFakeClient();
+
+    async function listDriftedTablesFailing(): Promise<string[]> {
+      try {
+        return await Promise.reject(new Error("remote unreachable"));
+      } finally {
+        client.close();
+      }
+    }
+
+    await expect(listDriftedTablesFailing()).rejects.toThrow(
+      "remote unreachable",
+    );
+    expect(client.closed).toBe(true);
+  });
+});


### PR DESCRIPTION
## The failure

Uploading a mini-app whose Turso replica had drifted column types failed on **every** attempt:

```
UNKNOWN: Client was closed: ClientError: Client was manually closed
```

Reproduced three times in a row on a real workspace, identical each time. This is the bug that surfaced *after* #108 fixed the verifier — same symptom for the user (Upload never converges), completely different cause.

## Root cause

`listDriftedTableNames` opens a libSQL client and a local SQLite handle, then:

```ts
try {
  return localRemoteUserSchemaDriftTables(remote, localDb, tables);  // no await
} finally {
  localDb.close();
  remoteHandle.close();
}
```

**`return promise` inside `try`/`finally` runs `finally` before the promise settles.** The function hands the pending promise to the caller, the frame unwinds, and both handles close while the scan is still mid-flight.

`localRemoteUserSchemaDriftTables` issues two queries per table (`sqlite_master` lookup + `readRemoteTableSchema`), each awaiting a network round-trip. The first `await` yields, `finally` closes the client, and the next query throws.

Minimal proof:

```
no-await : THREW -> Client was manually closed
with await: ok
```

## Why it mattered

- **Deterministic, not flaky.** Any app with ≥1 drifted table fails on the first round-trip, every time.
- **It blocks the recovery path.** `listDriftedTableNames` is called from `healSchemaDriftIfNeeded` and `waitForLinkedSourceSchemaConvergence` — exactly what a drifted replica needs to run to get healthy. Drift caused the scan; the scan crashed; drift persisted.
- **Silent.** See the reporting bug below.

## The fix

`return await` — keeps the async frame alive until the scan completes. `finally` still runs on both success and failure, so there is no leak (covered by a test).

## Also in this PR

**`backfillMigrationLedgers.ts`** has the same syntactic shape, but the returned expression is a synchronous `.map()` over an already-awaited result, so it is safe. Documented rather than changed, so nobody "fixes" it into a real bug later.

**`TursoSyncBridge.ts`** counted a push returning `status: "failed"` as `skipped` in *both* push loops:

```
attempted=1 pushed=0 skipped=1 failed=0
  └─ results[0].push.status = "failed"   ← the actual outcome
```

The summary looked clean while nothing reached the cloud — which is why this went unnoticed behind the verifier bug. Failures now increment `failed` and propagate `error`.

## Tests

`tests/schema-drift-scan-client-lifetime.test.ts` — models the lifetime rule against a fake client that throws once closed:

```
✓ keeps the client open until the scan finishes (return await)
✓ reproduces the failure when the await is missing
✓ closes the client even when the scan throws
```

The second test is the guard: it fails if someone reintroduces the missing `await`.

Neighbouring suites (`job-migration-ledger-sync`, `job-migration-turso-sync`, `database-migrations`) all pass. `tsc --noEmit` clean for touched files.

## Scope

Desktop only — no memory-server change needed. Independent of #108/#113: that pair fixed the server rejecting valid rebuild payloads; this fixes the desktop crashing before it can ship one.