### PR TITLE
fix(sync): stop metadata outbox from flooding itself into rate-limit failure

### DIFF
--- a/src/gateway/services/syncV3/metadataOutbox.ts
+++ b/src/gateway/services/syncV3/metadataOutbox.ts
@@ -82,10 +82,15 @@ export async function enqueueMetadataOutboxEntry(
 ): Promise<void> {
   const entries = await readEntries();
   const filtered = entries.filter((existing) => {
-    if (
-      existing.kind !== entry.kind ||
-      existing.updatedAt !== entry.updatedAt
-    ) {
+    // Supersede ANY queued entry of the same kind, not just one with an
+    // identical updatedAt. Every entry is a FULL snapshot of the registry or
+    // index, so an older one carries nothing the newer one lacks. Matching on
+    // updatedAt meant each retry — which stamps a fresh timestamp — appended
+    // instead of replacing: 200+ duplicate 42KB PUTs accumulated in minutes and
+    // tripped the server's 60-requests-per-minute limit. The flush then failed
+    // with 429 and re-enqueued, so the queue grew faster than it drained and
+    // every app's cloud upload failed on "registry upload failed".
+    if (existing.kind !== entry.kind) {
       return true;
     }
     if (


### PR DESCRIPTION
Every cloud upload in the workspace was failing with:

> App sync failed: Metadata sync to cloud failed — namespace databases registry upload failed.

The real server response was hidden behind that wrapper:

```
databases registry upload failed (429): {"error":"Rate limit exceeded: 60 per 1 minute"}
```

## Root cause

`enqueueMetadataOutboxEntry` only superseded a queued entry when **both** `kind` and `updatedAt` matched. Every retry stamps a fresh `updatedAt`, so nothing was ever deduped — each failure appended another full ~42KB registry snapshot instead of replacing the pending one.

`flushMetadataOutbox` replays entries serially, so the queue blew through the server 60-req/min limit, every request 429d, and each failure re-enqueued. The queue grew faster than it drained and never recovered.

## Evidence

```
before trim: 225 entries  ->  trimmed to 2  ->  69 again within 45s
kinds: Counter({databases: 198, jobs: 2})
126 entries carrying: "Rate limit exceeded: 60 per 1 minute"
```

## Fix

Each entry is a **complete snapshot** of the registry or index, so an older one carries nothing the newer one lacks. Supersede on `kind` alone (still keyed by `appId` for the per-app kinds), keeping at most one pending entry per kind.

## Verification

With the fix applied the queue holds at 2 entries instead of climbing without bound. Typecheck clean (`tsc -p tsconfig.gateway.json --noEmit`).