### PR TITLE
fix(migrations): treat drift-heal ids with no manifest ops as no-ops

### DIFF
--- a/src/gateway/services/jobs/jobMigrationTursoSync.ts
+++ b/src/gateway/services/jobs/jobMigrationTursoSync.ts
@@ -33,6 +33,10 @@ import {
 import { shouldSkipMigrationForRemoteLedger } from "./migrationLedgerPolicy.js";
 import { listAppliedMigrationIdsReadOnly } from "./schemaMigrationsLedger.js";
 
+// Kept in sync with schemaDriftHeal.ts / shipSchemaMigrationLog.ts, which each
+// declare their own copy rather than sharing one constant.
+const SCHEMA_DRIFT_HEAL_PREFIX = "__schema_drift_heal__";
+
 export {
   REMOTE_SCHEMA_MIGRATIONS_TABLE,
   ensureRemoteSchemaMigrationsTable,
@@ -155,6 +159,20 @@ async function applyMigrationToRemote(
     if (await migrationSatisfiedOnRemote(remote, migrationRoot, migrationId)) {
       console.warn(
         `[MigrationTurso] ${migrationId} SQL file missing but remote schema already satisfied — skipping replay`,
+      );
+      return;
+    }
+    // Schema-drift-heal migrations are synthetic: schemaDriftHeal.ts mints the
+    // id and ships its ops through the manifest, so a .sql file NEVER exists on
+    // disk for them. When the manifest entry is missing (pruned, or written on
+    // another device) this threw "Migration SQL missing", permanently blocking
+    // replica cutover — and because the databases registry uploads for the
+    // whole namespace at once, one such database failed cloud sync for EVERY
+    // app in the workspace. The ops were already applied remotely when the heal
+    // shipped, so replaying nothing is correct.
+    if (migrationId.startsWith(SCHEMA_DRIFT_HEAL_PREFIX)) {
+      console.warn(
+        `[MigrationTurso] ${migrationId} is a synthetic drift-heal id with no manifest ops — treating as no-op`,
       );
       return;
     }


### PR DESCRIPTION
Schema-drift-heal migrations are **synthetic**: `schemaDriftHeal.ts` mints `__schema_drift_heal___<ts>` and ships its ops through the manifest, so a `.sql` file *never* exists on disk for one.

`applyMigrationToRemote` falls back to `readMigrationSql` when the manifest has no ops for an id. For a drift-heal id that file cannot exist, so it threw:

```
Migration SQL missing for __schema_drift_heal___1787760298103
```

## Impact

That permanently blocked replica cutover for the database. Worse, the databases registry uploads for the **whole namespace at once**, so a single database in this state failed cloud sync for **every app in the workspace**:

> App sync failed: Metadata sync to cloud failed — namespace databases registry upload failed.

Two databases hit this in one session (`papr-books`, `investor-updates`). The only workaround was hand-writing no-op `.sql` placeholders for ids that were never supposed to have files.

## Why a no-op is correct

The manifest entry can go missing legitimately — pruned, or the heal shipped from another device — while the ops themselves were already applied remotely when the heal ran. The existing `migrationSatisfiedOnRemote` check (run just above) already covers the case where the remote schema is *not* satisfied, so falling through to a no-op only happens for ids whose ops are genuinely gone.

## Fix

Recognise the drift-heal prefix and treat it as a no-op instead of throwing.

Note: `SCHEMA_DRIFT_HEAL_PREFIX` is declared locally, matching the existing pattern in `schemaDriftHeal.ts` and `shipSchemaMigrationLog.ts` which each declare their own copy. Happy to hoist all three into a shared constant if preferred.

## Verification

Writing placeholder `.sql` files by hand cleared `cutoverBlocked` on both affected databases and unblocked the namespace registry upload — this change removes the need for that manual step. Typecheck clean.