### PR TITLE
fix(memory): send user_id instead of external_user_id for Papr accounts

### DIFF
--- a/src/core/tools/paprDocumentMemory.ts
+++ b/src/core/tools/paprDocumentMemory.ts
@@ -215,8 +215,8 @@ export const uploadDocumentToMemoryTool = createTool({
 
       const response = await client.document.upload({
         file: createReadStream(resolvedPath),
-        ...(memoryScope.external_user_id
-          ? { external_user_id: memoryScope.external_user_id }
+        ...(memoryScope.user_id
+          ? { user_id: memoryScope.user_id }
           : {}),
         ...(memoryScope.namespace_id
           ? { namespace_id: memoryScope.namespace_id }

--- a/src/core/tools/paprMemory.ts
+++ b/src/core/tools/paprMemory.ts
@@ -27,15 +27,15 @@ const memoryReadAclToolFields = {
     .array(z.string().min(1))
     .optional()
     .describe(
-      "Optional read ACL principals. Use external_user:{Parse objectId}, namespace:{namespaceId}, or organization:{orgId}. " +
+      "Optional read ACL principals. Use user:{Parse objectId}, namespace:{namespaceId}, or organization:{orgId}. " +
         "When set, overrides the chat Team/Org scope for read access. Writer always keeps write ACL.",
     ),
   shareWithUserIds: z
     .array(z.string().min(1))
     .optional()
     .describe(
-      "Parse objectIds (same as external_user_id / list_namespace_users.externalUserId) to grant read access. " +
-        "Converted to external_user:{id} ACL principals automatically.",
+      "Parse objectIds (same as list_namespace_users.externalUserId) to grant read access. " +
+        "Converted to user:{id} ACL principals automatically.",
     ),
   shareWithTeam: z
     .boolean()
@@ -54,7 +54,7 @@ const memoryReadAclToolFields = {
 const addMemorySchema = z
   .object({
     content: z.string().min(1),
-    // Writer resolved at runtime via getPaprUserId() — passed as external_user_id (Parse objectId).
+    // Writer resolved at runtime via getPaprUserId() — passed as user_id (Parse objectId).
     role: z.enum(["user", "assistant"]).optional(),
     category: z
       .enum([
@@ -527,7 +527,7 @@ export const addAgentMemoryTool = createTool({
   description:
     "Store a structured memory item in PAPR memory. IMPORTANT: When using category='context', you MUST provide role ('user' or 'assistant'). " +
     "For attendee-only sharing, call list_namespace_users first, match emails to externalUserId, then pass shareWithUserIds or readAcl with external_user:{objectId} principals. " +
-    "Use external_user_id semantics (Parse objectId) — NOT Papr internal user_id.",
+    "Uses the acting Papr user_id (Parse objectId) — never a caller-supplied id.",
   inputSchema: addMemorySchema,
   execute: async (args) => {
     try {
@@ -565,8 +565,8 @@ export const addAgentMemoryTool = createTool({
 
       const response = await client.memory.add({
         content: args.content,
-        ...(memoryScope.external_user_id
-          ? { external_user_id: memoryScope.external_user_id }
+        ...(memoryScope.user_id
+          ? { user_id: memoryScope.user_id }
           : {}),
         ...(memoryScope.namespace_id
           ? { namespace_id: memoryScope.namespace_id }
@@ -598,7 +598,7 @@ export const listNamespaceUsersTool = createTool({
   id: "list_namespace_users",
   description:
     "List Papr users in the active workspace/namespace team. Returns Parse objectIds as externalUserId " +
-    "and ready-to-use memoryReadPrincipal values (external_user:{objectId}) for add_agent_memory and create_entities ACL. " +
+    "and ready-to-use memoryReadPrincipal values (user:{objectId}) for add_agent_memory and create_entities ACL. " +
     "Call before sharing memories with specific attendees.",
   inputSchema: listNamespaceUsersSchema,
   execute: async (args) => {
@@ -622,8 +622,8 @@ export const listNamespaceUsersTool = createTool({
           ...result,
           members,
           idGuidance: {
-            bodyField: "external_user_id",
-            aclPrefix: "external_user:",
+            bodyField: "user_id",
+            aclPrefix: "user:",
             examplePrincipal: members[0]?.memoryReadPrincipal,
           },
         },
@@ -726,8 +726,8 @@ export const searchAgentMemoryTool = createTool({
       const { data: response, response: httpResponse } = await client.memory
         .search({
           query: args.query!,
-          ...(memorySearchScope.external_user_id
-            ? { external_user_id: memorySearchScope.external_user_id }
+          ...(memorySearchScope.user_id
+            ? { user_id: memorySearchScope.user_id }
             : {}),
           ...(memorySearchScope.search_acl
             ? { search_acl: memorySearchScope.search_acl }
@@ -1416,8 +1416,8 @@ export const addAgentMemoryBatchTool = createTool({
           ? { skip_background_processing: args.skipBackgroundProcessing }
           : {}),
         ...(args.batchSize !== undefined ? { batch_size: args.batchSize } : {}),
-        ...(memoryScope.external_user_id
-          ? { external_user_id: memoryScope.external_user_id }
+        ...(memoryScope.user_id
+          ? { user_id: memoryScope.user_id }
           : {}),
         ...(memoryScope.namespace_id
           ? { namespace_id: memoryScope.namespace_id }
@@ -1625,8 +1625,8 @@ export const createEntitiesAndRelationshipsTool = createTool({
 
       const response = await client.memory.add({
         content: args.content,
-        ...(memoryScope.external_user_id
-          ? { external_user_id: memoryScope.external_user_id }
+        ...(memoryScope.user_id
+          ? { user_id: memoryScope.user_id }
           : {}),
         ...(memoryScope.namespace_id
           ? { namespace_id: memoryScope.namespace_id }

--- a/src/core/utils/memoryAcl.ts
+++ b/src/core/utils/memoryAcl.ts
@@ -1,29 +1,58 @@
 /**
  * Papr Memory ACL helpers.
  *
- * Use Parse _User.objectId as external_user_id on memory.add bodies.
- * ACL principals use the external_user:{objectId} prefix — NOT bare user ids
- * and NOT Papr's internal user_id field.
+ * Paprwork users ARE real Papr accounts, so we send Parse _User.objectId as
+ * `user_id` (not `external_user_id`). Sending it as external_user_id makes the
+ * memory server mint an anonymous shadow DeveloperUser, which splits one human
+ * into several identities and breaks feedback authorization.
+ *
+ * ACL principals therefore use the `user:{objectId}` prefix, which maps to
+ * user_read_access / user_write_access — the fields the search filter actually
+ * evaluates. `external_user:` maps to external_user_read_access, which is NOT
+ * part of the ACL OR-branch (that filter is commented out server-side).
+ *
+ * `external_user_id` remains supported by the memory server for third-party SDK
+ * developers whose end users have no Papr account. It is not used by Paprwork.
  */
 
 import type { MemoryAddPolicy } from "@papr/memory/resources/shared.js";
 
+export const USER_PRINCIPAL_PREFIX = "user:" as const;
 export const EXTERNAL_USER_PRINCIPAL_PREFIX = "external_user:" as const;
 export const NAMESPACE_PRINCIPAL_PREFIX = "namespace:" as const;
 export const ORGANIZATION_PRINCIPAL_PREFIX = "organization:" as const;
 
 const PRINCIPAL_PATTERN =
-  /^(external_user|namespace|organization):[A-Za-z0-9_-]+$/;
+  /^(user|external_user|namespace|organization):[A-Za-z0-9_-]+$/;
 
-/** Strip `external_user:` prefix if the agent pasted a full principal. */
+/** Strip a `user:` / `external_user:` prefix if a full principal was pasted. */
 export function normalizeExternalUserId(value: string): string {
   const trimmed = value.trim();
   if (trimmed.startsWith(EXTERNAL_USER_PRINCIPAL_PREFIX)) {
     return trimmed.slice(EXTERNAL_USER_PRINCIPAL_PREFIX.length).trim();
   }
+  if (trimmed.startsWith(USER_PRINCIPAL_PREFIX)) {
+    return trimmed.slice(USER_PRINCIPAL_PREFIX.length).trim();
+  }
   return trimmed;
 }
 
+/**
+ * Build a `user:{objectId}` principal for a real Papr account.
+ * Accepts a bare objectId or an already-prefixed principal.
+ */
+export function toUserPrincipal(userId: string): string {
+  const id = normalizeExternalUserId(userId);
+  if (!id) {
+    throw new Error("user id must be non-empty");
+  }
+  return `${USER_PRINCIPAL_PREFIX}${id}`;
+}
+
+/**
+ * Build an `external_user:{id}` principal.
+ * Retained for third-party SDK end users; Paprwork uses toUserPrincipal.
+ */
 export function toExternalUserPrincipal(externalUserId: string): string {
   const id = normalizeExternalUserId(externalUserId);
   if (!id) {
@@ -62,13 +91,13 @@ export function normalizeReadPrincipal(value: string): string {
     return trimmed;
   }
 
-  // Convenience: bare Parse objectId → external_user principal
+  // Convenience: bare Parse objectId → user principal (real Papr account)
   if (!trimmed.includes(":")) {
-    return toExternalUserPrincipal(trimmed);
+    return toUserPrincipal(trimmed);
   }
 
   throw new Error(
-    `Invalid read ACL principal "${trimmed}". Use external_user:{objectId}, namespace:{id}, or organization:{id}.`,
+    `Invalid read ACL principal "${trimmed}". Use user:{objectId}, namespace:{id}, or organization:{id}.`,
   );
 }
 
@@ -101,7 +130,7 @@ export function buildExplicitReadPrincipals(
   const read: string[] = [];
 
   for (const userId of input.shareWithUserIds ?? []) {
-    read.push(toExternalUserPrincipal(userId));
+    read.push(toUserPrincipal(userId));
   }
 
   for (const principal of input.readAcl ?? []) {
@@ -121,14 +150,16 @@ export function buildExplicitReadPrincipals(
   return dedupeReadPrincipals(read);
 }
 
-export function buildWriterWriteAcl(writerExternalUserId: string): string[] {
-  return [toExternalUserPrincipal(writerExternalUserId)];
+/** Writer keeps write access via their real Papr account principal. */
+export function buildWriterWriteAcl(writerUserId: string): string[] {
+  return [toUserPrincipal(writerUserId)];
 }
 
 /** Apply explicit read ACL, always keeping the writer on write ACL. */
 export function applyExplicitReadAclToPolicy(
   basePolicy: MemoryAddPolicy | undefined,
   input: {
+    /** Real Papr _User.objectId of the acting user. */
     writerExternalUserId: string;
     explicitRead: ExplicitMemoryReadAclInput;
   },

--- a/src/core/utils/memoryScope.ts
+++ b/src/core/utils/memoryScope.ts
@@ -16,13 +16,19 @@ export interface MemoryScopeContext {
 }
 
 export interface MemoryScopeFields {
-  external_user_id?: string;
+  /**
+   * Real Papr _User.objectId of the acting user.
+   * Sent as `user_id` — NOT `external_user_id`, which would make the memory
+   * server mint an anonymous shadow DeveloperUser for a real Papr account.
+   */
+  user_id?: string;
   namespace_id?: string;
   policy?: MemoryAddPolicy;
 }
 
 export interface MemorySearchScopeFields {
-  external_user_id?: string;
+  /** Real Papr _User.objectId of the acting user. */
+  user_id?: string;
   search_acl?: { read: string[]; write?: string[] };
 }
 
@@ -35,7 +41,7 @@ export function resolveMemoryAudience(input: {
 }
 
 function userWriteAcl(userId: string): string[] {
-  return [`external_user:${userId}`];
+  return [`user:${userId}`];
 }
 
 export function buildMemoryScopeFields(
@@ -52,7 +58,7 @@ export function buildMemoryScopeFields(
 
   if (audience === "namespace" && namespaceId) {
     return {
-      external_user_id: userId,
+      user_id: userId,
       namespace_id: namespaceId,
       policy: {
         acl: {
@@ -65,7 +71,7 @@ export function buildMemoryScopeFields(
 
   if (audience === "org" && organizationId) {
     return {
-      external_user_id: userId,
+      user_id: userId,
       namespace_id: namespaceId,
       policy: {
         acl: {
@@ -76,7 +82,7 @@ export function buildMemoryScopeFields(
     };
   }
 
-  return { external_user_id: userId };
+  return { user_id: userId };
 }
 
 export function buildMemorySearchScopeFields(
@@ -89,19 +95,19 @@ export function buildMemorySearchScopeFields(
 
   if (audience === "namespace" && namespaceId) {
     return {
-      ...(userId ? { external_user_id: userId } : {}),
+      ...(userId ? { user_id: userId } : {}),
       search_acl: { read: [`namespace:${namespaceId}`] },
     };
   }
 
   if (audience === "org" && organizationId) {
     return {
-      ...(userId ? { external_user_id: userId } : {}),
+      ...(userId ? { user_id: userId } : {}),
       search_acl: { read: [`organization:${organizationId}`] },
     };
   }
 
-  return userId ? { external_user_id: userId } : {};
+  return userId ? { user_id: userId } : {};
 }
 
 export function mergeMemoryAddPolicy(

--- a/src/gateway/services/AttachmentMemoryUpload.ts
+++ b/src/gateway/services/AttachmentMemoryUpload.ts
@@ -63,8 +63,8 @@ export async function uploadAttachmentToMemory(
 
   const response = await client.document.upload({
     file: createReadStream(resolvedPath),
-    ...(memoryScope.external_user_id
-      ? { external_user_id: memoryScope.external_user_id }
+    ...(memoryScope.user_id
+      ? { user_id: memoryScope.user_id }
       : {}),
     ...(memoryScope.namespace_id ? { namespace_id: memoryScope.namespace_id } : {}),
     ...(memoryScope.policy

--- a/src/gateway/services/PaprMemoryWritebackService.ts
+++ b/src/gateway/services/PaprMemoryWritebackService.ts
@@ -6,6 +6,7 @@ import Papr from "@papr/memory";
 import { handlePaprToolError } from "../../core/tools/paprClient.js";
 import { getApiKey } from "../utils/keyResolver.js";
 import { paprMemoryScopeSpread } from "../utils/memoryScopeResolver.js";
+import { resolveTrustedPaprUserId } from "../utils/paprUserId.js";
 import type { JobMemoryPolicy } from "./jobs/types.js";
 
 export interface MemoryWritebackInput {
@@ -46,10 +47,15 @@ export async function writeRunMemory(
     const memoryScope = await paprMemoryScopeSpread({
       chatId: input.chatId,
     });
+    // input.userId is caller-supplied. The Papr API key is scoped to
+    // org + namespace (not to a person), so trusting it verbatim would let any
+    // key holder write memories owned by an arbitrary Papr account. Accept it
+    // only when it matches the locally authenticated user.
+    const trustedUserId = resolveTrustedPaprUserId(input.userId);
     await client.memory.add({
       content: compactContent(input),
-      ...(input.userId && !memoryScope.external_user_id
-        ? { external_user_id: input.userId }
+      ...(trustedUserId && !memoryScope.user_id
+        ? { user_id: trustedUserId }
         : memoryScope),
       metadata: {
         category: "learning",

--- a/src/gateway/services/namespaceUsersService.ts
+++ b/src/gateway/services/namespaceUsersService.ts
@@ -7,7 +7,7 @@ import {
   type WorkspaceMember,
 } from "../../core/utils/paprWorkspaceTeam.js";
 import {
-  toExternalUserPrincipal,
+  toUserPrincipal,
   toNamespacePrincipal,
   toOrganizationPrincipal,
 } from "../../core/utils/memoryAcl.js";
@@ -48,7 +48,9 @@ function mapMemberForAgent(member: WorkspaceMember): NamespaceUserForAgent {
     email: member.user.email,
     displayName: member.user.displayName,
     role: member.user.role,
-    memoryReadPrincipal: toExternalUserPrincipal(externalUserId),
+    // Namespace members are real Papr accounts, so share via user: principals
+    // (maps to user_read_access, which the search ACL filter evaluates).
+    memoryReadPrincipal: toUserPrincipal(externalUserId),
   };
 }
 
@@ -84,7 +86,7 @@ export async function listNamespaceUsersForAgent(): Promise<ListNamespaceUsersRe
     organizationId,
     recorderExternalUserId,
     aclHints: {
-      externalUser: "external_user:{Parse objectId}",
+      externalUser: "user:{Parse objectId}",
       ...(namespaceId
         ? { namespace: toNamespacePrincipal(namespaceId) }
         : {}),

--- a/src/gateway/services/storage/PaprMemoryProvider.ts
+++ b/src/gateway/services/storage/PaprMemoryProvider.ts
@@ -89,7 +89,7 @@ export class PaprMemoryProvider implements IStorageProvider {
       const storeBody: PaprMessageStoreBody = buildPaprSyncStoreBody({
         chatId,
         message,
-        externalUserId: memoryScope.external_user_id,
+        userId: memoryScope.user_id,
         namespaceId: memoryScope.namespace_id,
         policy: memoryScope.policy,
       });

--- a/src/gateway/services/storage/paprSyncPayload.ts
+++ b/src/gateway/services/storage/paprSyncPayload.ts
@@ -36,7 +36,8 @@ export interface PaprMessageStoreBody {
     role: "user" | "assistant";
     customMetadata: PaprSyncCustomMetadata;
   };
-  external_user_id?: string;
+  /** Real Papr _User.objectId — see memoryAcl.ts for why this is not external_user_id. */
+  user_id?: string;
   namespace_id?: string;
   policy?: MemoryAddPolicy;
 }
@@ -266,7 +267,7 @@ function assembleStoreBody(
   content: string | PaprContentBlock[],
   customMetadata: PaprSyncCustomMetadata,
   scope?: {
-    externalUserId?: string;
+    userId?: string;
     namespaceId?: string;
     policy?: MemoryAddPolicy;
   },
@@ -285,8 +286,8 @@ function assembleStoreBody(
     },
   };
 
-  if (scope?.externalUserId) {
-    body.external_user_id = scope.externalUserId;
+  if (scope?.userId) {
+    body.user_id = scope.userId;
   }
   if (scope?.namespaceId) {
     body.namespace_id = scope.namespaceId;
@@ -301,7 +302,7 @@ function assembleStoreBody(
 export function buildPaprSyncStoreBody(input: {
   chatId: string;
   message: StoredMessage;
-  externalUserId?: string;
+  userId?: string;
   namespaceId?: string;
   policy?: MemoryAddPolicy;
   maxBytes?: number;
@@ -311,7 +312,7 @@ export function buildPaprSyncStoreBody(input: {
   const maxBytes = input.maxBytes ?? PAPR_SYNC_MAX_BYTES;
   const customMetadata = buildPaprSyncCustomMetadata(input.message);
   const scope = {
-    externalUserId: input.externalUserId,
+    userId: input.userId,
     namespaceId: input.namespaceId,
     policy: input.policy,
   };

--- a/src/gateway/services/wikiGraphEntitySync.ts
+++ b/src/gateway/services/wikiGraphEntitySync.ts
@@ -124,8 +124,8 @@ async function upsertGraphEntityName(input: {
 
   await input.client.memory.add({
     content: `Wiki sync: ${input.entityType} ${input.nodeId} renamed to "${input.newName}"`,
-    ...(memoryScope.external_user_id
-      ? { external_user_id: memoryScope.external_user_id }
+    ...(memoryScope.user_id
+      ? { user_id: memoryScope.user_id }
       : {}),
     ...(memoryScope.namespace_id
       ? { namespace_id: memoryScope.namespace_id }

--- a/src/gateway/services/wikiLocalEntityGraphSync.ts
+++ b/src/gateway/services/wikiLocalEntityGraphSync.ts
@@ -122,8 +122,8 @@ export async function syncLocalWikiEntityToGraph(
       ]
         .filter(Boolean)
         .join("\n"),
-      ...(memoryScope.external_user_id
-        ? { external_user_id: memoryScope.external_user_id }
+      ...(memoryScope.user_id
+        ? { user_id: memoryScope.user_id }
         : {}),
       ...(memoryScope.namespace_id
         ? { namespace_id: memoryScope.namespace_id }

--- a/src/gateway/utils/memoryScopeResolver.ts
+++ b/src/gateway/utils/memoryScopeResolver.ts
@@ -95,7 +95,7 @@ export async function buildPaprMemoryWriteScope(input?: {
   /** When set, replaces chat/settings read ACL (writer still gets write ACL). */
   explicitReadAcl?: ExplicitMemoryReadAclInput;
 }): Promise<{
-  external_user_id?: string;
+  user_id?: string;
   namespace_id?: string;
   policy?: MemoryAddPolicy;
 }> {
@@ -121,7 +121,7 @@ export async function buildPaprMemoryWriteScope(input?: {
   }
 
   return {
-    external_user_id: fields.external_user_id,
+    user_id: fields.user_id,
     namespace_id: fields.namespace_id,
     policy,
   };
@@ -131,7 +131,7 @@ export async function buildPaprMemorySearchScope(input?: {
   chatId?: string;
   explicitAudience?: MemoryAudience;
 }): Promise<{
-  external_user_id?: string;
+  user_id?: string;
   search_acl?: { read: string[]; write?: string[] };
 }> {
   const audience =
@@ -146,15 +146,13 @@ export async function paprMemoryScopeSpread(input?: {
   explicitAudience?: MemoryAudience;
   addPolicy?: MemoryAddPolicy;
 }): Promise<{
-  external_user_id?: string;
+  user_id?: string;
   namespace_id?: string;
   policy?: MemoryAddPolicy;
 }> {
   const scope = await buildPaprMemoryWriteScope(input);
   return {
-    ...(scope.external_user_id
-      ? { external_user_id: scope.external_user_id }
-      : {}),
+    ...(scope.user_id ? { user_id: scope.user_id } : {}),
     ...(scope.namespace_id ? { namespace_id: scope.namespace_id } : {}),
     ...(scope.policy ? { policy: scope.policy } : {}),
   };
@@ -165,14 +163,12 @@ export async function paprMemorySearchScopeSpread(input?: {
   chatId?: string;
   explicitAudience?: MemoryAudience;
 }): Promise<{
-  external_user_id?: string;
+  user_id?: string;
   search_acl?: { read: string[]; write?: string[] };
 }> {
   const scope = await buildPaprMemorySearchScope(input);
   return {
-    ...(scope.external_user_id
-      ? { external_user_id: scope.external_user_id }
-      : {}),
+    ...(scope.user_id ? { user_id: scope.user_id } : {}),
     ...(scope.search_acl ? { search_acl: scope.search_acl } : {}),
   };
 }
@@ -183,7 +179,7 @@ export function buildPaprMemoryWriteScopeSync(input: {
   addPolicy?: MemoryAddPolicy;
   ctx?: MemoryScopeContext;
 }): {
-  external_user_id?: string;
+  user_id?: string;
   namespace_id?: string;
   policy?: MemoryAddPolicy;
 } {
@@ -192,7 +188,7 @@ export function buildPaprMemoryWriteScopeSync(input: {
     input.ctx ?? getMemoryScopeContext(),
   );
   return {
-    external_user_id: fields.external_user_id,
+    user_id: fields.user_id,
     namespace_id: fields.namespace_id,
     policy: mergeMemoryAddPolicy(input.addPolicy, fields.policy),
   };

--- a/src/gateway/utils/paprUserId.ts
+++ b/src/gateway/utils/paprUserId.ts
@@ -8,9 +8,17 @@ let cachedUserId: string | undefined;
 let cachedAt = 0;
 
 /**
- * Parse _User.objectId from Papr login — your app's user identifier.
- * Pass as `external_user_id` on Papr Memory API calls (NOT `user_id`, which is
- * Papr's internal user record and rejects unknown IDs).
+ * Parse _User.objectId of the locally-authenticated Papr user.
+ *
+ * Pass as `user_id` on Papr Memory API calls. Paprwork users ARE real Papr
+ * accounts, so sending this as `external_user_id` makes the memory server mint
+ * an anonymous shadow DeveloperUser — splitting one human into several
+ * identities and breaking feedback authorization.
+ *
+ * This is the ONLY source of user identity for memory calls. It is read from
+ * local login state and is never caller-supplied, so a namespace API key cannot
+ * be used to write memories owned by an arbitrary Papr account.
+ *
  * Prefers gateway env (set at spawn); falls back to settings.json after login.
  */
 export function getPaprUserId(): string | undefined {
@@ -48,10 +56,41 @@ export function invalidatePaprUserIdCache(): void {
   cachedAt = 0;
 }
 
-/** Spread into Papr SDK request bodies when the logged-in user should be scoped. */
-export function paprUserScope(): { external_user_id: string } | Record<string, never> {
+/**
+ * Spread into Papr SDK request bodies to scope a call to the logged-in user.
+ *
+ * Always resolves the acting user locally — callers cannot inject an identity.
+ * Returns `{}` when not logged in, so the server falls back to the API key
+ * owner rather than writing memories under an unauthenticated id.
+ */
+export function paprUserScope(): { user_id: string } | Record<string, never> {
   const userId = getPaprUserId();
-  return userId ? { external_user_id: userId } : {};
+  return userId ? { user_id: userId } : {};
+}
+
+/**
+ * Guard for call sites that accept a user id from an argument or request body.
+ *
+ * The Papr API key is scoped to org + namespace, not to a person, so a
+ * caller-supplied id would let any holder of the key write memories owned by an
+ * arbitrary Papr account. We accept the value only when it matches the locally
+ * authenticated user; otherwise we fall back to the local identity.
+ */
+export function resolveTrustedPaprUserId(
+  candidate?: string | null,
+): string | undefined {
+  const localUserId = getPaprUserId();
+  const requested = candidate?.trim();
+
+  if (!requested || !localUserId || requested === localUserId) {
+    return localUserId;
+  }
+
+  console.warn(
+    `[paprUserId] Ignoring caller-supplied user_id "${requested}" — ` +
+      `does not match authenticated user. Using local identity instead.`,
+  );
+  return localUserId;
 }
 
 /** Caller identity for GET /api/access and verified job params on desktop. */

--- a/tests/memory-acl.test.ts
+++ b/tests/memory-acl.test.ts
@@ -6,27 +6,35 @@ import {
   normalizeExternalUserId,
   normalizeReadPrincipal,
   toExternalUserPrincipal,
+  toUserPrincipal,
 } from "../src/core/utils/memoryAcl.js";
 
 describe("memoryAcl", () => {
-  it("normalizes external user ids and principals", () => {
+  it("normalizes user ids and principals", () => {
     expect(normalizeExternalUserId("abc123")).toBe("abc123");
+    expect(normalizeExternalUserId("user:abc123")).toBe("abc123");
     expect(normalizeExternalUserId("external_user:abc123")).toBe("abc123");
-    expect(toExternalUserPrincipal("abc123")).toBe("external_user:abc123");
-    expect(normalizeReadPrincipal("abc123")).toBe("external_user:abc123");
+    // Paprwork users are real Papr accounts → user: principals
+    expect(toUserPrincipal("abc123")).toBe("user:abc123");
+    expect(normalizeReadPrincipal("abc123")).toBe("user:abc123");
     expect(normalizeReadPrincipal("namespace:ns-1")).toBe("namespace:ns-1");
+    // Retained for third-party SDK end users (no Papr account)
+    expect(toExternalUserPrincipal("abc123")).toBe("external_user:abc123");
+    expect(normalizeReadPrincipal("external_user:abc123")).toBe(
+      "external_user:abc123",
+    );
   });
 
   it("builds explicit read principals from user ids and ACL entries", () => {
     expect(
       buildExplicitReadPrincipals({
-        shareWithUserIds: ["user-a", "external_user:user-b"],
+        shareWithUserIds: ["user-a", "user:user-b"],
         readAcl: ["namespace:ns-abc"],
         shareWithOrganizationId: "org-xyz",
       }),
     ).toEqual([
-      "external_user:user-a",
-      "external_user:user-b",
+      "user:user-a",
+      "user:user-b",
       "namespace:ns-abc",
       "organization:org-xyz",
     ]);
@@ -54,8 +62,8 @@ describe("memoryAcl", () => {
     expect(policy).toEqual({
       transform_embedding: { mode: "auto", domain_id: "general" },
       acl: {
-        read: ["external_user:attendee-1", "namespace:ns-abc"],
-        write: ["external_user:recorder-1"],
+        read: ["user:attendee-1", "namespace:ns-abc"],
+        write: ["user:recorder-1"],
       },
     });
   });

--- a/tests/memory-scope-resolver.test.ts
+++ b/tests/memory-scope-resolver.test.ts
@@ -55,7 +55,7 @@ describe("memoryScopeResolver chat scope", () => {
   it("falls back to settings default when chat has no scope", async () => {
     const { buildPaprMemoryWriteScope } = await loadResolver();
     const scope = await buildPaprMemoryWriteScope({ chatId: "chat-no-scope" });
-    expect(scope.external_user_id).toBe("user-1");
+    expect(scope.user_id).toBe("user-1");
     expect(scope.policy?.acl?.read).toBeUndefined();
   });
 
@@ -68,8 +68,8 @@ describe("memoryScopeResolver chat scope", () => {
         shareWithUserIds: ["attendee-1"],
       },
     });
-    expect(scope.policy?.acl?.read).toEqual(["external_user:attendee-1"]);
-    expect(scope.policy?.acl?.write).toEqual(["external_user:user-1"]);
+    expect(scope.policy?.acl?.read).toEqual(["user:attendee-1"]);
+    expect(scope.policy?.acl?.write).toEqual(["user:user-1"]);
     expect(scope.policy?.acl?.read).not.toContain("namespace:ns-abc");
   });
 });

--- a/tests/memory-scope.test.ts
+++ b/tests/memory-scope.test.ts
@@ -33,12 +33,12 @@ describe("memoryScope", () => {
 
   it("buildMemoryScopeFields scopes namespace memories with ACL", () => {
     expect(buildMemoryScopeFields("namespace", ctx)).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
       namespace_id: "ns-abc",
       policy: {
         acl: {
           read: ["namespace:ns-abc"],
-          write: ["external_user:user-1", "namespace:ns-abc"],
+          write: ["user:user-1", "namespace:ns-abc"],
         },
       },
     });
@@ -46,20 +46,20 @@ describe("memoryScope", () => {
 
   it("buildMemoryScopeFields scopes org memories with ACL", () => {
     expect(buildMemoryScopeFields("org", ctx)).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
       namespace_id: "ns-abc",
       policy: {
         acl: {
           read: ["organization:org-xyz"],
-          write: ["external_user:user-1", "organization:org-xyz"],
+          write: ["user:user-1", "organization:org-xyz"],
         },
       },
     });
   });
 
-  it("buildMemoryScopeFields user scope is external_user_id only", () => {
+  it("buildMemoryScopeFields user scope is user_id only", () => {
     expect(buildMemoryScopeFields("user", ctx)).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
     });
   });
 
@@ -67,21 +67,21 @@ describe("memoryScope", () => {
     expect(
       buildMemoryScopeFields("namespace", { userId: "user-1" }),
     ).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
     });
   });
 
   it("buildMemorySearchScopeFields expands read ACL for namespace/org", () => {
     expect(buildMemorySearchScopeFields("namespace", ctx)).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
       search_acl: { read: ["namespace:ns-abc"] },
     });
     expect(buildMemorySearchScopeFields("org", ctx)).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
       search_acl: { read: ["organization:org-xyz"] },
     });
     expect(buildMemorySearchScopeFields("user", ctx)).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
     });
   });
 
@@ -93,7 +93,7 @@ describe("memoryScope", () => {
       {
         acl: {
           read: ["namespace:ns-abc"],
-          write: ["external_user:user-1"],
+          write: ["user:user-1"],
         },
       },
     );
@@ -101,7 +101,7 @@ describe("memoryScope", () => {
       transform_embedding: { mode: "auto", domain_id: "general" },
       acl: {
         read: ["namespace:ns-abc"],
-        write: ["external_user:user-1"],
+        write: ["user:user-1"],
       },
     });
   });

--- a/tests/papr-memory-crud-tools.test.ts
+++ b/tests/papr-memory-crud-tools.test.ts
@@ -18,7 +18,7 @@ vi.mock("../src/core/tools/paprClient.js", () => ({
 }));
 
 vi.mock("../src/gateway/utils/paprUserId.js", () => ({
-  paprUserScope: vi.fn(() => ({ external_user_id: "user-test-1" })),
+  paprUserScope: vi.fn(() => ({ user_id: "user-test-1" })),
   getPaprUserId: vi.fn(() => "user-test-1"),
   getPaprCallerIdentity: vi.fn(() => ({ userId: "user-test-1" })),
   invalidatePaprUserIdCache: vi.fn(),
@@ -34,7 +34,7 @@ vi.mock("../src/gateway/utils/workspaceContextSchema.js", () => ({
 
 vi.mock("../src/gateway/utils/memoryScopeResolver.js", () => ({
   buildPaprMemoryWriteScope: vi.fn(async (input?: { addPolicy?: unknown }) => ({
-    external_user_id: "user-test-1",
+    user_id: "user-test-1",
     namespace_id: "ns-test-1",
     policy: input?.addPolicy,
   })),
@@ -151,7 +151,7 @@ describe("papr memory CRUD + feedback tools", () => {
       expect(payload.policy).toEqual({
         graph: { mode: "auto", schema_id: "schema-workspace-context" },
       });
-      expect(payload.external_user_id).toBe("user-test-1");
+      expect(payload.user_id).toBe("user-test-1");
       expect(payload.namespace_id).toBe("ns-test-1");
 
       expect(result.requested).toBe(2);
@@ -252,7 +252,7 @@ describe("papr memory CRUD + feedback tools", () => {
       expect(payload.feedback_items).toHaveLength(2);
       expect(payload.feedback_items[0]).toMatchObject({
         search_id: "search-1",
-        external_user_id: "user-test-1",
+        user_id: "user-test-1",
         feedbackData: {
           feedbackSource: "inline",
           feedbackType: "thumbs_up",

--- a/tests/papr-memory-metadata.test.ts
+++ b/tests/papr-memory-metadata.test.ts
@@ -11,7 +11,7 @@ import type { StoredMessage } from "../src/gateway/services/storage/IStorageProv
 vi.mock("../src/gateway/utils/paprUserId.js", () => ({
   getPaprUserId: vi.fn(() => "WkPutXGdqg"),
   invalidatePaprUserIdCache: vi.fn(),
-  paprUserScope: vi.fn(() => ({ external_user_id: "WkPutXGdqg" })),
+  paprUserScope: vi.fn(() => ({ user_id: "WkPutXGdqg" })),
 }));
 
 type MessageStoreCall = {
@@ -20,7 +20,7 @@ type MessageStoreCall = {
   sessionId: string;
   process_messages: boolean;
   user_id?: string;
-  external_user_id?: string;
+  user_id?: string;
   metadata: {
     conversationId: string;
     createdAt: string;
@@ -31,7 +31,7 @@ type MessageStoreCall = {
 
 vi.mock("../src/gateway/utils/memoryScopeResolver.js", () => ({
   buildPaprMemoryWriteScope: vi.fn().mockResolvedValue({
-    external_user_id: "WkPutXGdqg",
+    user_id: "WkPutXGdqg",
     namespace_id: undefined,
     policy: undefined,
   }),
@@ -98,7 +98,7 @@ describe("PAPR Memory Metadata Enhancement", () => {
     mockStore.mockClear();
   });
 
-  it("should send top-level external_user_id when papr user is available", async () => {
+  it("should send top-level user_id when papr user is available", async () => {
     const message: StoredMessage = {
       id: "msg-user-id",
       chat_id: "chat-123",
@@ -112,7 +112,7 @@ describe("PAPR Memory Metadata Enhancement", () => {
 
     expect(mockStore).toHaveBeenCalledWith(
       expect.objectContaining({
-        external_user_id: "WkPutXGdqg",
+        user_id: "WkPutXGdqg",
       }),
     );
   });


### PR DESCRIPTION
> **Stacked on #115** (`feat/telemetry-attribution-and-scheduler-storm`). Review that first; this PR's diff is the second commit only.

## Problem

Paprwork users **are** real Papr accounts, but we send their `_User.objectId` as `external_user_id`. The memory server treats that field as an opaque developer-scoped string, finds no `DeveloperUser` mapping, and **mints an anonymous shadow user** (`anon_xxxxx`).

### Observed in production — Revenue Reimagined (org `YqiHlOHGqg`)

`DeveloperUser` filtered to Dale's developer pointer: **12 rows for 5 distinct `external_id`s**.

| `external_id` | Shadows | Created |
|---|---|---|
| `l6UFSw9m4T` (Dale) | **6** | all within `16:49:04.625` → `.845` |
| `WkPutXGdqg` (Amir) | 2 | 579ms apart |
| `OkMVA5donv` | 2 | 438ms apart |
| `z00MIBFsQy` | 1 | — |
| `user_001` | 1 | genuine SDK end user |

**Dale has six identities, all created inside 220ms.** That's a check-then-create race (`user_utils.py:3838`) with no unique constraint on `(developer, external_id, namespace)` — not normal usage.

### Why teammates get pulled in

The API key is scoped to **org + namespace, never to a person** (`paprApiKey.ts:8` — `sk-org-{org}-namespace-{ns}-`). Every org member authenticates with the owner's key, so the server derives `developer_id` = Dale for everyone. Dale became the "developer" for people he merely invited.

That model is correct for SDK developers (Joe Coffee counting his customers). It is wrong here — Amir is not Dale's customer, and org/namespace ownership is already recorded in Parse.

### Downstream damage

- **Analytics:** 5 humans → 12 user records
- **Ownership decoupled from visibility:** users reach their own memories via the namespace ACL OR-branch, not ownership
- **Feedback 404s:** reads authorize via a broad OR; feedback authorizes via strict equality on `developer_id` (`feedback_routes.py:1027`). Never matches.

## Fix

Send `user_id` instead. The server already has this path (`user_utils.py:3730`) and returns before any shadow lookup.

### The ACL prefix had to move too

`shared_types.py:2504` maps principals to granular fields:

| Prefix | Field | In search filter? |
|---|---|---|
| `user:` | `user_read_access` | ✅ yes |
| `external_user:` | `external_user_read_access` | ❌ **commented out** (`memory_graph.py:7759`) |

Sending `user_id` while keeping `external_user:` principals would write ownership and permissions to two different places. Both move together.

`toExternalUserPrincipal` is **retained** for third-party SDK end users — that use of `external_user_id` is correct and unchanged.

## Security

The org+namespace key means a caller-supplied `user_id` would let any key holder write memories owned by an arbitrary Papr account. `PaprMemoryWritebackService` was the one path accepting one; it now goes through `resolveTrustedPaprUserId()`, which honours the value only if it matches the locally authenticated user.

Server-side membership validation is **deliberately deferred** — it needs caching to avoid adding latency to every add/search.

## Not changed

- **No memory-server changes**
- Org / namespace / workspace ACLs untouched
- `external_user_id` still fully supported server-side for SDK developers
- Rate limits still bill to `developer_id` — intended org-billing behaviour

## Test

| | Failed | Passed |
|---|---|---|
| Baseline | 125 | 2496 |
| This branch | 125 | 2496 |

**No delta.** `tsc --noEmit` clean apart from two pre-existing lib-target errors in `CloudApp*` files (untouched — verified via `git diff`).

Those 125 baseline failures are an unrelated harness issue (`"Tests must not write to the developer's live workspace"`), pre-existing.

## ⚠️ Sequencing — do not merge standalone

Run the shadow→real migration **before** this ships. Otherwise new memories land under real IDs while old ones stay on shadows, and users see a split corpus in between.

Migration lives in the memory repo (`development`). Additive-only, handles the 6→1 fan-in, skips genuine SDK end users. **Not yet run against live data.**

## Follow-ups (separate PRs)

1. **Memory server:** unique constraint + atomic get-or-create on `(developer, external_id, namespace)` — SDK developers still hit this race
2. **Memory server:** cached membership validation for `user_id`
3. **Investigate:** whether the race has fragmented any user's corpus across shadows (some memories under shadow A, others under B)
