### PR TITLE
fix(app-backend): vendor papr_db.py when an app has no copy at all

### DIFF
--- a/src/gateway/services/appRuntime/appBackendRunner.ts
+++ b/src/gateway/services/appRuntime/appBackendRunner.ts
@@ -152,14 +152,22 @@ async function refreshVendoredDbHelper(handlerPath: string): Promise<void> {
     try {
       existing = await fs.readFile(vendoredPath, "utf8");
     } catch {
-      return; // no vendored helper (source-mode handler) — nothing to refresh
+      // No vendored helper at all. This used to return, which meant apps
+      // created before the scaffolding wrote papr_db.py could NEVER import it:
+      // `import papr_db` raised ModuleNotFoundError on every request, because
+      // nothing else puts the helper on a path-mode handler's sys.path.
+      // Creating it here lets those older apps self-heal on next use, the same
+      // way a stale copy is upgraded below.
+      existing = null;
     }
 
-    if (readHelperVersion(existing) >= canonicalVersion) return;
+    if (existing !== null && readHelperVersion(existing) >= canonicalVersion) {
+      return;
+    }
 
     await fs.writeFile(vendoredPath, canonical, "utf8");
     console.log(
-      `[appBackendRunner] Refreshed stale papr_db.py -> v${canonicalVersion} (${vendoredPath})`,
+      `[appBackendRunner] ${existing === null ? "Vendored missing" : "Refreshed stale"} papr_db.py -> v${canonicalVersion} (${vendoredPath})`,
     );
   } catch (error) {
     // Never block handler execution on a refresh failure.


### PR DESCRIPTION
`refreshVendoredDbHelper` returned early when `<app>/backend/papr_db.py` did not exist, so it only ever **upgraded** a stale helper — it never created a missing one.

## Impact

The helper is written by `AppService` scaffolding at create time, so any app created **before** that scaffolding landed has no copy. For those apps every Python backend handler failed on import:

```
File ".../backend/qbo_common.py", line 14, in <module>
    import papr_db
ModuleNotFoundError: No module named papr_db
```

Nothing else puts the helper on a path-mode handler `sys.path` — the tmpdir copy in `runPythonHandler` only covers source-mode handlers — so these apps could never call the DB SDK.

This is quiet in the UI: mini-apps treat a non-OK handler response as `null`, so a broken handler looks like an empty state rather than an error.

Hit in production on Papr Books: all six QuickBooks OAuth handlers 500d this way after migrating off raw `sqlite3`, leaving a valid parked auth code unreadable and the app stuck on "Connect to QuickBooks".

## Fix

Write the canonical helper when none exists, using the same version gate as the refresh path so a newer or hand-edited copy is still never clobbered.

## Verification

Vendoring the helper by hand made the failing handlers work immediately; the QuickBooks connection then completed against a production realm. Typecheck clean.