### PR TITLE
Fix app crash when opening web sync before status resolves

### DIFF
--- a/ui/__tests__/components/WebSyncPopover.test.tsx
+++ b/ui/__tests__/components/WebSyncPopover.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * WebSyncPopover Component Tests
+ *
+ * Regression cover for the crash on clicking Upload before the first sync
+ * check resolves:
+ *   TypeError: Cannot read properties of null (reading 'hasSchemaDrift')
+ *
+ * `status` is typed `AppCloudSyncStatus | null`, and MiniAppPublishBar renders
+ * the popover as soon as it opens — so null must render, never throw.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WebSyncPopover } from "../../components/Apps/WebSyncPopover";
+
+const baseProps = {
+  appId: "0a1ab32b-7c0c-4364-a98a-da637aa0dc70",
+  onPushNow: vi.fn(),
+  onBumpQueue: vi.fn(),
+  onPullUpdates: vi.fn(),
+  onApplyRemoteUpdates: vi.fn(),
+};
+
+describe("WebSyncPopover", () => {
+  it("renders without throwing when status is null and loading", () => {
+    expect(() =>
+      render(<WebSyncPopover {...baseProps} status={null} loading />),
+    ).not.toThrow();
+
+    expect(screen.getByText("Checking…")).toBeTruthy();
+  });
+
+  it("renders without throwing when status is null and NOT loading", () => {
+    // The original crash path: popover opened before any status resolved,
+    // with loading already false, so the `loading && !status` guard missed.
+    expect(() =>
+      render(<WebSyncPopover {...baseProps} status={null} loading={false} />),
+    ).not.toThrow();
+  });
+
+  it("still offers Upload now while status is unresolved", () => {
+    render(<WebSyncPopover {...baseProps} status={null} loading={false} />);
+
+    // Previously returned null here, so clicking Upload showed nothing at all.
+    expect(screen.getByRole("button", { name: /upload now/i })).toBeTruthy();
+  });
+
+  it("surfaces an error alongside the unresolved state", () => {
+    render(
+      <WebSyncPopover
+        {...baseProps}
+        status={null}
+        loading={false}
+        error="App sync failed"
+      />,
+    );
+
+    expect(screen.getByText("App sync failed")).toBeTruthy();
+  });
+});

--- a/ui/components/Apps/WebSyncPopover.tsx
+++ b/ui/components/Apps/WebSyncPopover.tsx
@@ -122,9 +122,11 @@ export function WebSyncPopover({
   const queuedForUpload = status?.uploadQueued === true;
   const showMergeReview = remoteReviewNeeded && !metadataSync;
   const showWriterConflict = writerConflict && !showMergeReview && !metadataSync;
+  // status is null until the first sync check resolves, and this runs above
+  // the `!status` guard below — keep it optional-chained.
   const schemaDriftBlocked =
-    status.hasSchemaDrift ||
-    (status.publishDetail?.toLowerCase().includes("schema") ?? false);
+    status?.hasSchemaDrift === true ||
+    (status?.publishDetail?.toLowerCase().includes("schema") ?? false);
   const showSchemaDriftHelp =
     schemaDriftBlocked && !showMergeReview && !showWriterConflict && !metadataSync;
   const showAutoUploadToggle =
@@ -137,7 +139,9 @@ export function WebSyncPopover({
     ? `mini-app-publish-bar__sync-popover mini-app-publish-bar__sync-popover--stacked ${className}`
     : "mini-app-publish-bar__sync-popover mini-app-publish-bar__sync-popover--stacked";
 
-  if (loading && !status) {
+  // No status yet (first open, or a check that has not resolved): show the
+  // shell with Upload now rather than rendering nothing on click.
+  if (!status) {
     return (
       <div
         ref={popoverRef}
@@ -161,10 +165,6 @@ export function WebSyncPopover({
         </div>
       </div>
     );
-  }
-
-  if (!status) {
-    return null;
   }
 
   const commitSummary =


### PR DESCRIPTION
Clicking the web sync / **Upload now** control could take down the entire app window. Reproduced live on the local dev build.

```
TypeError: Cannot read properties of null (reading 'hasSchemaDrift')
  at WebSyncPopover (components/Apps/WebSyncPopover.tsx:97)
```

There is no error boundary above it, so React unmounted the tree from `MiniAppView` down — the user sees a blank window, not a broken popover. React even says so in the log: *"Consider adding an error boundary to your tree."*

## Root cause

`status` is typed `AppCloudSyncStatus | null`, and every derived flag optional-chains it — except one:

```ts
const remoteReviewNeeded = status?.gitRemoteRequiresReview === true;
const writerConflict     = status?.writerConflict === true;
const metadataSync       = status?.gitRemoteMetadataSync === true;
const activelyUploading  = status?.overall === "uploading";
const queuedForUpload    = status?.uploadQueued === true;
const schemaDriftBlocked =
  status.hasSchemaDrift ||            // <-- no ?.
  (status.publishDetail?.toLowerCase().includes("schema") ?? false);
```

That line sits **above** the `!status` early return, so it runs on every render including the null one. `MiniAppPublishBar` renders the popover as soon as it opens and passes `loading={webSyncLoading && !webSyncStatus}` — so null is a normal state, not an edge case.

The existing guard only covered `loading && !status`. Once a check had resolved-but-cleared, or errored, `loading` was false while `status` was still null, and rendering fell through to the crashing line.

Worth noting the other ~40 bare `status.` dereferences in this file are **fine** — they all sit below the early return, where TypeScript narrows the type. Only these two were misplaced, so this is a two-line fix rather than a sweep.

## Fix

- optional-chain the schema-drift check so it tolerates a null status
- widen the placeholder guard from `loading && !status` to `!status`, so opening the popover always renders the shell with **Upload now** instead of returning `null` and showing nothing
- drop the now-unreachable `if (!status) return null`

## Testing

`WebSyncPopover` had no test coverage, which is why this shipped. Added `ui/__tests__/components/WebSyncPopover.test.tsx` — 4 tests covering null status with and without loading, Upload now availability while unresolved, and error display.

**Mutation-checked:** reverted the fixed line to the original and confirmed all 4 tests fail; restored it and all 4 pass. The tests fail for the right reason.

| Check | Result |
| --- | --- |
| New tests | 4 passed |
| `unit-ui` full suite | 199 passed, 23 failed |
| `unit-ui` baseline (changes stashed) | 195 passed, **same 23 failed** |
| `tsc --noEmit` | 157 before and after — unchanged |
| `oxlint` | clean |

The 23 failures are pre-existing in `ChatContainer.test.tsx` and unrelated.

## Reviewer note

The widened guard changes behavior slightly: previously the popover rendered nothing when status was null and not loading; now it shows the shell with **Upload now** enabled. That seemed clearly better than a click that appears to do nothing, but it does mean users can trigger a push before the first status check completes.
