### PR TITLE
Show synced after Upload now on apps that are not published

### DIFF
--- a/ui/__tests__/appCloudSyncStatusPublish.test.ts
+++ b/ui/__tests__/appCloudSyncStatusPublish.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Web sync status for apps that have been uploaded but never published.
+ *
+ * Regression cover: clicking "Upload now" on an unpublished (Draft · Private)
+ * app left the indicator amber with "Some changes still need to sync to the
+ * web", even though the upload had fully succeeded. publishLayerSynced
+ * required publishLive, so a never-published app could never reach "synced".
+ *
+ * Upload = code in the private cloud repo. Publish = shared on the web.
+ * They are separate actions, and upload must be able to complete on its own.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  deriveAppCloudSyncStatus,
+  webSyncVisualState,
+} from "../utils/appCloudSyncStatus";
+
+const APP = "0a1ab32b-7c0c-4364-a98a-da637aa0dc70";
+
+function items(over: {
+  publishLive?: boolean;
+  publishedAt?: string | null;
+  publishStatus?: string;
+  codeStatus?: string;
+  codePhase?: string;
+  hasLocalChanges?: boolean;
+}): any {
+  const codeStatus = over.codeStatus ?? "synced";
+  const codePhase = over.codePhase ?? "synced";
+  return {
+    enabled: true,
+    github: {
+      workspace: [],
+      apps: [
+        {
+          id: APP,
+          kind: "app",
+          label: "Papr Investor Update",
+          relativePath: `apps/${APP}`,
+          status: codeStatus,
+          lastSyncAt: "2026-08-26T02:55:34.928Z",
+          lastError: null,
+          failedAt: null,
+        },
+      ],
+      jobs: [],
+      queuedPaths: [],
+    },
+    turso: { sources: [] },
+    publish: { status: over.publishStatus ?? "synced" },
+    upload: { status: "idle", label: "Nothing uploading right now" },
+    appSync: {
+      protocol: "v3",
+      appId: APP,
+      relativePath: `apps/${APP}`,
+      status: codeStatus,
+      phase: codePhase,
+      label: "App code on the web",
+      detail: "App files match the cloud repo",
+      lastUploadedAt: "2026-08-26T02:55:34.928Z",
+      lastError: null,
+      manualUploadHold: false,
+      pendingWriterOps: 0,
+      inflightWriterOps: 0,
+      deadLetterWriterOps: 0,
+      hasLocalChanges: over.hasLocalChanges ?? false,
+      queuedForUpload: false,
+    },
+    appContext: {
+      appId: APP,
+      dependentJobIds: [],
+      registryDbIds: [],
+      globalAutoUploadEnabled: false,
+      publishLive: over.publishLive ?? false,
+      publishedAt: over.publishedAt ?? null,
+    },
+    cached: false,
+    uploadError: null,
+  };
+}
+
+describe("upload vs publish", () => {
+  it("reports synced after upload even when the app was never published", () => {
+    const s = deriveAppCloudSyncStatus(APP, items({ publishLive: false }), "synced");
+
+    expect(s.codePhase).toBe("synced");
+    expect(s.overall).toBe("synced");
+    expect(webSyncVisualState(s, {})).toBe("synced");
+  });
+
+  it("says uploaded but not shared, not 'changes still need to sync'", () => {
+    const s = deriveAppCloudSyncStatus(APP, items({ publishLive: false }), "synced");
+
+    expect(s.summaryLine).not.toContain("still need to sync");
+    expect(s.summaryLine.toLowerCase()).toContain("not shared yet");
+  });
+
+  it("still reports synced for a published app with a healthy publish layer", () => {
+    const s = deriveAppCloudSyncStatus(
+      APP,
+      items({ publishLive: true, publishedAt: "2026-08-26T02:00:00.000Z" }),
+      "synced",
+    );
+
+    expect(s.overall).toBe("synced");
+    expect(webSyncVisualState(s, {})).toBe("synced");
+  });
+
+  it("does NOT mask real local changes on an unpublished app", () => {
+    const s = deriveAppCloudSyncStatus(
+      APP,
+      items({
+        publishLive: false,
+        codeStatus: "pending",
+        codePhase: "changed",
+        hasLocalChanges: true,
+      }),
+      "synced",
+    );
+
+    expect(s.overall).toBe("needs_sync");
+    expect(webSyncVisualState(s, {})).not.toBe("synced");
+  });
+
+  it("does NOT mask publish drift on a published app", () => {
+    const s = deriveAppCloudSyncStatus(
+      APP,
+      items({
+        publishLive: true,
+        publishedAt: "2026-08-26T02:00:00.000Z",
+        publishStatus: "drift",
+      }),
+      "synced",
+    );
+
+    expect(s.overall).toBe("needs_sync");
+  });
+});

--- a/ui/utils/appCloudSyncStatus.ts
+++ b/ui/utils/appCloudSyncStatus.ts
@@ -393,6 +393,7 @@ function buildSummaryLine(opts: {
   lastUploadedAt: string | null;
   publishStatus?: AppCloudPublishStatus;
   publishDetail?: string | null;
+  publishNotConfigured?: boolean;
   gitRemoteRequiresReview?: boolean;
   gitRemoteMetadataSync?: boolean;
   uploadLabel?: string | null;
@@ -412,6 +413,7 @@ function buildSummaryLine(opts: {
     lastUploadedAt,
     publishStatus,
     publishDetail,
+    publishNotConfigured,
     gitRemoteRequiresReview,
     gitRemoteMetadataSync,
     uploadLabel,
@@ -472,6 +474,13 @@ function buildSummaryLine(opts: {
   if (parts.length === 0) {
     if (overall === "synced") {
       const relative = formatLastUploadedAt(lastUploadedAt);
+      // Uploaded but never published: say so, so "synced" is not misread as
+      // "shared with people".
+      if (publishNotConfigured) {
+        return relative
+          ? `Uploaded ${relative} · not shared yet`
+          : "Uploaded to your private cloud repo · not shared yet";
+      }
       return relative
         ? `Last uploaded ${relative}`
         : "Everything for this app matches the web";
@@ -747,12 +756,18 @@ export function deriveAppCloudSyncStatus(
   const publishDetail = items.publish?.detail ?? null;
   const publishLabel = publishDetailLabel(publishStatus, publishDetail);
   const cloudPublishing = publishStatus === "republishing";
+  // Never published: there is no web layer to keep in sync, so publish state
+  // must not hold the app at "needs sync". Upload now puts code in the cloud
+  // repo; publishing is a separate, explicit action.
+  const publishNotConfigured = !publishLive && publishedAt == null;
   const publishLayerSynced =
-    publishLive && publishStatus === "synced" && !cloudPublishing;
+    publishNotConfigured ||
+    (publishLive && publishStatus === "synced" && !cloudPublishing);
   const publishBlocksWeb =
-    publishStatus === "drift" ||
-    publishStatus === "error" ||
-    (publishStatus === "not_web_ready" && !publishLive);
+    !publishNotConfigured &&
+    (publishStatus === "drift" ||
+      publishStatus === "error" ||
+      (publishStatus === "not_web_ready" && !publishLive));
 
   const uploadStatus = items.upload?.status;
   const uploadLabel = items.upload?.label ?? null;
@@ -912,6 +927,7 @@ export function deriveAppCloudSyncStatus(
           lastUploadedAt,
           publishStatus,
           publishDetail,
+          publishNotConfigured,
           gitRemoteRequiresReview,
           gitRemoteMetadataSync,
           uploadLabel,


### PR DESCRIPTION
Clicking **Upload now** on an app that has never been published (Draft · Private) leaves the web sync indicator amber with *"Some changes still need to sync to the web"* — even though the upload fully succeeded. There is no action left to take, and clicking Upload now again changes nothing, so the app looks permanently half-broken.

## Reproduction

Derived status from the exact `/api/sync/items` payload after a successful upload, with `publishLive: false`:

```
codePhase   : synced                                   <- upload succeeded
codeLabel   : App files match the cloud repo
overall     : needs_sync                               <- wrong
dot         : warn                                     <- amber
summaryLine : Some changes still need to sync to the web
```

The code layer and the overall state disagree.

## Root cause

```ts
const publishLayerSynced =
  publishLive && publishStatus === "synced" && !cloudPublishing;
```

An app that was never published has `publishLive: false`, so `publishLayerSynced` can never be true. That feeds `needsSync`:

```ts
(!publishLayerSynced && displayCodePhase === "synced" && ...)
```

…which forces `overall = "needs_sync"` regardless of how clean the code sync is. `webSyncVisualState` then returns `warn`, and the summary falls through to the generic "still need to sync" string.

## Why this is a bug, not a preference

**Upload and publish are separate actions.** Upload now pushes code to the private per-app cloud repo. Publishing shares it on the web. An app with no publish configured has no web layer to be out of sync *with*, so publish state should not hold it at `needs_sync`.

Reserving green for "published" also overloads the indicator: sharing state is already shown by the **Draft · Private** chip and the Local/Web toggle right next to it.

## Fix

- treat *never published* (`!publishLive && publishedAt == null`) as a satisfied publish layer rather than an outstanding sync obligation
- stop `publishBlocksWeb` firing for apps that were never published
- summarise the synced-but-unpublished state as **"Uploaded 2m ago · not shared yet"**, so green is not misread as "shared with people"

That last point matters: the goal is an honest green, not a permissive one.

## Testing

New `ui/__tests__/appCloudSyncStatusPublish.test.ts` — 5 tests. Two assert the fix; **three are guard tests** that must keep passing so this cannot mask real problems:

| Test | Asserts |
| --- | --- |
| synced after upload when never published | `overall: synced`, dot `synced` |
| summary says uploaded, not "still need to sync" | wording |
| published app with healthy publish layer | still `synced` |
| **unpublished app with real local changes** | still `needs_sync` |
| **published app with publish drift** | still `needs_sync` |

**Mutation-checked:** reverted to the previous logic — the 2 bug tests fail, the 3 guard tests still pass. The tests fail for the right reason.

| Check | Result |
| --- | --- |
| New tests | 5 passed |
| `unit-ui` with fix | 204 passed, 23 failed |
| `unit-ui` baseline (stashed) | 199 passed, **same 23 failed** |
| `tsc --noEmit` | 156, no errors in changed files |
| `oxlint` | clean (1 pre-existing warning on an untouched line) |

The 23 failures are pre-existing in `ChatContainer.test.tsx` and unrelated.

## Reviewer note

I scoped "never published" deliberately tightly with `publishedAt == null`. An app that **was** published and later unpublished still has `publishedAt` set, so it keeps the old strict behaviour — an unpublish that leaves cloud state behind should still be surfaced. Worth confirming that matches the intended semantics of `publishedAt`.
