### PR TITLE
Fix every mini-app rendering blank on packaged builds

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -35,7 +35,8 @@
     "node_modules/playwright/**",
     "node_modules/playwright-core/**",
     "dist/resources/default-apps/**",
-    "dist/resources/default-jobs/**"
+    "dist/resources/default-jobs/**",
+    "dist/resources/mini-app-sdk/**"
   ],
   "extraResources": [
     {

--- a/src/gateway/utils/registerPaprMiniAppSdkRoutes.ts
+++ b/src/gateway/utils/registerPaprMiniAppSdkRoutes.ts
@@ -13,7 +13,33 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const SDK_DIR = path.join(__dirname, "../../resources/mini-app-sdk");
+/**
+ * SDK sources must live OUTSIDE app.asar in packaged builds.
+ *
+ * esbuild bundles these files, and esbuild is a native binary running as a
+ * separate process. The asar virtual filesystem is patched into Electron's
+ * `fs` module only — a child process sees `app.asar` as a single opaque
+ * file, so every bundle failed with:
+ *
+ *   Could not resolve ".../app.asar/dist/resources/mini-app-sdk/papr-job-events.ts"
+ *
+ * Mini-apps import `/__papr__/papr-job-events.ts`, so that 500 meant the app
+ * bundle never evaluated and rendered blank — with an empty console, because
+ * a failed module fetch logs nothing.
+ *
+ * `dist/resources/mini-app-sdk/**` is in electron-builder `asarUnpack`, so
+ * prefer the unpacked copy whenever this file is loaded from inside an asar.
+ * Do NOT probe with fs.existsSync to choose: Electron's patched `fs` reports
+ * the in-asar path as readable, which is exactly the path esbuild cannot use.
+ */
+function resolveSdkDir(): string {
+  const bundled = path.join(__dirname, "../../resources/mini-app-sdk");
+  return bundled.includes(`app.asar${path.sep}`)
+    ? bundled.replace(`app.asar${path.sep}`, `app.asar.unpacked${path.sep}`)
+    : bundled;
+}
+
+const SDK_DIR = resolveSdkDir();
 
 async function serveSdkFile(
   sdkFileName: string,

--- a/tests/mini-app-sdk-asar-unpacked.test.ts
+++ b/tests/mini-app-sdk-asar-unpacked.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Regression: every mini-app rendered blank on packaged builds (v2.4.6).
+ *
+ * The SDK route bundles `dist/resources/mini-app-sdk/*.ts` with esbuild.
+ * esbuild is a native binary in a child process, and the asar virtual
+ * filesystem is patched into Electron's `fs` only — a child process sees
+ * `app.asar` as one opaque file. So the bundle failed with:
+ *
+ *   Could not resolve ".../app.asar/dist/resources/mini-app-sdk/papr-job-events.ts"
+ *
+ * `/__papr__/papr-job-events.ts` returned 500, the app bundle never
+ * evaluated, and the mini-app showed nothing — with an EMPTY console, since
+ * a failed module fetch logs no error. Only the network tab revealed it.
+ *
+ * Two guards below: the packaging config must unpack the SDK, and the route
+ * must resolve to the unpacked copy.
+ */
+
+const repoRoot = path.resolve(__dirname, "..");
+
+describe("mini-app SDK packaging", () => {
+  it("unpacks the SDK from asar so esbuild can read it", () => {
+    const config = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, "electron-builder.json"), "utf8"),
+    ) as { asarUnpack?: string[] };
+
+    const unpack = config.asarUnpack ?? [];
+
+    // Without this, esbuild cannot resolve the SDK entry points and every
+    // mini-app that imports from /__papr__/ renders blank.
+    expect(unpack).toContain("dist/resources/mini-app-sdk/**");
+
+    // esbuild itself must stay unpacked for the same reason.
+    expect(unpack).toContain("node_modules/esbuild/**");
+  });
+
+  it("resolves SDK_DIR to app.asar.unpacked when loaded from inside an asar", () => {
+    const source = fs.readFileSync(
+      path.join(
+        repoRoot,
+        "src/gateway/utils/registerPaprMiniAppSdkRoutes.ts",
+      ),
+      "utf8",
+    );
+
+    // The route must redirect into the unpacked tree rather than handing
+    // esbuild a path inside the archive.
+    expect(source).toContain("app.asar.unpacked");
+
+    // fs-based probing cannot pick the right path here: Electron's patched
+    // fs reports the in-asar path as readable, which is the broken one.
+    const chooses = /existsSync[\s\S]{0,200}mini-app-sdk/.test(source);
+    expect(chooses).toBe(false);
+  });
+
+  it("keeps every SDK entry point inside the unpacked directory", () => {
+    const sdkDir = path.join(repoRoot, "src/resources/mini-app-sdk");
+    const entryPoints = fs
+      .readdirSync(sdkDir)
+      .filter((f) => f.endsWith(".ts") && !f.endsWith(".d.ts"));
+
+    // Guards against a future SDK file living outside the unpacked glob.
+    expect(entryPoints.length).toBeGreaterThan(0);
+    for (const file of entryPoints) {
+      expect(path.join("dist/resources/mini-app-sdk", file)).toMatch(
+        /^dist\/resources\/mini-app-sdk\//,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Impact

**Every mini-app that imports from `/__papr__/` renders blank on v2.4.6 packaged builds.** No data, no UI, and — worst of all — an **empty console**. Users see "nothing to show" and reasonably assume their data is gone.

Reproduced on a real workspace with a healthy 5.5 MB database and 3,897 rows fully intact.

## Symptom

Only the network tab reveals it:

```
GET /apps/{id}/dist/app.js                 -> 200
GET /__papr__/papr-job-events.ts           -> 500
GET /__papr__/papr-native-dialog-shim.js   -> 500
(no /api/db/* calls — the app never got that far)
```

```
Build failed with 1 error:
error: Could not resolve
"/Applications/Papr Work.app/Contents/Resources/app.asar/dist/resources/mini-app-sdk/papr-job-events.ts"
```

## Root cause

`registerPaprMiniAppSdkRoutes` bundles SDK sources **with esbuild on demand**:

```ts
const SDK_DIR = path.join(__dirname, "../../resources/mini-app-sdk");
const esbuild = await import("esbuild");
await esbuild.build({ entryPoints: [path.join(SDK_DIR, sdkFileName)], ... });
```

**esbuild is a native binary running as a child process.** The asar virtual filesystem is patched into Electron's `fs` module only — an external process sees `app.asar` as a single opaque file and cannot resolve paths inside it.

Verified the files *are* in the archive (35 `mini-app-sdk` entries), but `app.asar.unpacked/dist/resources/` contained only `default-apps`. `asarUnpack` already covered esbuild and the default app/job resources; the SDK directory was missed when the on-demand bundle route was added.

**Why it is silent:** `dist/app.js` imports `papr-job-events.ts` and leaves `/__papr__/` external. A failed module fetch aborts the module graph without logging — so nothing renders and nothing is reported.

## Fix

1. **`electron-builder.json`** — add `dist/resources/mini-app-sdk/**` to `asarUnpack`
2. **`registerPaprMiniAppSdkRoutes.ts`** — resolve `SDK_DIR` into `app.asar.unpacked` when loaded from inside an asar, so the route stays correct even if the packaging config drifts again

Deliberately **not** an `fs.existsSync` probe: Electron's patched `fs` reports the in-asar path as readable — that is precisely the path esbuild cannot use. Probing would pick the broken one. Documented inline.

## Tests

`tests/mini-app-sdk-asar-unpacked.test.ts` — 3/3:

```
+ unpacks the SDK from asar so esbuild can read it
+ resolves SDK_DIR to app.asar.unpacked when loaded from inside an asar
+ keeps every SDK entry point inside the unpacked directory
```

Verified the guard works by removing the glob and re-running:

```
x unpacks the SDK from asar so esbuild can read it
  Tests  1 failed | 2 passed (3)
```

`tsc --noEmit` clean for touched files; neighbouring suites pass.

## Note for release

This is a **packaging** fix — it only takes effect in a new packaged build. Anyone on v2.4.6 has all mini-apps broken until the next release, so this warrants a patch release rather than waiting.