### PR TITLE
feat(attribution): stamp X-Papr-Client=paprwork on memory requests

### DIFF
--- a/src/core/tools/bash.ts
+++ b/src/core/tools/bash.ts
@@ -279,7 +279,11 @@ async function searchPaprMemoryForCode(
     const { buildSearchPolicy } = await import(
       "../../gateway/utils/paprMemoryPolicy.js"
     );
-    const client = new Papr({ xAPIKey: paprKey });
+    const { PAPR_DEFAULT_HEADERS } = await import("./paprSurface.js");
+    const client = new Papr({
+      xAPIKey: paprKey,
+      defaultHeaders: PAPR_DEFAULT_HEADERS,
+    });
 
     const projectId = extractProjectIdFromPaprPath(grepPath);
     const customMetadata: Record<string, string> = {

--- a/src/core/tools/paprClient.ts
+++ b/src/core/tools/paprClient.ts
@@ -3,6 +3,7 @@ import {
   formatPaprQuotaMessage,
   reportPaprQuotaError,
 } from "../utils/paprQuota.js";
+import { PAPR_DEFAULT_HEADERS } from "./paprSurface.js";
 
 export async function getPaprClient(): Promise<Papr> {
   const { getPaprApiKey } = await import("../../gateway/utils/keyResolver.js");
@@ -17,6 +18,9 @@ export async function getPaprClient(): Promise<Papr> {
     xAPIKey: apiKey,
     maxRetries: 2,
     timeout: 120000,
+    // Surface attribution — see paprSurface.ts. Without this, Paprwork writes
+    // would be misattributed to ts_sdk via X-Stainless-Lang.
+    defaultHeaders: PAPR_DEFAULT_HEADERS,
   });
 }
 

--- a/src/core/tools/paprSurface.ts
+++ b/src/core/tools/paprSurface.ts
@@ -1,0 +1,27 @@
+/**
+ * Papr surface attribution.
+ *
+ * Every request Paprwork makes to the memory server is stamped with the product
+ * surface that issued it, so memories can be attributed to the client that
+ * actually wrote them.
+ *
+ * The memory server resolves the surface in this order:
+ *   1. X-Papr-Client            (paprwork | dev_platform | mcp | cli)
+ *   2. X-Stainless-Lang: js     -> ts_sdk
+ *   3. X-Stainless-Lang: python -> py_sdk
+ *   4. otherwise                -> api
+ *
+ * Paprwork runs *on top of* the TypeScript SDK, which already sends
+ * X-Stainless-Lang: js. Without this explicit stamp every Paprwork write would
+ * be misattributed to `ts_sdk`. The explicit header wins over the SDK signal.
+ *
+ * No SDK release is required — `defaultHeaders` is already supported by
+ * @papr/memory.
+ */
+export const PAPR_CLIENT_HEADER = "X-Papr-Client";
+export const PAPR_SURFACE = "paprwork";
+
+/** Default headers to pass to every `new Papr({ ... })` construction. */
+export const PAPR_DEFAULT_HEADERS: Record<string, string> = {
+  [PAPR_CLIENT_HEADER]: PAPR_SURFACE,
+};

--- a/src/gateway/websocket/memory.ts
+++ b/src/gateway/websocket/memory.ts
@@ -887,10 +887,14 @@ async function handleListSchemas(
     }
 
     const Papr = (await import("@papr/memory")).default;
+    const { PAPR_DEFAULT_HEADERS } = await import(
+      "../../core/tools/paprSurface.js"
+    );
     const client = new Papr({
       xAPIKey: apiKey,
       maxRetries: 2,
       timeout: 30_000,
+      defaultHeaders: PAPR_DEFAULT_HEADERS,
     });
 
     const payload = message.payload as { statusFilter?: string } | undefined;


### PR DESCRIPTION
Stamps `X-Papr-Client: paprwork` on every memory-server request.

## Why

Paprwork runs **on top of** the TypeScript SDK, which already sends `X-Stainless-Lang: js`. Without an explicit stamp, the memory server would attribute every Paprwork write to `ts_sdk`. The explicit header wins over the SDK signal.

## Changes

- `src/core/tools/paprSurface.ts` (new) — shared constant, so the literal is not duplicated
- `src/core/tools/paprClient.ts` — central `getPaprClient()` factory
- `src/core/tools/bash.ts` — code-index memory search
- `src/gateway/websocket/memory.ts` — schema list

All three `new Papr({ ... })` sites in the repo are covered.

## No SDK release required

`defaultHeaders` is already supported by `@papr/memory` (`src/client.ts:218`).

## Blocked on

**Papr-ai/memory#133** — until that deploys, this header is a no-op. Draft until then.

## Typecheck

163 pre-existing errors on `master`, 163 after this change. No new errors.