### PR TITLE
Fix Upload now failing with "fetch failed" when writer URL is unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,9 @@ PAPR_API_KEY=your_papr_api_key_here
 # PAPR_TEST_CHAT_ID=your-session-id
 # PAPR_MEMORY_SERVER_URL=http://localhost:5001
 
-# App-repo-writer (local dev defaults work — see docs/SYNC_V3_ENV.md)
+# App-repo-writer — defaults to the Papr Cloud writer, so leave unset unless you
+# are running the writer locally (npm run start:app-repo-writer).
+# See docs/SYNC_V3_ENV.md
 # PAPR_APP_REPO_WRITER_URL=http://127.0.0.1:8789
 # PARSE_SERVER_URL=https://api.papr.ai
 # PARSE_APPLICATION_ID=your_parse_app_id

--- a/docs/SYNC_V3_ENV.md
+++ b/docs/SYNC_V3_ENV.md
@@ -28,7 +28,7 @@ Packaged apps also load defaults at runtime if `packaged-gateway-env.json` is em
 | --- | --- | --- |
 | `PAPR_API_KEY` | keychain | Always — Papr login provisions this |
 | `PAPR_MEMORY_SERVER_URL` | `https://memory.papr.ai` | Non-default memory server |
-| `PAPR_APP_REPO_WRITER_URL` | `http://127.0.0.1:8789` | Production Cloud Run writer URL |
+| `PAPR_APP_REPO_WRITER_URL` | Cloud Run writer (built-in) | Only to override — e.g. `http://127.0.0.1:8789` for local writer dev |
 | `PAPR_CLOUD_APP_HOST_KEY` | packaged JSON / `.env.local` | Notify `apps.papr.ai` after DB/code sync (not user API key) |
 
 **Auth:** Desktop calls app-repo-writer with the user's `PAPR_API_KEY` only. Writer validates namespace ACL via memory server RepoRegistry — no shared writer secret on the open-source client (same idea as cloud-app-host using a server-side key to call memory, not the reverse).

--- a/src/gateway/services/syncV3/AppOpsClient.ts
+++ b/src/gateway/services/syncV3/AppOpsClient.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../core/types/appRepoWriterOps.js";
 import { getPaprApiKey } from "../../utils/keyResolver.js";
 import { applyAckedBlobOids, seedOidCacheFromHead } from "./OidCache.js";
-import { getAppRepoWriterBaseUrl } from "./writerConfig.js";
+import { getAppRepoWriterBaseUrl, isLocalAppRepoWriter } from "./writerConfig.js";
 import { incrementSyncV3Metric } from "./syncV3Metrics.js";
 import { invalidateWriterConflictPaths } from "./writerConflict.js";
 
@@ -62,10 +62,11 @@ async function writerFetch(
     "X-API-Key": apiKey,
   };
 
+  const baseUrl = getAppRepoWriterBaseUrl();
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), WRITER_FETCH_TIMEOUT_MS);
   try {
-    return await fetch(`${getAppRepoWriterBaseUrl()}${route}`, {
+    return await fetch(`${baseUrl}${route}`, {
       ...init,
       headers: { ...headers, ...(init.headers as Record<string, string>) },
       signal: controller.signal,
@@ -78,7 +79,17 @@ async function writerFetch(
         `Writer request timed out after ${Math.round(WRITER_FETCH_TIMEOUT_MS / 1000)}s`,
       );
     }
-    throw err;
+    // Bare `fetch failed` hides the URL, so a wrong/unreachable writer looks
+    // like a generic sync bug. Name the host and the likely cause.
+    const cause = err instanceof Error ? err.message : String(err);
+    const hint = isLocalAppRepoWriter()
+      ? " Local writer is not running — start it with `npm run start:app-repo-writer`, or unset PAPR_APP_REPO_WRITER_URL to use the Papr Cloud writer."
+      : " Check your network connection and try Upload now again.";
+    throw new AppOpsClientError(
+      "writer",
+      503,
+      `Cannot reach app-repo-writer at ${baseUrl}: ${cause}.${hint}`,
+    );
   } finally {
     clearTimeout(timer);
   }

--- a/src/gateway/services/syncV3/writerConfig.ts
+++ b/src/gateway/services/syncV3/writerConfig.ts
@@ -2,12 +2,30 @@
  * Desktop / writer service configuration for Sync V3 ops path.
  */
 
+/** Cloud Run writer used by every shipped build (also in packaged-gateway-env.defaults.json). */
+export const PRODUCTION_APP_REPO_WRITER_URL =
+  "https://app-repo-writer-223473570766.us-west1.run.app";
+
+/** Local writer for `npm run start:app-repo-writer`. Opt in via PAPR_APP_REPO_WRITER_URL. */
+export const LOCAL_APP_REPO_WRITER_URL = "http://127.0.0.1:8789";
+
 export function getAppRepoWriterBaseUrl(): string {
-  return (
-    process.env.PAPR_APP_REPO_WRITER_URL ??
-    process.env.SYNC_WRITER_URL ??
-    "http://127.0.0.1:8789"
-  ).replace(/\/$/, "");
+  const explicit =
+    process.env.PAPR_APP_REPO_WRITER_URL ?? process.env.SYNC_WRITER_URL;
+  if (typeof explicit === "string" && explicit.trim()) {
+    return explicit.trim().replace(/\/$/, "");
+  }
+  // Never default to localhost: when packaged env is missing or the app runs
+  // unpackaged, a localhost default makes every Upload now fail with
+  // "fetch failed" (ECONNREFUSED) instead of syncing to the real writer.
+  return PRODUCTION_APP_REPO_WRITER_URL;
+}
+
+/** True when the resolved writer is a developer-local instance. */
+export function isLocalAppRepoWriter(): boolean {
+  return /^https?:\/\/(127\.0\.0\.1|localhost|\[::1\])(:|\/|$)/.test(
+    getAppRepoWriterBaseUrl(),
+  );
 }
 
 /** App code always syncs via writer ops (V3 — no namespace git for apps). */

--- a/tests/writer-config-default-url.test.ts
+++ b/tests/writer-config-default-url.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+const ENV_KEYS = ["PAPR_APP_REPO_WRITER_URL", "SYNC_WRITER_URL"] as const;
+
+describe("app-repo-writer base URL resolution", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  test("defaults to the Cloud Run writer, never localhost", async () => {
+    const { getAppRepoWriterBaseUrl, PRODUCTION_APP_REPO_WRITER_URL } =
+      await import("../src/gateway/services/syncV3/writerConfig.js");
+
+    // Regression: a localhost default made every Upload now fail with
+    // "fetch failed" (ECONNREFUSED) whenever packaged env was missing.
+    expect(getAppRepoWriterBaseUrl()).toBe(PRODUCTION_APP_REPO_WRITER_URL);
+    expect(getAppRepoWriterBaseUrl()).not.toMatch(/127\.0\.0\.1|localhost/);
+  });
+
+  test("PAPR_APP_REPO_WRITER_URL still wins for local dev", async () => {
+    process.env.PAPR_APP_REPO_WRITER_URL = "http://127.0.0.1:8789";
+    const { getAppRepoWriterBaseUrl, isLocalAppRepoWriter } = await import(
+      "../src/gateway/services/syncV3/writerConfig.js"
+    );
+
+    expect(getAppRepoWriterBaseUrl()).toBe("http://127.0.0.1:8789");
+    expect(isLocalAppRepoWriter()).toBe(true);
+  });
+
+  test("trailing slashes and blank values are handled", async () => {
+    const { getAppRepoWriterBaseUrl, PRODUCTION_APP_REPO_WRITER_URL } =
+      await import("../src/gateway/services/syncV3/writerConfig.js");
+
+    process.env.PAPR_APP_REPO_WRITER_URL = "https://writer.example.com/";
+    expect(getAppRepoWriterBaseUrl()).toBe("https://writer.example.com");
+
+    // A blank override must not strand sync on an empty host.
+    process.env.PAPR_APP_REPO_WRITER_URL = "   ";
+    expect(getAppRepoWriterBaseUrl()).toBe(PRODUCTION_APP_REPO_WRITER_URL);
+  });
+
+  test("SYNC_WRITER_URL is honoured as a fallback override", async () => {
+    process.env.SYNC_WRITER_URL = "https://staging-writer.example.com";
+    const { getAppRepoWriterBaseUrl, isLocalAppRepoWriter } = await import(
+      "../src/gateway/services/syncV3/writerConfig.js"
+    );
+
+    expect(getAppRepoWriterBaseUrl()).toBe("https://staging-writer.example.com");
+    expect(isLocalAppRepoWriter()).toBe(false);
+  });
+});


### PR DESCRIPTION
Upload now fails with a bare **`App code — fetch failed`** and never recovers. Reproduced live on 2.0.27.

## Root cause

`getAppRepoWriterBaseUrl()` fell back to `http://127.0.0.1:8789` when both `PAPR_APP_REPO_WRITER_URL` and `SYNC_WRITER_URL` are unset:

```ts
return (
  process.env.PAPR_APP_REPO_WRITER_URL ??
  process.env.SYNC_WRITER_URL ??
  "http://127.0.0.1:8789"   // local writer dev default
).replace(/\/$/, "");
```

That default is meant for `npm run start:app-repo-writer`, but it also applies when the packaged env is missing. `readPackagedGatewayEnv()` returns `{}` when `!app.isPackaged`, so nothing injects the Cloud Run URL and app sync POSTs to a port with nothing listening.

The failure then loses all context on the way up:

| Layer | What it produces |
| --- | --- |
| `writerFetch` | `fetch` rejects, `ECONNREFUSED` |
| `flushAppNow` | `App sync failed: fetch failed` |
| Sync panel | `App code — fetch failed` |

Nothing names the writer URL, so Upload now keeps failing until you find the env var. Confirmed on the affected machine: nothing listening on 8789, `PAPR_APP_REPO_WRITER_URL` unset in the running process, `manualFlushErrors` accumulating on every click.

Worth noting the URL is not secret — it already ships in `src/resources/packaged-gateway-env.defaults.json`, so this only changes which of two known values is the default.

## Fix

Default to the production Cloud Run writer; local development opts in explicitly. Packaged builds are unaffected — they resolve the same URL they already bake in.

- `writerConfig`: default to `PRODUCTION_APP_REPO_WRITER_URL`, trim and ignore blank overrides, add `isLocalAppRepoWriter()`
- `AppOpsClient`: wrap transport failures as `Cannot reach app-repo-writer at <url>: <cause>` with a hint to start the local writer or check the network
- `docs/SYNC_V3_ENV.md`, `.env.example`: writer URL is an override, not a required setting

## Testing

- New `tests/writer-config-default-url.test.ts` — 4 passing: production default, `PAPR_APP_REPO_WRITER_URL` override, `SYNC_WRITER_URL` fallback, trailing-slash and blank handling
- Existing writer suites pass unchanged — 17 tests across `sync-v3-writer-client`, `app-repo-writer-ops`, `push-app-via-writer-ops`, `writer-outbox-errors`, `cloud-app-writer-debounced-push`
- `oxlint` clean on both changed files
- `tsc --noEmit`: 99 errors before and after, all pre-existing and unrelated

## Reviewer notes

Two things worth a second opinion:

1. **Blank override now falls through to production.** `PAPR_APP_REPO_WRITER_URL=""` previously yielded an empty base URL and a malformed request; it now uses the production writer. That seemed clearly better than failing, but it does mean you cannot blank the var to disable sync.
2. **Transport errors are now `AppOpsClientError(503)` rather than the raw `fetch` error.** Anything matching on the old message string would need updating — I did not find such a caller.
