### PR TITLE
Fix app-search crash: guard undefined fields in getFilteredArtifacts

### DIFF
--- a/ui/stores/artifactsStore.ts
+++ b/ui/stores/artifactsStore.ts
@@ -132,17 +132,17 @@ export const useArtifactsStore = create<ArtifactsState>((set, get) => ({
     // Apply search
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
+      const matches = (value: unknown): boolean =>
+        typeof value === "string" && value.toLowerCase().includes(query);
+
       filtered = filtered.filter(
         (a) =>
-          a.title.toLowerCase().includes(query) ||
-          a.id.toLowerCase().includes(query) ||
-          a.description?.toLowerCase().includes(query) ||
-          a.tags?.some((tag) => tag.toLowerCase().includes(query)) ||
-          a.cloudLineage?.sourceSlug.toLowerCase().includes(query) ||
-          Object.values(a.metadata ?? {}).some(
-            (value) =>
-              typeof value === "string" && value.toLowerCase().includes(query),
-          ),
+          matches(a.title) ||
+          matches(a.id) ||
+          matches(a.description) ||
+          (Array.isArray(a.tags) && a.tags.some(matches)) ||
+          matches(a.cloudLineage?.sourceSlug) ||
+          Object.values(a.metadata ?? {}).some(matches),
       );
     }
 


### PR DESCRIPTION
## Problem

Clicking the app search box (Apps view / Command Palette) and typing crashed the Electron app:

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
  at stores/artifactsStore.ts:48
  at getFilteredArtifacts (stores/artifactsStore.ts:47)
  at useArtifacts (hooks/useArtifacts.ts:262)
  at AppsView / CommandPalette
```

`getFilteredArtifacts` assumed `title`, `id`, each `tags[]` entry, and `cloudLineage.sourceSlug` were always strings. `Artifact` types them as required, but artifacts loaded from disk/cloud can arrive without them (e.g. an app entry with no title, or a `cloudLineage` object lacking `sourceSlug`).

Because the throw happens **during render** of both `AppsView` and `CommandPalette`, and there's no error boundary above them, React unmounts the entire tree — the window goes blank / the app appears to crash.

## Fix

Route every candidate field through one `matches()` helper that type-checks before calling `toLowerCase()`, and guard `tags` with `Array.isArray`. Behaviour is unchanged for well-formed artifacts.

## Testing

- `npx tsc --noEmit` clean
- Search no longer throws on artifacts with missing title/tags/sourceSlug

## Follow-up (not in this PR)

Consider an error boundary around `ContentArea` so a render throw in one view can't blank the whole app.