### PR TITLE
Measure agent and job work per mini-app (runs, hours, local + cloud)

### DIFF
--- a/src/core/telemetry/events.ts
+++ b/src/core/telemetry/events.ts
@@ -3,6 +3,11 @@
  * Central registry of all tracked events with their properties
  */
 
+import type {
+  JobAgentKind,
+  JobRunTelemetryDimensions,
+} from "./jobRunTelemetry.js";
+
 // ============================================
 // Event Names (Centralized)
 // ============================================
@@ -235,29 +240,46 @@ export interface BrowserActionProperties extends BaseEventProperties {
 
 export interface JobCreatedProperties extends BaseEventProperties {
   job_id: string;
-  job_type: "python" | "node" | "bash" | "shell" | "agent" | "subagent" | "swift";
+  job_type:
+    | "python"
+    | "node"
+    | "bash"
+    | "shell"
+    | "agent"
+    | "subagent"
+    | "swift";
   has_schedule: boolean;
   has_dependencies: boolean;
   schedule_type?: "interval" | "cron" | "at_time";
+  /**
+   * Owning mini-app. Without this, "agents per app" — the shape of a Paprwork
+   * app like My Papr Books — cannot be computed from create events.
+   */
+  app_id?: string;
+  app_count?: number;
+  is_standalone?: boolean;
+  agent_kind?: JobAgentKind;
+  is_agent?: boolean;
 }
 
-export interface JobCompletedProperties extends BaseEventProperties {
-  job_id: string;
-  job_type: string;
-  duration_ms: number;
+export interface JobCompletedProperties
+  extends BaseEventProperties,
+    JobRunTelemetryDimensions {
   exit_code?: number;
-  had_retry: boolean;
+  had_retry?: boolean;
   output_size_bytes?: number;
-  scheduled: boolean;
+  attempts?: number;
 }
 
-export interface JobFailedProperties extends BaseEventProperties {
-  job_id: string;
-  job_type: string;
+export interface JobFailedProperties
+  extends BaseEventProperties,
+    JobRunTelemetryDimensions {
   error_type: string;
   error_message?: string;
-  attempt_number: number;
-  max_attempts: number;
+  exit_code?: number;
+  attempts?: number;
+  retry_class?: string;
+  failure_hint?: string;
 }
 
 /**
@@ -379,7 +401,9 @@ export interface SyncV3MetricProperties extends BaseEventProperties {
 // Type Guards
 // ============================================
 
-export function isValidEventName(name: string): name is keyof typeof AmplitudeEvents {
+export function isValidEventName(
+  name: string,
+): name is keyof typeof AmplitudeEvents {
   return Object.values(AmplitudeEvents).includes(name as any);
 }
 

--- a/src/core/telemetry/index.ts
+++ b/src/core/telemetry/index.ts
@@ -19,3 +19,11 @@ export type {
   TelemetryClientDeps,
   TelemetryClientOptions,
 } from "./TelemetryClient.js";
+export { buildJobRunDimensions, isAgentJobType } from "./jobRunTelemetry.js";
+export type {
+  JobAgentKind,
+  JobRunSurface,
+  JobRunTelemetryDimensions,
+  JobRunTelemetryInput,
+  JobRunTrigger,
+} from "./jobRunTelemetry.js";

--- a/src/core/telemetry/jobRunTelemetry.ts
+++ b/src/core/telemetry/jobRunTelemetry.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared shape for "how much work did agents and jobs actually do".
+ *
+ * The unit of value in Paprwork is a mini-app that runs itself — "My Papr Books"
+ * is one app, a handful of agents, some jobs, and a stream of runs. Counting
+ * runs alone understates that: a 40-minute accounting agent and a 200ms cron
+ * ping are both "1 run". Duration is what separates them.
+ *
+ * Local and cloud runs are emitted from different services (JobsService vs
+ * CloudJobRunService). Both build dimensions here so a run is attributed the
+ * same way regardless of where it executed — otherwise `sum(duration_hours)`
+ * silently means "local only".
+ */
+
+/** Where the run actually executed. */
+export type JobRunSurface = "local" | "cloud";
+
+/** What started this run. Separates human intent from automation volume. */
+export type JobRunTrigger = "manual" | "scheduled" | "dependency";
+
+/**
+ * Agent jobs do LLM reasoning work; script jobs are deterministic pipelines.
+ * Both are "work", but only agent hours represent autonomous labour, which is
+ * the number that makes "agents doing work for you" measurable.
+ */
+export type JobAgentKind = "agent" | "script";
+
+export interface JobRunTelemetryInput {
+  jobId: string;
+  jobType: string;
+  /** Mini-app UUIDs this job belongs to. First one is the attribution target. */
+  appIds?: string[];
+  durationMs: number;
+  surface: JobRunSurface;
+  trigger?: JobRunTrigger;
+  /** Present on subagent jobs — indicates a named custom agent profile. */
+  subAgentId?: string;
+  scheduled?: boolean;
+}
+
+export interface JobRunTelemetryDimensions {
+  job_id: string;
+  job_type: string;
+  /** Primary owning mini-app. Absent for standalone jobs. */
+  app_id?: string;
+  /** Jobs may serve several apps; count keeps that visible without leaking ids. */
+  app_count: number;
+  is_standalone: boolean;
+  agent_kind: JobAgentKind;
+  is_agent: boolean;
+  has_custom_agent: boolean;
+  surface: JobRunSurface;
+  trigger: JobRunTrigger;
+  duration_ms: number;
+  /**
+   * Pre-divided so Amplitude charts can sum hours directly. Doing this in the
+   * chart requires a formula on every panel; doing it here makes
+   * `sum(duration_hours)` the whole query.
+   */
+  duration_hours: number;
+}
+
+/** Sentinel used by create_job for jobs deliberately not tied to any app. */
+const STANDALONE = "__standalone__";
+
+function realAppIds(appIds?: string[]): string[] {
+  return (appIds ?? []).filter((id) => id && id !== STANDALONE);
+}
+
+export function isAgentJobType(jobType: string): boolean {
+  return jobType === "agent" || jobType === "subagent";
+}
+
+/**
+ * Round to 4dp (~0.36s). Amplitude sums floats fine, but unbounded precision
+ * makes event payloads noisy and property values harder to eyeball in the UI.
+ */
+function toHours(durationMs: number): number {
+  if (!Number.isFinite(durationMs) || durationMs <= 0) return 0;
+  return Math.round((durationMs / 3_600_000) * 10_000) / 10_000;
+}
+
+export function buildJobRunDimensions(
+  input: JobRunTelemetryInput,
+): JobRunTelemetryDimensions {
+  const apps = realAppIds(input.appIds);
+  const isAgent = isAgentJobType(input.jobType);
+  const durationMs =
+    Number.isFinite(input.durationMs) && input.durationMs > 0
+      ? Math.round(input.durationMs)
+      : 0;
+
+  const trigger: JobRunTrigger =
+    input.trigger ?? (input.scheduled ? "scheduled" : "manual");
+
+  return {
+    job_id: input.jobId,
+    job_type: input.jobType,
+    app_id: apps[0],
+    app_count: apps.length,
+    is_standalone: apps.length === 0,
+    agent_kind: isAgent ? "agent" : "script",
+    is_agent: isAgent,
+    has_custom_agent: isAgent && !!input.subAgentId,
+    surface: input.surface,
+    trigger,
+    duration_ms: durationMs,
+    duration_hours: toHours(durationMs),
+  };
+}

--- a/src/core/tools/paprDocumentMemory.ts
+++ b/src/core/tools/paprDocumentMemory.ts
@@ -215,8 +215,8 @@ export const uploadDocumentToMemoryTool = createTool({
 
       const response = await client.document.upload({
         file: createReadStream(resolvedPath),
-        ...(memoryScope.external_user_id
-          ? { external_user_id: memoryScope.external_user_id }
+        ...(memoryScope.user_id
+          ? { user_id: memoryScope.user_id }
           : {}),
         ...(memoryScope.namespace_id
           ? { namespace_id: memoryScope.namespace_id }

--- a/src/core/tools/paprMemory.ts
+++ b/src/core/tools/paprMemory.ts
@@ -27,15 +27,15 @@ const memoryReadAclToolFields = {
     .array(z.string().min(1))
     .optional()
     .describe(
-      "Optional read ACL principals. Use external_user:{Parse objectId}, namespace:{namespaceId}, or organization:{orgId}. " +
+      "Optional read ACL principals. Use user:{Parse objectId}, namespace:{namespaceId}, or organization:{orgId}. " +
         "When set, overrides the chat Team/Org scope for read access. Writer always keeps write ACL.",
     ),
   shareWithUserIds: z
     .array(z.string().min(1))
     .optional()
     .describe(
-      "Parse objectIds (same as external_user_id / list_namespace_users.externalUserId) to grant read access. " +
-        "Converted to external_user:{id} ACL principals automatically.",
+      "Parse objectIds (same as list_namespace_users.externalUserId) to grant read access. " +
+        "Converted to user:{id} ACL principals automatically.",
     ),
   shareWithTeam: z
     .boolean()
@@ -54,7 +54,7 @@ const memoryReadAclToolFields = {
 const addMemorySchema = z
   .object({
     content: z.string().min(1),
-    // Writer resolved at runtime via getPaprUserId() — passed as external_user_id (Parse objectId).
+    // Writer resolved at runtime via getPaprUserId() — passed as user_id (Parse objectId).
     role: z.enum(["user", "assistant"]).optional(),
     category: z
       .enum([
@@ -527,7 +527,7 @@ export const addAgentMemoryTool = createTool({
   description:
     "Store a structured memory item in PAPR memory. IMPORTANT: When using category='context', you MUST provide role ('user' or 'assistant'). " +
     "For attendee-only sharing, call list_namespace_users first, match emails to externalUserId, then pass shareWithUserIds or readAcl with external_user:{objectId} principals. " +
-    "Use external_user_id semantics (Parse objectId) — NOT Papr internal user_id.",
+    "Uses the acting Papr user_id (Parse objectId) — never a caller-supplied id.",
   inputSchema: addMemorySchema,
   execute: async (args) => {
     try {
@@ -565,8 +565,8 @@ export const addAgentMemoryTool = createTool({
 
       const response = await client.memory.add({
         content: args.content,
-        ...(memoryScope.external_user_id
-          ? { external_user_id: memoryScope.external_user_id }
+        ...(memoryScope.user_id
+          ? { user_id: memoryScope.user_id }
           : {}),
         ...(memoryScope.namespace_id
           ? { namespace_id: memoryScope.namespace_id }
@@ -598,7 +598,7 @@ export const listNamespaceUsersTool = createTool({
   id: "list_namespace_users",
   description:
     "List Papr users in the active workspace/namespace team. Returns Parse objectIds as externalUserId " +
-    "and ready-to-use memoryReadPrincipal values (external_user:{objectId}) for add_agent_memory and create_entities ACL. " +
+    "and ready-to-use memoryReadPrincipal values (user:{objectId}) for add_agent_memory and create_entities ACL. " +
     "Call before sharing memories with specific attendees.",
   inputSchema: listNamespaceUsersSchema,
   execute: async (args) => {
@@ -622,8 +622,8 @@ export const listNamespaceUsersTool = createTool({
           ...result,
           members,
           idGuidance: {
-            bodyField: "external_user_id",
-            aclPrefix: "external_user:",
+            bodyField: "user_id",
+            aclPrefix: "user:",
             examplePrincipal: members[0]?.memoryReadPrincipal,
           },
         },
@@ -726,8 +726,8 @@ export const searchAgentMemoryTool = createTool({
       const { data: response, response: httpResponse } = await client.memory
         .search({
           query: args.query!,
-          ...(memorySearchScope.external_user_id
-            ? { external_user_id: memorySearchScope.external_user_id }
+          ...(memorySearchScope.user_id
+            ? { user_id: memorySearchScope.user_id }
             : {}),
           ...(memorySearchScope.search_acl
             ? { search_acl: memorySearchScope.search_acl }
@@ -1416,8 +1416,8 @@ export const addAgentMemoryBatchTool = createTool({
           ? { skip_background_processing: args.skipBackgroundProcessing }
           : {}),
         ...(args.batchSize !== undefined ? { batch_size: args.batchSize } : {}),
-        ...(memoryScope.external_user_id
-          ? { external_user_id: memoryScope.external_user_id }
+        ...(memoryScope.user_id
+          ? { user_id: memoryScope.user_id }
           : {}),
         ...(memoryScope.namespace_id
           ? { namespace_id: memoryScope.namespace_id }
@@ -1625,8 +1625,8 @@ export const createEntitiesAndRelationshipsTool = createTool({
 
       const response = await client.memory.add({
         content: args.content,
-        ...(memoryScope.external_user_id
-          ? { external_user_id: memoryScope.external_user_id }
+        ...(memoryScope.user_id
+          ? { user_id: memoryScope.user_id }
           : {}),
         ...(memoryScope.namespace_id
           ? { namespace_id: memoryScope.namespace_id }

--- a/src/core/utils/memoryAcl.ts
+++ b/src/core/utils/memoryAcl.ts
@@ -1,29 +1,58 @@
 /**
  * Papr Memory ACL helpers.
  *
- * Use Parse _User.objectId as external_user_id on memory.add bodies.
- * ACL principals use the external_user:{objectId} prefix — NOT bare user ids
- * and NOT Papr's internal user_id field.
+ * Paprwork users ARE real Papr accounts, so we send Parse _User.objectId as
+ * `user_id` (not `external_user_id`). Sending it as external_user_id makes the
+ * memory server mint an anonymous shadow DeveloperUser, which splits one human
+ * into several identities and breaks feedback authorization.
+ *
+ * ACL principals therefore use the `user:{objectId}` prefix, which maps to
+ * user_read_access / user_write_access — the fields the search filter actually
+ * evaluates. `external_user:` maps to external_user_read_access, which is NOT
+ * part of the ACL OR-branch (that filter is commented out server-side).
+ *
+ * `external_user_id` remains supported by the memory server for third-party SDK
+ * developers whose end users have no Papr account. It is not used by Paprwork.
  */
 
 import type { MemoryAddPolicy } from "@papr/memory/resources/shared.js";
 
+export const USER_PRINCIPAL_PREFIX = "user:" as const;
 export const EXTERNAL_USER_PRINCIPAL_PREFIX = "external_user:" as const;
 export const NAMESPACE_PRINCIPAL_PREFIX = "namespace:" as const;
 export const ORGANIZATION_PRINCIPAL_PREFIX = "organization:" as const;
 
 const PRINCIPAL_PATTERN =
-  /^(external_user|namespace|organization):[A-Za-z0-9_-]+$/;
+  /^(user|external_user|namespace|organization):[A-Za-z0-9_-]+$/;
 
-/** Strip `external_user:` prefix if the agent pasted a full principal. */
+/** Strip a `user:` / `external_user:` prefix if a full principal was pasted. */
 export function normalizeExternalUserId(value: string): string {
   const trimmed = value.trim();
   if (trimmed.startsWith(EXTERNAL_USER_PRINCIPAL_PREFIX)) {
     return trimmed.slice(EXTERNAL_USER_PRINCIPAL_PREFIX.length).trim();
   }
+  if (trimmed.startsWith(USER_PRINCIPAL_PREFIX)) {
+    return trimmed.slice(USER_PRINCIPAL_PREFIX.length).trim();
+  }
   return trimmed;
 }
 
+/**
+ * Build a `user:{objectId}` principal for a real Papr account.
+ * Accepts a bare objectId or an already-prefixed principal.
+ */
+export function toUserPrincipal(userId: string): string {
+  const id = normalizeExternalUserId(userId);
+  if (!id) {
+    throw new Error("user id must be non-empty");
+  }
+  return `${USER_PRINCIPAL_PREFIX}${id}`;
+}
+
+/**
+ * Build an `external_user:{id}` principal.
+ * Retained for third-party SDK end users; Paprwork uses toUserPrincipal.
+ */
 export function toExternalUserPrincipal(externalUserId: string): string {
   const id = normalizeExternalUserId(externalUserId);
   if (!id) {
@@ -62,13 +91,13 @@ export function normalizeReadPrincipal(value: string): string {
     return trimmed;
   }
 
-  // Convenience: bare Parse objectId → external_user principal
+  // Convenience: bare Parse objectId → user principal (real Papr account)
   if (!trimmed.includes(":")) {
-    return toExternalUserPrincipal(trimmed);
+    return toUserPrincipal(trimmed);
   }
 
   throw new Error(
-    `Invalid read ACL principal "${trimmed}". Use external_user:{objectId}, namespace:{id}, or organization:{id}.`,
+    `Invalid read ACL principal "${trimmed}". Use user:{objectId}, namespace:{id}, or organization:{id}.`,
   );
 }
 
@@ -101,7 +130,7 @@ export function buildExplicitReadPrincipals(
   const read: string[] = [];
 
   for (const userId of input.shareWithUserIds ?? []) {
-    read.push(toExternalUserPrincipal(userId));
+    read.push(toUserPrincipal(userId));
   }
 
   for (const principal of input.readAcl ?? []) {
@@ -121,14 +150,16 @@ export function buildExplicitReadPrincipals(
   return dedupeReadPrincipals(read);
 }
 
-export function buildWriterWriteAcl(writerExternalUserId: string): string[] {
-  return [toExternalUserPrincipal(writerExternalUserId)];
+/** Writer keeps write access via their real Papr account principal. */
+export function buildWriterWriteAcl(writerUserId: string): string[] {
+  return [toUserPrincipal(writerUserId)];
 }
 
 /** Apply explicit read ACL, always keeping the writer on write ACL. */
 export function applyExplicitReadAclToPolicy(
   basePolicy: MemoryAddPolicy | undefined,
   input: {
+    /** Real Papr _User.objectId of the acting user. */
     writerExternalUserId: string;
     explicitRead: ExplicitMemoryReadAclInput;
   },

--- a/src/core/utils/memoryScope.ts
+++ b/src/core/utils/memoryScope.ts
@@ -16,13 +16,19 @@ export interface MemoryScopeContext {
 }
 
 export interface MemoryScopeFields {
-  external_user_id?: string;
+  /**
+   * Real Papr _User.objectId of the acting user.
+   * Sent as `user_id` — NOT `external_user_id`, which would make the memory
+   * server mint an anonymous shadow DeveloperUser for a real Papr account.
+   */
+  user_id?: string;
   namespace_id?: string;
   policy?: MemoryAddPolicy;
 }
 
 export interface MemorySearchScopeFields {
-  external_user_id?: string;
+  /** Real Papr _User.objectId of the acting user. */
+  user_id?: string;
   search_acl?: { read: string[]; write?: string[] };
 }
 
@@ -35,7 +41,7 @@ export function resolveMemoryAudience(input: {
 }
 
 function userWriteAcl(userId: string): string[] {
-  return [`external_user:${userId}`];
+  return [`user:${userId}`];
 }
 
 export function buildMemoryScopeFields(
@@ -52,7 +58,7 @@ export function buildMemoryScopeFields(
 
   if (audience === "namespace" && namespaceId) {
     return {
-      external_user_id: userId,
+      user_id: userId,
       namespace_id: namespaceId,
       policy: {
         acl: {
@@ -65,7 +71,7 @@ export function buildMemoryScopeFields(
 
   if (audience === "org" && organizationId) {
     return {
-      external_user_id: userId,
+      user_id: userId,
       namespace_id: namespaceId,
       policy: {
         acl: {
@@ -76,7 +82,7 @@ export function buildMemoryScopeFields(
     };
   }
 
-  return { external_user_id: userId };
+  return { user_id: userId };
 }
 
 export function buildMemorySearchScopeFields(
@@ -89,19 +95,19 @@ export function buildMemorySearchScopeFields(
 
   if (audience === "namespace" && namespaceId) {
     return {
-      ...(userId ? { external_user_id: userId } : {}),
+      ...(userId ? { user_id: userId } : {}),
       search_acl: { read: [`namespace:${namespaceId}`] },
     };
   }
 
   if (audience === "org" && organizationId) {
     return {
-      ...(userId ? { external_user_id: userId } : {}),
+      ...(userId ? { user_id: userId } : {}),
       search_acl: { read: [`organization:${organizationId}`] },
     };
   }
 
-  return userId ? { external_user_id: userId } : {};
+  return userId ? { user_id: userId } : {};
 }
 
 export function mergeMemoryAddPolicy(

--- a/src/gateway/services/AttachmentMemoryUpload.ts
+++ b/src/gateway/services/AttachmentMemoryUpload.ts
@@ -63,8 +63,8 @@ export async function uploadAttachmentToMemory(
 
   const response = await client.document.upload({
     file: createReadStream(resolvedPath),
-    ...(memoryScope.external_user_id
-      ? { external_user_id: memoryScope.external_user_id }
+    ...(memoryScope.user_id
+      ? { user_id: memoryScope.user_id }
       : {}),
     ...(memoryScope.namespace_id ? { namespace_id: memoryScope.namespace_id } : {}),
     ...(memoryScope.policy

--- a/src/gateway/services/CloudJobRunService.ts
+++ b/src/gateway/services/CloudJobRunService.ts
@@ -10,6 +10,8 @@ import { getCloudSyncService } from "./CloudSyncService.js";
 import type { JobRecord } from "./jobs/types.js";
 import type { JobsService } from "./JobsService.js";
 import { CLOUD_AGENT_JOB_TIMEOUT_MS } from "../../core/constants/cloudAgentLimits.js";
+import { buildJobRunDimensions } from "../../core/telemetry/jobRunTelemetry.js";
+import { getGatewayTelemetry } from "./gatewayTelemetry.js";
 
 export type JobRunRuntime = "local" | "cloud";
 
@@ -49,6 +51,42 @@ async function appendCloudRunLog(
   const body = [payload.stdout, payload.stderr].filter(Boolean).join("\n");
   const footer = `\nexitCode=${payload.exitCode} status=${payload.status}\n`;
   await fs.appendFile(logPath, `${header}${body}${footer}`, "utf8");
+}
+
+/**
+ * Cloud runs previously emitted nothing, so total agent hours silently meant
+ * "local only". Same event names and dimension builder as the local path, with
+ * surface=cloud as the only difference — so charts can sum both or split them.
+ */
+function emitCloudRunTelemetry(
+  job: JobRecord,
+  payload: CloudJobRunApiResponse,
+  durationMs: number,
+): void {
+  const succeeded = payload.exitCode === 0;
+  const dimensions = buildJobRunDimensions({
+    jobId: job.id,
+    jobType: job.type,
+    appIds: job.appIds,
+    durationMs,
+    surface: "cloud",
+    // Reached only via the explicit run-in-cloud action; scheduled cloud runs
+    // report through applyCloudRunPatch instead.
+    trigger: "manual",
+    subAgentId: job.subAgentId,
+  });
+
+  getGatewayTelemetry().trackFireAndForget(
+    succeeded ? "paprwork_job_completed" : "paprwork_job_failed",
+    succeeded
+      ? { ...dimensions, exit_code: payload.exitCode, attempts: 1 }
+      : {
+          ...dimensions,
+          exit_code: payload.exitCode,
+          error_type: `exit_${payload.exitCode}`,
+          attempts: 1,
+        },
+  );
 }
 
 async function syncAfterCloudRun(
@@ -97,6 +135,9 @@ export async function runJobInCloud(
   }
 
   const timeoutMs = cloudRunTimeoutMs(job);
+  // Measured around the request only. Includes cloud queue + execution, which
+  // is the wall-clock time the user actually waited for the agent's work.
+  const startedAt = Date.now();
   const res = await cloudApiFetch("/v1/cloud/runtime/job-run", {
     method: "POST",
     body: {
@@ -117,6 +158,7 @@ export async function runJobInCloud(
   const payload = (await res.json()) as CloudJobRunApiResponse;
   await appendCloudRunLog(jobId, payload);
   await syncAfterCloudRun(jobsService, jobId, payload);
+  emitCloudRunTelemetry(job, payload, Date.now() - startedAt);
 
   const updated = await jobsService.getJob(jobId);
   if (!updated) {

--- a/src/gateway/services/JobsService.ts
+++ b/src/gateway/services/JobsService.ts
@@ -18,6 +18,11 @@ import { AgentJobExecutor } from "./jobs/executors/AgentJobExecutor.js";
 import type { IJobExecutor } from "./jobs/executors/IJobExecutor.js";
 import { sanitizeError } from "../../core/tools/security.js";
 import { getGatewayTelemetry } from "./gatewayTelemetry.js";
+import {
+  buildJobRunDimensions,
+  isAgentJobType,
+} from "../../core/telemetry/jobRunTelemetry.js";
+import type { JobRunTrigger } from "../../core/telemetry/jobRunTelemetry.js";
 import { getJobRunHistory } from "./jobs/JobRunHistory.js";
 import {
   getPaprAppsRoot,
@@ -1431,6 +1436,18 @@ export class JobsService {
       has_schedule: !!input.schedule?.enabled,
       has_dependencies: (input.dependsOn ?? []).length > 0,
       schedule_type: input.schedule?.cron ? "cron" : input.schedule?.intervalMs ? "interval" : undefined,
+      // App attribution at create time answers "how many agents does this app
+      // have" without needing a run to have happened yet.
+      ...(() => {
+        const owned = appIds.filter((id) => id !== STANDALONE_APP_ID);
+        return {
+          app_id: owned[0],
+          app_count: owned.length,
+          is_standalone: owned.length === 0,
+        };
+      })(),
+      agent_kind: isAgentJobType(input.type) ? "agent" : "script",
+      is_agent: isAgentJobType(input.type),
     });
 
     return job;
@@ -2227,6 +2244,15 @@ export class JobsService {
     if (architectureErrors) {
       throw new Error(`Job architecture validation failed before run:\n${architectureErrors}`);
     }
+    // Read before stack.add: a non-empty stack means this run was pulled in by
+    // ensureDependencyChain rather than started directly. Separating chained
+    // runs from human ones keeps pipeline fan-out from reading as user demand.
+    const runTrigger: JobRunTrigger =
+      stack.size > 0
+        ? "dependency"
+        : scheduledDueAt && scheduledDueAt.length > 0
+          ? "scheduled"
+          : "manual";
     stack.add(jobId);
 
     try {
@@ -2369,10 +2395,18 @@ export class JobsService {
           }
 
           getGatewayTelemetry().trackFireAndForget("paprwork_job_completed", {
-            job_id: job.id,
-            job_type: job.type,
-            duration_ms: Math.round(performance.now() - attemptStart),
+            ...buildJobRunDimensions({
+              jobId: job.id,
+              jobType: job.type,
+              appIds: job.appIds,
+              durationMs: performance.now() - attemptStart,
+              surface: "local",
+              trigger: runTrigger,
+              subAgentId: job.subAgentId,
+            }),
+            exit_code: result.exitCode,
             attempts: attempt,
+            had_retry: attempt > 1,
           });
 
           // Sync structured job DB rows to Papr Memory (preferred over log writeback)
@@ -2482,10 +2516,19 @@ export class JobsService {
             result.errorMessage ?? `Exit code ${result.exitCode}`,
           );
           getGatewayTelemetry().trackFireAndForget("paprwork_job_failed", {
-            job_id: job.id,
+            ...buildJobRunDimensions({
+              jobId: job.id,
+              jobType: job.type,
+              appIds: job.appIds,
+              // Failed work still consumed time and compute. Excluding it would
+              // make an agent that burns 20 minutes then errors look free.
+              durationMs: performance.now() - attemptStart,
+              surface: "local",
+              trigger: runTrigger,
+              subAgentId: job.subAgentId,
+            }),
             job_name:
               job.name.length > 80 ? `${job.name.slice(0, 79)}…` : job.name,
-            job_type: job.type,
             exit_code: result.exitCode,
             error_type: `exit_${result.exitCode}`,
             attempts: maxAttempts,

--- a/src/gateway/services/PaprMemoryWritebackService.ts
+++ b/src/gateway/services/PaprMemoryWritebackService.ts
@@ -6,6 +6,7 @@ import Papr from "@papr/memory";
 import { handlePaprToolError } from "../../core/tools/paprClient.js";
 import { getApiKey } from "../utils/keyResolver.js";
 import { paprMemoryScopeSpread } from "../utils/memoryScopeResolver.js";
+import { resolveTrustedPaprUserId } from "../utils/paprUserId.js";
 import type { JobMemoryPolicy } from "./jobs/types.js";
 
 export interface MemoryWritebackInput {
@@ -46,10 +47,15 @@ export async function writeRunMemory(
     const memoryScope = await paprMemoryScopeSpread({
       chatId: input.chatId,
     });
+    // input.userId is caller-supplied. The Papr API key is scoped to
+    // org + namespace (not to a person), so trusting it verbatim would let any
+    // key holder write memories owned by an arbitrary Papr account. Accept it
+    // only when it matches the locally authenticated user.
+    const trustedUserId = resolveTrustedPaprUserId(input.userId);
     await client.memory.add({
       content: compactContent(input),
-      ...(input.userId && !memoryScope.external_user_id
-        ? { external_user_id: input.userId }
+      ...(trustedUserId && !memoryScope.user_id
+        ? { user_id: trustedUserId }
         : memoryScope),
       metadata: {
         category: "learning",

--- a/src/gateway/services/namespaceUsersService.ts
+++ b/src/gateway/services/namespaceUsersService.ts
@@ -7,7 +7,7 @@ import {
   type WorkspaceMember,
 } from "../../core/utils/paprWorkspaceTeam.js";
 import {
-  toExternalUserPrincipal,
+  toUserPrincipal,
   toNamespacePrincipal,
   toOrganizationPrincipal,
 } from "../../core/utils/memoryAcl.js";
@@ -48,7 +48,9 @@ function mapMemberForAgent(member: WorkspaceMember): NamespaceUserForAgent {
     email: member.user.email,
     displayName: member.user.displayName,
     role: member.user.role,
-    memoryReadPrincipal: toExternalUserPrincipal(externalUserId),
+    // Namespace members are real Papr accounts, so share via user: principals
+    // (maps to user_read_access, which the search ACL filter evaluates).
+    memoryReadPrincipal: toUserPrincipal(externalUserId),
   };
 }
 
@@ -84,7 +86,7 @@ export async function listNamespaceUsersForAgent(): Promise<ListNamespaceUsersRe
     organizationId,
     recorderExternalUserId,
     aclHints: {
-      externalUser: "external_user:{Parse objectId}",
+      externalUser: "user:{Parse objectId}",
       ...(namespaceId
         ? { namespace: toNamespacePrincipal(namespaceId) }
         : {}),

--- a/src/gateway/services/storage/PaprMemoryProvider.ts
+++ b/src/gateway/services/storage/PaprMemoryProvider.ts
@@ -89,7 +89,7 @@ export class PaprMemoryProvider implements IStorageProvider {
       const storeBody: PaprMessageStoreBody = buildPaprSyncStoreBody({
         chatId,
         message,
-        externalUserId: memoryScope.external_user_id,
+        userId: memoryScope.user_id,
         namespaceId: memoryScope.namespace_id,
         policy: memoryScope.policy,
       });

--- a/src/gateway/services/storage/paprSyncPayload.ts
+++ b/src/gateway/services/storage/paprSyncPayload.ts
@@ -36,7 +36,8 @@ export interface PaprMessageStoreBody {
     role: "user" | "assistant";
     customMetadata: PaprSyncCustomMetadata;
   };
-  external_user_id?: string;
+  /** Real Papr _User.objectId — see memoryAcl.ts for why this is not external_user_id. */
+  user_id?: string;
   namespace_id?: string;
   policy?: MemoryAddPolicy;
 }
@@ -266,7 +267,7 @@ function assembleStoreBody(
   content: string | PaprContentBlock[],
   customMetadata: PaprSyncCustomMetadata,
   scope?: {
-    externalUserId?: string;
+    userId?: string;
     namespaceId?: string;
     policy?: MemoryAddPolicy;
   },
@@ -285,8 +286,8 @@ function assembleStoreBody(
     },
   };
 
-  if (scope?.externalUserId) {
-    body.external_user_id = scope.externalUserId;
+  if (scope?.userId) {
+    body.user_id = scope.userId;
   }
   if (scope?.namespaceId) {
     body.namespace_id = scope.namespaceId;
@@ -301,7 +302,7 @@ function assembleStoreBody(
 export function buildPaprSyncStoreBody(input: {
   chatId: string;
   message: StoredMessage;
-  externalUserId?: string;
+  userId?: string;
   namespaceId?: string;
   policy?: MemoryAddPolicy;
   maxBytes?: number;
@@ -311,7 +312,7 @@ export function buildPaprSyncStoreBody(input: {
   const maxBytes = input.maxBytes ?? PAPR_SYNC_MAX_BYTES;
   const customMetadata = buildPaprSyncCustomMetadata(input.message);
   const scope = {
-    externalUserId: input.externalUserId,
+    userId: input.userId,
     namespaceId: input.namespaceId,
     policy: input.policy,
   };

--- a/src/gateway/services/wikiGraphEntitySync.ts
+++ b/src/gateway/services/wikiGraphEntitySync.ts
@@ -124,8 +124,8 @@ async function upsertGraphEntityName(input: {
 
   await input.client.memory.add({
     content: `Wiki sync: ${input.entityType} ${input.nodeId} renamed to "${input.newName}"`,
-    ...(memoryScope.external_user_id
-      ? { external_user_id: memoryScope.external_user_id }
+    ...(memoryScope.user_id
+      ? { user_id: memoryScope.user_id }
       : {}),
     ...(memoryScope.namespace_id
       ? { namespace_id: memoryScope.namespace_id }

--- a/src/gateway/services/wikiLocalEntityGraphSync.ts
+++ b/src/gateway/services/wikiLocalEntityGraphSync.ts
@@ -122,8 +122,8 @@ export async function syncLocalWikiEntityToGraph(
       ]
         .filter(Boolean)
         .join("\n"),
-      ...(memoryScope.external_user_id
-        ? { external_user_id: memoryScope.external_user_id }
+      ...(memoryScope.user_id
+        ? { user_id: memoryScope.user_id }
         : {}),
       ...(memoryScope.namespace_id
         ? { namespace_id: memoryScope.namespace_id }

--- a/src/gateway/utils/memoryScopeResolver.ts
+++ b/src/gateway/utils/memoryScopeResolver.ts
@@ -95,7 +95,7 @@ export async function buildPaprMemoryWriteScope(input?: {
   /** When set, replaces chat/settings read ACL (writer still gets write ACL). */
   explicitReadAcl?: ExplicitMemoryReadAclInput;
 }): Promise<{
-  external_user_id?: string;
+  user_id?: string;
   namespace_id?: string;
   policy?: MemoryAddPolicy;
 }> {
@@ -121,7 +121,7 @@ export async function buildPaprMemoryWriteScope(input?: {
   }
 
   return {
-    external_user_id: fields.external_user_id,
+    user_id: fields.user_id,
     namespace_id: fields.namespace_id,
     policy,
   };
@@ -131,7 +131,7 @@ export async function buildPaprMemorySearchScope(input?: {
   chatId?: string;
   explicitAudience?: MemoryAudience;
 }): Promise<{
-  external_user_id?: string;
+  user_id?: string;
   search_acl?: { read: string[]; write?: string[] };
 }> {
   const audience =
@@ -146,15 +146,13 @@ export async function paprMemoryScopeSpread(input?: {
   explicitAudience?: MemoryAudience;
   addPolicy?: MemoryAddPolicy;
 }): Promise<{
-  external_user_id?: string;
+  user_id?: string;
   namespace_id?: string;
   policy?: MemoryAddPolicy;
 }> {
   const scope = await buildPaprMemoryWriteScope(input);
   return {
-    ...(scope.external_user_id
-      ? { external_user_id: scope.external_user_id }
-      : {}),
+    ...(scope.user_id ? { user_id: scope.user_id } : {}),
     ...(scope.namespace_id ? { namespace_id: scope.namespace_id } : {}),
     ...(scope.policy ? { policy: scope.policy } : {}),
   };
@@ -165,14 +163,12 @@ export async function paprMemorySearchScopeSpread(input?: {
   chatId?: string;
   explicitAudience?: MemoryAudience;
 }): Promise<{
-  external_user_id?: string;
+  user_id?: string;
   search_acl?: { read: string[]; write?: string[] };
 }> {
   const scope = await buildPaprMemorySearchScope(input);
   return {
-    ...(scope.external_user_id
-      ? { external_user_id: scope.external_user_id }
-      : {}),
+    ...(scope.user_id ? { user_id: scope.user_id } : {}),
     ...(scope.search_acl ? { search_acl: scope.search_acl } : {}),
   };
 }
@@ -183,7 +179,7 @@ export function buildPaprMemoryWriteScopeSync(input: {
   addPolicy?: MemoryAddPolicy;
   ctx?: MemoryScopeContext;
 }): {
-  external_user_id?: string;
+  user_id?: string;
   namespace_id?: string;
   policy?: MemoryAddPolicy;
 } {
@@ -192,7 +188,7 @@ export function buildPaprMemoryWriteScopeSync(input: {
     input.ctx ?? getMemoryScopeContext(),
   );
   return {
-    external_user_id: fields.external_user_id,
+    user_id: fields.user_id,
     namespace_id: fields.namespace_id,
     policy: mergeMemoryAddPolicy(input.addPolicy, fields.policy),
   };

--- a/src/gateway/utils/paprUserId.ts
+++ b/src/gateway/utils/paprUserId.ts
@@ -8,9 +8,17 @@ let cachedUserId: string | undefined;
 let cachedAt = 0;
 
 /**
- * Parse _User.objectId from Papr login — your app's user identifier.
- * Pass as `external_user_id` on Papr Memory API calls (NOT `user_id`, which is
- * Papr's internal user record and rejects unknown IDs).
+ * Parse _User.objectId of the locally-authenticated Papr user.
+ *
+ * Pass as `user_id` on Papr Memory API calls. Paprwork users ARE real Papr
+ * accounts, so sending this as `external_user_id` makes the memory server mint
+ * an anonymous shadow DeveloperUser — splitting one human into several
+ * identities and breaking feedback authorization.
+ *
+ * This is the ONLY source of user identity for memory calls. It is read from
+ * local login state and is never caller-supplied, so a namespace API key cannot
+ * be used to write memories owned by an arbitrary Papr account.
+ *
  * Prefers gateway env (set at spawn); falls back to settings.json after login.
  */
 export function getPaprUserId(): string | undefined {
@@ -48,10 +56,41 @@ export function invalidatePaprUserIdCache(): void {
   cachedAt = 0;
 }
 
-/** Spread into Papr SDK request bodies when the logged-in user should be scoped. */
-export function paprUserScope(): { external_user_id: string } | Record<string, never> {
+/**
+ * Spread into Papr SDK request bodies to scope a call to the logged-in user.
+ *
+ * Always resolves the acting user locally — callers cannot inject an identity.
+ * Returns `{}` when not logged in, so the server falls back to the API key
+ * owner rather than writing memories under an unauthenticated id.
+ */
+export function paprUserScope(): { user_id: string } | Record<string, never> {
   const userId = getPaprUserId();
-  return userId ? { external_user_id: userId } : {};
+  return userId ? { user_id: userId } : {};
+}
+
+/**
+ * Guard for call sites that accept a user id from an argument or request body.
+ *
+ * The Papr API key is scoped to org + namespace, not to a person, so a
+ * caller-supplied id would let any holder of the key write memories owned by an
+ * arbitrary Papr account. We accept the value only when it matches the locally
+ * authenticated user; otherwise we fall back to the local identity.
+ */
+export function resolveTrustedPaprUserId(
+  candidate?: string | null,
+): string | undefined {
+  const localUserId = getPaprUserId();
+  const requested = candidate?.trim();
+
+  if (!requested || !localUserId || requested === localUserId) {
+    return localUserId;
+  }
+
+  console.warn(
+    `[paprUserId] Ignoring caller-supplied user_id "${requested}" — ` +
+      `does not match authenticated user. Using local identity instead.`,
+  );
+  return localUserId;
 }
 
 /** Caller identity for GET /api/access and verified job params on desktop. */

--- a/tests/job-run-telemetry.test.ts
+++ b/tests/job-run-telemetry.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildJobRunDimensions,
+  isAgentJobType,
+} from "../src/core/telemetry/jobRunTelemetry.js";
+
+describe("isAgentJobType", () => {
+  it("treats agent and subagent as agent work", () => {
+    expect(isAgentJobType("agent")).toBe(true);
+    expect(isAgentJobType("subagent")).toBe(true);
+  });
+
+  it("treats scripted runtimes as script work", () => {
+    for (const type of ["python", "node", "bash", "shell", "swift"]) {
+      expect(isAgentJobType(type)).toBe(false);
+    }
+  });
+});
+
+describe("buildJobRunDimensions", () => {
+  it("attributes a run to its owning mini-app", () => {
+    const d = buildJobRunDimensions({
+      jobId: "job-1",
+      jobType: "agent",
+      appIds: ["app-books"],
+      durationMs: 60_000,
+      surface: "local",
+    });
+
+    expect(d.app_id).toBe("app-books");
+    expect(d.app_count).toBe(1);
+    expect(d.is_standalone).toBe(false);
+  });
+
+  it("does not report the standalone sentinel as an app", () => {
+    const d = buildJobRunDimensions({
+      jobId: "job-1",
+      jobType: "python",
+      appIds: ["__standalone__"],
+      durationMs: 1_000,
+      surface: "local",
+    });
+
+    // A standalone job counting as app "__standalone__" would invent a
+    // phantom app in every per-app breakdown.
+    expect(d.app_id).toBeUndefined();
+    expect(d.app_count).toBe(0);
+    expect(d.is_standalone).toBe(true);
+  });
+
+  it("counts multi-app jobs while attributing to the first app", () => {
+    const d = buildJobRunDimensions({
+      jobId: "job-1",
+      jobType: "python",
+      appIds: ["app-a", "app-b", "app-c"],
+      durationMs: 1_000,
+      surface: "local",
+    });
+
+    expect(d.app_id).toBe("app-a");
+    expect(d.app_count).toBe(3);
+  });
+
+  it("converts duration to hours so charts can sum directly", () => {
+    const oneHour = buildJobRunDimensions({
+      jobId: "j",
+      jobType: "agent",
+      durationMs: 3_600_000,
+      surface: "local",
+    });
+    expect(oneHour.duration_hours).toBe(1);
+
+    const halfHour = buildJobRunDimensions({
+      jobId: "j",
+      jobType: "agent",
+      durationMs: 1_800_000,
+      surface: "local",
+    });
+    expect(halfHour.duration_hours).toBe(0.5);
+  });
+
+  it("clamps negative or non-finite durations to zero", () => {
+    // performance.now() deltas can go negative across clock adjustments;
+    // a negative hour would silently subtract from workspace totals.
+    for (const bad of [-5_000, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const d = buildJobRunDimensions({
+        jobId: "j",
+        jobType: "agent",
+        durationMs: bad,
+        surface: "local",
+      });
+      expect(d.duration_ms).toBe(0);
+      expect(d.duration_hours).toBe(0);
+    }
+  });
+
+  it("separates agent work from script work", () => {
+    const agent = buildJobRunDimensions({
+      jobId: "j",
+      jobType: "subagent",
+      durationMs: 1_000,
+      surface: "local",
+      subAgentId: "accounting-agent",
+    });
+    expect(agent.agent_kind).toBe("agent");
+    expect(agent.is_agent).toBe(true);
+    expect(agent.has_custom_agent).toBe(true);
+
+    const script = buildJobRunDimensions({
+      jobId: "j",
+      jobType: "python",
+      durationMs: 1_000,
+      surface: "local",
+    });
+    expect(script.agent_kind).toBe("script");
+    expect(script.is_agent).toBe(false);
+    expect(script.has_custom_agent).toBe(false);
+  });
+
+  it("never marks a script job as having a custom agent", () => {
+    const d = buildJobRunDimensions({
+      jobId: "j",
+      jobType: "python",
+      durationMs: 1_000,
+      surface: "local",
+      subAgentId: "leftover-id",
+    });
+    expect(d.has_custom_agent).toBe(false);
+  });
+
+  it("keeps local and cloud runs in the same shape", () => {
+    const keys = (surface: "local" | "cloud") =>
+      Object.keys(
+        buildJobRunDimensions({
+          jobId: "j",
+          jobType: "agent",
+          appIds: ["app-a"],
+          durationMs: 1_000,
+          surface,
+        }),
+      ).sort();
+
+    // Divergent shapes would make sum(duration_hours) mean different things
+    // depending on where the job happened to run.
+    expect(keys("local")).toEqual(keys("cloud"));
+  });
+
+  it("defaults trigger from the scheduled flag when not given", () => {
+    expect(
+      buildJobRunDimensions({
+        jobId: "j",
+        jobType: "python",
+        durationMs: 1,
+        surface: "local",
+        scheduled: true,
+      }).trigger,
+    ).toBe("scheduled");
+
+    expect(
+      buildJobRunDimensions({
+        jobId: "j",
+        jobType: "python",
+        durationMs: 1,
+        surface: "local",
+      }).trigger,
+    ).toBe("manual");
+  });
+
+  it("prefers an explicit trigger over the scheduled flag", () => {
+    expect(
+      buildJobRunDimensions({
+        jobId: "j",
+        jobType: "python",
+        durationMs: 1,
+        surface: "local",
+        scheduled: true,
+        trigger: "dependency",
+      }).trigger,
+    ).toBe("dependency");
+  });
+
+  it("sums agent hours per app across mixed runs", () => {
+    // Mirrors the reporting question: for one mini-app, how many hours did
+    // agents work, ignoring script jobs in the same app?
+    const runs = [
+      { jobType: "subagent", durationMs: 3_600_000 },
+      { jobType: "agent", durationMs: 1_800_000 },
+      { jobType: "python", durationMs: 7_200_000 },
+    ].map((r) =>
+      buildJobRunDimensions({
+        jobId: "j",
+        jobType: r.jobType,
+        appIds: ["app-books"],
+        durationMs: r.durationMs,
+        surface: "local",
+      }),
+    );
+
+    const agentHours = runs
+      .filter((r) => r.is_agent && r.app_id === "app-books")
+      .reduce((sum, r) => sum + r.duration_hours, 0);
+
+    expect(agentHours).toBe(1.5);
+    expect(runs.length).toBe(3);
+  });
+});

--- a/tests/memory-acl.test.ts
+++ b/tests/memory-acl.test.ts
@@ -6,27 +6,35 @@ import {
   normalizeExternalUserId,
   normalizeReadPrincipal,
   toExternalUserPrincipal,
+  toUserPrincipal,
 } from "../src/core/utils/memoryAcl.js";
 
 describe("memoryAcl", () => {
-  it("normalizes external user ids and principals", () => {
+  it("normalizes user ids and principals", () => {
     expect(normalizeExternalUserId("abc123")).toBe("abc123");
+    expect(normalizeExternalUserId("user:abc123")).toBe("abc123");
     expect(normalizeExternalUserId("external_user:abc123")).toBe("abc123");
-    expect(toExternalUserPrincipal("abc123")).toBe("external_user:abc123");
-    expect(normalizeReadPrincipal("abc123")).toBe("external_user:abc123");
+    // Paprwork users are real Papr accounts → user: principals
+    expect(toUserPrincipal("abc123")).toBe("user:abc123");
+    expect(normalizeReadPrincipal("abc123")).toBe("user:abc123");
     expect(normalizeReadPrincipal("namespace:ns-1")).toBe("namespace:ns-1");
+    // Retained for third-party SDK end users (no Papr account)
+    expect(toExternalUserPrincipal("abc123")).toBe("external_user:abc123");
+    expect(normalizeReadPrincipal("external_user:abc123")).toBe(
+      "external_user:abc123",
+    );
   });
 
   it("builds explicit read principals from user ids and ACL entries", () => {
     expect(
       buildExplicitReadPrincipals({
-        shareWithUserIds: ["user-a", "external_user:user-b"],
+        shareWithUserIds: ["user-a", "user:user-b"],
         readAcl: ["namespace:ns-abc"],
         shareWithOrganizationId: "org-xyz",
       }),
     ).toEqual([
-      "external_user:user-a",
-      "external_user:user-b",
+      "user:user-a",
+      "user:user-b",
       "namespace:ns-abc",
       "organization:org-xyz",
     ]);
@@ -54,8 +62,8 @@ describe("memoryAcl", () => {
     expect(policy).toEqual({
       transform_embedding: { mode: "auto", domain_id: "general" },
       acl: {
-        read: ["external_user:attendee-1", "namespace:ns-abc"],
-        write: ["external_user:recorder-1"],
+        read: ["user:attendee-1", "namespace:ns-abc"],
+        write: ["user:recorder-1"],
       },
     });
   });

--- a/tests/memory-scope-resolver.test.ts
+++ b/tests/memory-scope-resolver.test.ts
@@ -55,7 +55,7 @@ describe("memoryScopeResolver chat scope", () => {
   it("falls back to settings default when chat has no scope", async () => {
     const { buildPaprMemoryWriteScope } = await loadResolver();
     const scope = await buildPaprMemoryWriteScope({ chatId: "chat-no-scope" });
-    expect(scope.external_user_id).toBe("user-1");
+    expect(scope.user_id).toBe("user-1");
     expect(scope.policy?.acl?.read).toBeUndefined();
   });
 
@@ -68,8 +68,8 @@ describe("memoryScopeResolver chat scope", () => {
         shareWithUserIds: ["attendee-1"],
       },
     });
-    expect(scope.policy?.acl?.read).toEqual(["external_user:attendee-1"]);
-    expect(scope.policy?.acl?.write).toEqual(["external_user:user-1"]);
+    expect(scope.policy?.acl?.read).toEqual(["user:attendee-1"]);
+    expect(scope.policy?.acl?.write).toEqual(["user:user-1"]);
     expect(scope.policy?.acl?.read).not.toContain("namespace:ns-abc");
   });
 });

--- a/tests/memory-scope.test.ts
+++ b/tests/memory-scope.test.ts
@@ -33,12 +33,12 @@ describe("memoryScope", () => {
 
   it("buildMemoryScopeFields scopes namespace memories with ACL", () => {
     expect(buildMemoryScopeFields("namespace", ctx)).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
       namespace_id: "ns-abc",
       policy: {
         acl: {
           read: ["namespace:ns-abc"],
-          write: ["external_user:user-1", "namespace:ns-abc"],
+          write: ["user:user-1", "namespace:ns-abc"],
         },
       },
     });
@@ -46,20 +46,20 @@ describe("memoryScope", () => {
 
   it("buildMemoryScopeFields scopes org memories with ACL", () => {
     expect(buildMemoryScopeFields("org", ctx)).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
       namespace_id: "ns-abc",
       policy: {
         acl: {
           read: ["organization:org-xyz"],
-          write: ["external_user:user-1", "organization:org-xyz"],
+          write: ["user:user-1", "organization:org-xyz"],
         },
       },
     });
   });
 
-  it("buildMemoryScopeFields user scope is external_user_id only", () => {
+  it("buildMemoryScopeFields user scope is user_id only", () => {
     expect(buildMemoryScopeFields("user", ctx)).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
     });
   });
 
@@ -67,21 +67,21 @@ describe("memoryScope", () => {
     expect(
       buildMemoryScopeFields("namespace", { userId: "user-1" }),
     ).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
     });
   });
 
   it("buildMemorySearchScopeFields expands read ACL for namespace/org", () => {
     expect(buildMemorySearchScopeFields("namespace", ctx)).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
       search_acl: { read: ["namespace:ns-abc"] },
     });
     expect(buildMemorySearchScopeFields("org", ctx)).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
       search_acl: { read: ["organization:org-xyz"] },
     });
     expect(buildMemorySearchScopeFields("user", ctx)).toEqual({
-      external_user_id: "user-1",
+      user_id: "user-1",
     });
   });
 
@@ -93,7 +93,7 @@ describe("memoryScope", () => {
       {
         acl: {
           read: ["namespace:ns-abc"],
-          write: ["external_user:user-1"],
+          write: ["user:user-1"],
         },
       },
     );
@@ -101,7 +101,7 @@ describe("memoryScope", () => {
       transform_embedding: { mode: "auto", domain_id: "general" },
       acl: {
         read: ["namespace:ns-abc"],
-        write: ["external_user:user-1"],
+        write: ["user:user-1"],
       },
     });
   });

--- a/tests/papr-memory-crud-tools.test.ts
+++ b/tests/papr-memory-crud-tools.test.ts
@@ -18,7 +18,7 @@ vi.mock("../src/core/tools/paprClient.js", () => ({
 }));
 
 vi.mock("../src/gateway/utils/paprUserId.js", () => ({
-  paprUserScope: vi.fn(() => ({ external_user_id: "user-test-1" })),
+  paprUserScope: vi.fn(() => ({ user_id: "user-test-1" })),
   getPaprUserId: vi.fn(() => "user-test-1"),
   getPaprCallerIdentity: vi.fn(() => ({ userId: "user-test-1" })),
   invalidatePaprUserIdCache: vi.fn(),
@@ -34,7 +34,7 @@ vi.mock("../src/gateway/utils/workspaceContextSchema.js", () => ({
 
 vi.mock("../src/gateway/utils/memoryScopeResolver.js", () => ({
   buildPaprMemoryWriteScope: vi.fn(async (input?: { addPolicy?: unknown }) => ({
-    external_user_id: "user-test-1",
+    user_id: "user-test-1",
     namespace_id: "ns-test-1",
     policy: input?.addPolicy,
   })),
@@ -151,7 +151,7 @@ describe("papr memory CRUD + feedback tools", () => {
       expect(payload.policy).toEqual({
         graph: { mode: "auto", schema_id: "schema-workspace-context" },
       });
-      expect(payload.external_user_id).toBe("user-test-1");
+      expect(payload.user_id).toBe("user-test-1");
       expect(payload.namespace_id).toBe("ns-test-1");
 
       expect(result.requested).toBe(2);
@@ -252,7 +252,7 @@ describe("papr memory CRUD + feedback tools", () => {
       expect(payload.feedback_items).toHaveLength(2);
       expect(payload.feedback_items[0]).toMatchObject({
         search_id: "search-1",
-        external_user_id: "user-test-1",
+        user_id: "user-test-1",
         feedbackData: {
           feedbackSource: "inline",
           feedbackType: "thumbs_up",

--- a/tests/papr-memory-metadata.test.ts
+++ b/tests/papr-memory-metadata.test.ts
@@ -11,7 +11,7 @@ import type { StoredMessage } from "../src/gateway/services/storage/IStorageProv
 vi.mock("../src/gateway/utils/paprUserId.js", () => ({
   getPaprUserId: vi.fn(() => "WkPutXGdqg"),
   invalidatePaprUserIdCache: vi.fn(),
-  paprUserScope: vi.fn(() => ({ external_user_id: "WkPutXGdqg" })),
+  paprUserScope: vi.fn(() => ({ user_id: "WkPutXGdqg" })),
 }));
 
 type MessageStoreCall = {
@@ -20,7 +20,7 @@ type MessageStoreCall = {
   sessionId: string;
   process_messages: boolean;
   user_id?: string;
-  external_user_id?: string;
+  user_id?: string;
   metadata: {
     conversationId: string;
     createdAt: string;
@@ -31,7 +31,7 @@ type MessageStoreCall = {
 
 vi.mock("../src/gateway/utils/memoryScopeResolver.js", () => ({
   buildPaprMemoryWriteScope: vi.fn().mockResolvedValue({
-    external_user_id: "WkPutXGdqg",
+    user_id: "WkPutXGdqg",
     namespace_id: undefined,
     policy: undefined,
   }),
@@ -98,7 +98,7 @@ describe("PAPR Memory Metadata Enhancement", () => {
     mockStore.mockClear();
   });
 
-  it("should send top-level external_user_id when papr user is available", async () => {
+  it("should send top-level user_id when papr user is available", async () => {
     const message: StoredMessage = {
       id: "msg-user-id",
       chat_id: "chat-123",
@@ -112,7 +112,7 @@ describe("PAPR Memory Metadata Enhancement", () => {
 
     expect(mockStore).toHaveBeenCalledWith(
       expect.objectContaining({
-        external_user_id: "WkPutXGdqg",
+        user_id: "WkPutXGdqg",
       }),
     );
   });


### PR DESCRIPTION
Stacked on #115 — review that one first. Base will retarget to `master` automatically once #115 merges.

## The question this answers

A Paprwork mini-app is one app, a few agents, some jobs, and a stream of runs. "My Papr Books" has an accounting agent; the thing worth counting is how much work it does on the user's behalf.

None of that was measurable.

## What was actually broken

`paprwork_job_completed` and `paprwork_job_failed` already fired with `duration_ms`. But they were missing every dimension needed to use them:

| Gap | Consequence |
|---|---|
| No `app_id` | Runs could not be attributed to the owning mini-app — even though `JobRecord.appIds` was right there |
| **Cloud runs emitted nothing** | `runJobInCloud` logged, patched state, returned silently. Any hours total meant "local only" without saying so |
| No agent/script split | A 40-minute accounting agent and a 200ms cron ping were both "1 run" |
| No trigger source | Dependency fan-out read as user demand |

The cloud gap is the one I'd flag: it wasn't a wrong number, it was a number that looked complete and wasn't.

## Approach

One shared builder — `core/telemetry/jobRunTelemetry.ts` — used by **both** the local and cloud paths. Local and cloud emit from different services, so without a shared builder the two drift and `sum(duration_hours)` quietly means different things depending on where a job ran. A test asserts both surfaces produce identical key sets.

Dimensions on every run event:

`app_id` · `app_count` · `is_standalone` · `agent_kind` · `is_agent` · `has_custom_agent` · `surface` · `trigger` · `duration_ms` · `duration_hours`

## Judgment calls worth reviewing

**`duration_hours` is pre-divided.** Doing it in Amplitude means a formula on every panel; doing it here makes `sum(duration_hours)` the entire query.

**Failed runs report duration.** An agent that burns 20 minutes then errors is not free work. Excluding it would flatter the numbers.

**Negative/non-finite durations clamp to zero.** `performance.now()` deltas can go negative across clock adjustments — a negative hour would silently subtract from workspace totals.

**The `__standalone__` sentinel is filtered, not passed through.** Otherwise it invents a phantom app in every per-app breakdown.

**Trigger is read before `stack.add()`** in `runJobWithDependencies` — a non-empty stack means the run was pulled in by `ensureDependencyChain` rather than started by a human.

## Now answerable

- Apps that have agents, and agents per app
- Runs per app; agent hours per app
- Local vs cloud split of real work
- Human-triggered vs scheduled vs dependency-chained volume
- Cost-shaped questions: which apps consume the most agent time

`paprwork_job_created` carries the same app/agent dimensions, so "agents per app" works before any run has happened.

## Verification

- 13 new tests in `tests/job-run-telemetry.test.ts`
- 41 related tests passing (telemetry, scheduler, renderer telemetry)
- Gateway typecheck clean; oxlint clean; oxfmt unchanged
- 6 files, +453/−20

## Note for the dashboard

`duration_hours` sums across `surface` — chart it split at least once before trusting a combined total, since cloud data starts only from this deploy. Local history predates it.