### PR TITLE
Repair unsatisfiable WAL watermarks before the Turso engine aborts the app

### DIFF
--- a/src/core/tools/paprDb.ts
+++ b/src/core/tools/paprDb.ts
@@ -30,7 +30,9 @@ export const paprDbSyncStatusTool = createTool({
   description:
     "Plan A Turso replica sync status for a registry database. " +
     "Returns online, syncMode, pendingPush, pendingOps, sidecarWedge, cutoverBlocked, lastPushError. " +
-    "When sidecarWedge is true, pull/push/migration will fail until sidecars are reset. " +
+    "sidecarWedge means the recorded WAL watermark names a frame the WAL does not hold. " +
+    "Connecting now resets those sidecars automatically, so this is normally false; if it stays " +
+    "true the replica could not be opened at all and needs repair_cloud_sync. " +
     "Only repair_cloud_sync accept_cloud resets them - 'pull' and 'merge_lww' do NOT, and may report success while doing nothing. " +
     "accept_cloud reseeds local from the Turso primary, so confirm cloud is not missing local-only rows before using it. " +
     "Requires PAPR_TURSO_REPLICA_SYNC and Papr cloud sync enabled.",

--- a/src/gateway/services/tursoReplica/TursoReplicaService.ts
+++ b/src/gateway/services/tursoReplica/TursoReplicaService.ts
@@ -34,9 +34,12 @@ import {
   isReplicaReadTransportError,
 } from "./tursoReplicaCheckpointRecovery.js";
 import {
+  describeReplicaSidecarWedge,
   detectReplicaSidecarWedge,
+  inspectReplicaSidecarWedge,
   repairReplicaSidecarWedge,
   repairReplicaSidecarsOnCheckpointError,
+  resetReplicaSidecars,
 } from "./tursoReplicaSidecarWedge.js";
 
 const REPLICA_STATUS_OPEN_TIMEOUT_MS = 12_000;
@@ -148,6 +151,9 @@ export class TursoReplicaService {
   }): Promise<TursoReplicaWriteResult> {
     return this.withSerializedPath(options.localPath, async () => {
       const online = isTursoReplicaOnline();
+      if (online) {
+        await this.ensureSyncableSidecars(options.localPath, "write sync");
+      }
       const handle = await this.getOrOpen({
         localPath: options.localPath,
         tursoDatabase: options.tursoDatabase,
@@ -195,6 +201,9 @@ export class TursoReplicaService {
   ): Promise<{ pendingPush: boolean }> {
     return this.withSerializedPath(localPath, async () => {
       const online = isTursoReplicaOnline();
+      if (online) {
+        await this.ensureSyncableSidecars(localPath, "exec sync");
+      }
       const handle = await this.getOrOpen({
         localPath,
         tursoDatabase,
@@ -232,6 +241,9 @@ export class TursoReplicaService {
   ): Promise<TursoReplicaPushResponse> {
     try {
       await this.withSerializedPath(localPath, async () => {
+        if (isTursoReplicaOnline()) {
+          await this.ensureSyncableSidecars(localPath, "push");
+        }
         const handle = await this.getOrOpen({
           localPath,
           tursoDatabase,
@@ -259,6 +271,7 @@ export class TursoReplicaService {
   async pull(localPath: string, tursoDatabase: string): Promise<boolean> {
     return this.withSerializedPath(localPath, async () => {
       try {
+        await this.ensureSyncableSidecars(localPath, "pull");
         const handle = await this.getOrOpen({
           localPath,
           tursoDatabase,
@@ -669,6 +682,31 @@ export class TursoReplicaService {
     }
   }
 
+  /**
+   * Precondition for every sync call: the watermark in `-info` must name a frame the `-wal`
+   * actually holds.
+   *
+   * An unsatisfiable watermark makes the engine abort the process from Rust, so there is no
+   * error to recover from afterwards — the check has to happen before pull()/push() is reached.
+   * Closing first matters: the repair unlinks the `-wal` the open handle is holding.
+   */
+  private async ensureSyncableSidecars(
+    localPath: string,
+    context: string,
+  ): Promise<boolean> {
+    const report = inspectReplicaSidecarWedge(localPath);
+    if (!report.wedged) {
+      return false;
+    }
+    await this.close(localPath);
+    resetReplicaSidecars(localPath);
+    console.warn(
+      `[TursoReplicaService] Reset wedged sync sidecars before ${context}: ` +
+        `${localPath} — ${describeReplicaSidecarWedge(report)}`,
+    );
+    return true;
+  }
+
   private async recoverSidecarsAfterCheckpointError(
     localPath: string,
   ): Promise<void> {
@@ -742,6 +780,10 @@ export class TursoReplicaService {
     if (!bridge.enabled) {
       throw new Error("Turso sync bridge not available — sign in to Papr");
     }
+
+    // Cold path (startup, reconnect, post-close): sidecars left by an unclean shutdown are
+    // repaired here, before the engine can be handed an unsatisfiable watermark.
+    await this.ensureSyncableSidecars(options.localPath, "connect");
 
     const localReplicaExists = fs.existsSync(options.localPath);
     const bootstrapIfEmpty =

--- a/src/gateway/services/tursoReplica/tursoReplicaSidecarWedge.ts
+++ b/src/gateway/services/tursoReplica/tursoReplicaSidecarWedge.ts
@@ -8,17 +8,40 @@
  *   `data.db-wal-revert` — owned by @tursodatabase/sync. The SDK recreates them on connect;
  *   do not delete them in normal operation.
  *
- * A "wedge" is when Plan A metadata (-info) claims WAL progress but the sync WAL is empty.
- * That state wedges pull()/push(). Root cause: calling checkpoint() after push on replica files.
- * Repair resets only Plan A sidecars (keeps data.db) for already-wedged disks — not a startup scan.
+ * A "wedge" is when `data.db-info` carries a `revert_since_wal_watermark` that names a frame
+ * the `data.db-wal` does not contain. The engine resolves that watermark through
+ * `WalFile::find_frame`, which asserts the frame exists — an unsatisfiable watermark is a Rust
+ * `panic!`, and a panic inside the napi worker aborts the whole process rather than surfacing a
+ * catchable error. Detection is therefore a precondition check, not error handling: once pull()
+ * runs it is already too late.
+ *
+ * Repair resets only Plan A sidecars (keeps data.db), so the next connect re-bootstraps WAL
+ * state from Turso.
  */
 
 import * as fs from "fs";
 import { removeTursoReplicaSidecarsOnly } from "./tursoReplicaFileGuard.js";
+import { readReplicaWalShape } from "./tursoReplicaWalFrames.js";
 
 interface ReplicaSidecarInfo {
   revertSinceWalWatermark: number;
+  /** Remote revision marker, *not* a local WAL frame index — never gates a wedge. */
   walFragmentNo: number;
+}
+
+export type ReplicaSidecarWedgeReason =
+  | "ok"
+  | "missing_db"
+  | "no_sidecar_info"
+  | "wal_unreadable"
+  | "watermark_past_wal_end";
+
+export interface ReplicaSidecarWedgeReport {
+  wedged: boolean;
+  reason: ReplicaSidecarWedgeReason;
+  watermark: number;
+  walFrameCount: number;
+  walSizeBytes: number;
 }
 
 function readReplicaSidecarInfo(dbPath: string): ReplicaSidecarInfo | null {
@@ -54,35 +77,99 @@ function readReplicaSidecarInfo(dbPath: string): ReplicaSidecarInfo | null {
   }
 }
 
-function localTursoSyncWalSize(dbPath: string): number {
-  try {
-    return fs.statSync(`${dbPath}-wal`).size;
-  } catch {
-    return 0;
-  }
-}
-
 /**
- * Sync engine metadata claims WAL progress but the Turso Sync WAL file is empty.
- * Reads via sqlite3/better-sqlite3 still work; pull()/push() wedge.
+ * Report whether the sync engine would be asked to resolve a WAL frame that is not there.
+ *
+ * Deliberately narrow. Repair deletes sidecars and forces a re-bootstrap from Turso, so a false
+ * positive is expensive: it throws away local WAL state on a database that was fine. We only
+ * report a wedge when the WAL is parseable *and* provably too short for the recorded watermark.
+ *
+ * In particular a checkpointed (empty) WAL alongside a non-zero `wal_fragment_no` is the normal
+ * resting state of a healthy replica — `wal_fragment_no` tracks the remote revision, not local
+ * frames, so it says nothing about whether `find_frame` can be satisfied.
  */
-export function detectReplicaSidecarWedge(dbPath: string): boolean {
+export function inspectReplicaSidecarWedge(
+  dbPath: string,
+): ReplicaSidecarWedgeReport {
+  const base: ReplicaSidecarWedgeReport = {
+    wedged: false,
+    reason: "ok",
+    watermark: 0,
+    walFrameCount: 0,
+    walSizeBytes: 0,
+  };
+
   if (!fs.existsSync(dbPath)) {
-    return false;
+    return { ...base, reason: "missing_db" };
   }
-  const walSize = localTursoSyncWalSize(dbPath);
-  if (walSize > 0) {
-    return false;
-  }
+
   const info = readReplicaSidecarInfo(dbPath);
   if (!info) {
-    return false;
+    return { ...base, reason: "no_sidecar_info" };
   }
-  return info.revertSinceWalWatermark > 0 || info.walFragmentNo > 0;
+
+  const wal = readReplicaWalShape(dbPath);
+  const watermark = info.revertSinceWalWatermark;
+
+  if (watermark <= 0) {
+    // Nothing to revert — find_frame is never asked for a watermark frame.
+    return {
+      ...base,
+      watermark,
+      walFrameCount: wal.frameCount,
+      walSizeBytes: wal.sizeBytes,
+    };
+  }
+
+  if (!wal.frameCountKnown) {
+    // Can't parse the WAL, so we can't prove the watermark is unsatisfiable.
+    // Leaving it alone is the safe call; a real wedge still trips the checkpoint-error path.
+    return {
+      ...base,
+      reason: "wal_unreadable",
+      watermark,
+      walSizeBytes: wal.sizeBytes,
+    };
+  }
+
+  if (watermark > wal.frameCount) {
+    return {
+      wedged: true,
+      reason: "watermark_past_wal_end",
+      watermark,
+      walFrameCount: wal.frameCount,
+      walSizeBytes: wal.sizeBytes,
+    };
+  }
+
+  return {
+    ...base,
+    watermark,
+    walFrameCount: wal.frameCount,
+    walSizeBytes: wal.sizeBytes,
+  };
+}
+
+/** One-line diagnostic for logs — explains *why* sidecars are being reset. */
+export function describeReplicaSidecarWedge(
+  report: ReplicaSidecarWedgeReport,
+): string {
+  return (
+    `${report.reason} (watermark=${report.watermark}, ` +
+    `walFrames=${report.walFrameCount}, walBytes=${report.walSizeBytes})`
+  );
 }
 
 /**
- * Reset @tursodatabase/sync sidecars when metadata claims WAL progress but the sync WAL is empty.
+ * Sync engine metadata names a WAL frame the sync WAL does not contain.
+ * Reads via sqlite3/better-sqlite3 still work; pull()/push() abort the process.
+ */
+export function detectReplicaSidecarWedge(dbPath: string): boolean {
+  return inspectReplicaSidecarWedge(dbPath).wedged;
+}
+
+/**
+ * Reset @tursodatabase/sync sidecars when the recorded watermark is unsatisfiable.
  * Keeps data.db intact — next pull reconnects from Turso.
  */
 export function repairReplicaSidecarWedge(dbPath: string): boolean {
@@ -91,6 +178,16 @@ export function repairReplicaSidecarWedge(dbPath: string): boolean {
   }
   removeTursoReplicaSidecarsOnly(dbPath);
   return true;
+}
+
+/**
+ * Delete Plan A sidecars for a path the caller has already inspected and closed.
+ *
+ * Split from {@link repairReplicaSidecarWedge} so the pre-sync path can inspect once, close the
+ * open handle, then repair — unlinking a `-wal` that the engine still has open corrupts it.
+ */
+export function resetReplicaSidecars(dbPath: string): void {
+  removeTursoReplicaSidecarsOnly(dbPath);
 }
 
 /**

--- a/src/gateway/services/tursoReplica/tursoReplicaWalFrames.ts
+++ b/src/gateway/services/tursoReplica/tursoReplicaWalFrames.ts
@@ -1,0 +1,154 @@
+/**
+ * Frame accounting for a @tursodatabase/sync replica WAL (`data.db-wal`).
+ *
+ * `data.db-info` stores `revert_since_wal_watermark`, a frame index into that WAL.
+ * The sync engine resolves it with `WalFile::find_frame`, which asserts the frame
+ * exists — if the watermark points past the last frame the assert fires as a Rust
+ * `panic!`, and a panic in a napi worker aborts the whole process. There is no
+ * JS-catchable error, so the only defence is to read the WAL ourselves and refuse
+ * to hand the engine a watermark it cannot satisfy.
+ *
+ * WAL layout (SQLite file format, unchanged by Turso):
+ *   32-byte header — magic u32be, format u32be, page size u32be, then salts/checksums
+ *   N frames       — 24-byte frame header + one page of `pageSize` bytes each
+ */
+
+import * as fs from "fs";
+
+const WAL_HEADER_BYTES = 32;
+const WAL_FRAME_HEADER_BYTES = 24;
+const WAL_PAGE_SIZE_OFFSET = 8;
+
+/** Big-endian magic; the low bit selects frame checksum endianness, not layout. */
+const WAL_MAGIC_MASK = 0xfffffffe;
+const WAL_MAGIC = 0x377f0682;
+
+const MIN_PAGE_SIZE = 512;
+const MAX_PAGE_SIZE = 65536;
+
+export interface ReplicaWalShape {
+  /** The `-wal` file is present on disk. */
+  exists: boolean;
+  sizeBytes: number;
+  /** Page size from the WAL header; 0 when the header could not be read. */
+  pageSizeBytes: number;
+  /** Frames physically present in the WAL. Only meaningful when `frameCountKnown`. */
+  frameCount: number;
+  /**
+   * We can state `frameCount` with confidence.
+   *
+   * False for a WAL we cannot parse (bad magic, implausible page size, truncated
+   * header). A parse failure is *not* evidence of zero frames, and treating it as
+   * such would delete healthy sidecars — callers must not infer a wedge from it.
+   */
+  frameCountKnown: boolean;
+}
+
+function isPlausiblePageSize(value: number): boolean {
+  // SQLite encodes 65536 as 1 in the *database* header. The WAL header carries a
+  // full u32, but accept the encoded form too rather than reject a valid WAL.
+  const pageSize = value === 1 ? MAX_PAGE_SIZE : value;
+  if (pageSize < MIN_PAGE_SIZE || pageSize > MAX_PAGE_SIZE) {
+    return false;
+  }
+  return (pageSize & (pageSize - 1)) === 0;
+}
+
+function normalizePageSize(value: number): number {
+  return value === 1 ? MAX_PAGE_SIZE : value;
+}
+
+/**
+ * Read `data.db-wal` and report how many frames it actually holds.
+ *
+ * Never throws — an unreadable WAL yields `frameCountKnown: false` so callers
+ * fall back to leaving the sidecars alone.
+ */
+export function readReplicaWalShape(dbPath: string): ReplicaWalShape {
+  const walPath = `${dbPath}-wal`;
+
+  let sizeBytes: number;
+  try {
+    sizeBytes = fs.statSync(walPath).size;
+  } catch {
+    // No WAL file at all: definitively zero frames. The engine recreates it.
+    return {
+      exists: false,
+      sizeBytes: 0,
+      pageSizeBytes: 0,
+      frameCount: 0,
+      frameCountKnown: true,
+    };
+  }
+
+  if (sizeBytes < WAL_HEADER_BYTES) {
+    // Includes the common 0-byte case left behind by a checkpoint.
+    return {
+      exists: true,
+      sizeBytes,
+      pageSizeBytes: 0,
+      frameCount: 0,
+      frameCountKnown: true,
+    };
+  }
+
+  const header = Buffer.alloc(WAL_HEADER_BYTES);
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(walPath, "r");
+    const read = fs.readSync(fd, header, 0, WAL_HEADER_BYTES, 0);
+    if (read < WAL_HEADER_BYTES) {
+      return {
+        exists: true,
+        sizeBytes,
+        pageSizeBytes: 0,
+        frameCount: 0,
+        frameCountKnown: false,
+      };
+    }
+  } catch {
+    return {
+      exists: true,
+      sizeBytes,
+      pageSizeBytes: 0,
+      frameCount: 0,
+      frameCountKnown: false,
+    };
+  } finally {
+    if (fd !== null) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+
+  const magic = header.readUInt32BE(0);
+  const rawPageSize = header.readUInt32BE(WAL_PAGE_SIZE_OFFSET);
+
+  if (
+    (magic & WAL_MAGIC_MASK) !== WAL_MAGIC ||
+    !isPlausiblePageSize(rawPageSize)
+  ) {
+    return {
+      exists: true,
+      sizeBytes,
+      pageSizeBytes: 0,
+      frameCount: 0,
+      frameCountKnown: false,
+    };
+  }
+
+  const pageSizeBytes = normalizePageSize(rawPageSize);
+  const frameStride = WAL_FRAME_HEADER_BYTES + pageSizeBytes;
+  const frameCount = Math.floor((sizeBytes - WAL_HEADER_BYTES) / frameStride);
+
+  return {
+    exists: true,
+    sizeBytes,
+    pageSizeBytes,
+    frameCount,
+    frameCountKnown: true,
+  };
+}

--- a/tests/turso-replica-checkpoint-recovery.test.ts
+++ b/tests/turso-replica-checkpoint-recovery.test.ts
@@ -198,7 +198,7 @@ describe("turso replica checkpoint wedge — production guarantees", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("syncStatus reports sidecarWedge when -info claims progress but WAL is empty", async () => {
+  it("syncStatus repairs an unsatisfiable watermark on connect and reports healthy", async () => {
     process.env.CLOUD_SYNC_ENABLED = "true";
     process.env.PAPR_TURSO_REPLICA_SYNC = "force";
 
@@ -243,7 +243,11 @@ describe("turso replica checkpoint wedge — production guarantees", () => {
       syncMode: "replica",
     });
 
-    expect(status.sidecarWedge).toBe(true);
+    // watermark=12 against an empty WAL is unsatisfiable: the engine would abort the
+    // process resolving it, so opening the replica resets the sidecars first. By the time
+    // status is computed the replica is genuinely no longer wedged.
+    expect(fs.existsSync(`${dbPath}-info`)).toBe(false);
+    expect(status.sidecarWedge).toBe(false);
     expect(status.pendingOps).toBe(2);
 
     fs.rmSync(dir, { recursive: true, force: true });

--- a/tests/turso-replica-sidecar-wedge.test.ts
+++ b/tests/turso-replica-sidecar-wedge.test.ts
@@ -1,70 +1,187 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { detectReplicaSidecarWedge, repairReplicaSidecarWedge } from "../src/gateway/services/tursoReplica/tursoReplicaSidecarWedge.js";
+import {
+  detectReplicaSidecarWedge,
+  inspectReplicaSidecarWedge,
+  repairReplicaSidecarWedge,
+} from "../src/gateway/services/tursoReplica/tursoReplicaSidecarWedge.js";
 
-describe("tursoReplicaSidecarWedge", () => {
-  it("detects empty WAL with non-zero watermark in sidecar info", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "papr-wedge-"));
-    const dbPath = path.join(dir, "data.db");
-    fs.writeFileSync(dbPath, "sqlite");
+const WAL_HEADER_BYTES = 32;
+const WAL_FRAME_HEADER_BYTES = 24;
+const WAL_MAGIC_BE = 0x377f0682;
+const PAGE_SIZE = 4096;
+
+const tempDirs: string[] = [];
+
+function makeTempDb(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "papr-wedge-"));
+  tempDirs.push(dir);
+  const dbPath = path.join(dir, "data.db");
+  fs.writeFileSync(dbPath, "sqlite-data");
+  return dbPath;
+}
+
+function writeSidecarInfo(
+  dbPath: string,
+  options: { watermark?: number; walFragmentNo?: number },
+): void {
+  fs.writeFileSync(
+    `${dbPath}-info`,
+    JSON.stringify({
+      version: "v1",
+      revert_since_wal_salt: null,
+      revert_since_wal_watermark: options.watermark ?? 0,
+      synced_revision: {
+        type: "v1",
+        revision: JSON.stringify({
+          generation: 999999999999999998,
+          wal_fragment_no: options.walFragmentNo ?? 0,
+        }),
+      },
+    }),
+  );
+}
+
+function writeWal(dbPath: string, frameCount: number): void {
+  const header = Buffer.alloc(WAL_HEADER_BYTES);
+  header.writeUInt32BE(WAL_MAGIC_BE, 0);
+  header.writeUInt32BE(3007000, 4);
+  header.writeUInt32BE(PAGE_SIZE, 8);
+  const frames = Buffer.alloc(
+    (WAL_FRAME_HEADER_BYTES + PAGE_SIZE) * frameCount,
+  );
+  fs.writeFileSync(`${dbPath}-wal`, Buffer.concat([header, frames]));
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("detectReplicaSidecarWedge", () => {
+  it("flags a watermark that names a frame an empty WAL cannot hold", () => {
+    const dbPath = makeTempDb();
     fs.writeFileSync(`${dbPath}-wal`, "");
-    fs.writeFileSync(
-      `${dbPath}-info`,
-      JSON.stringify({
-        revert_since_wal_watermark: 0,
-        synced_revision: {
-          revision: JSON.stringify({ wal_fragment_no: 85 }),
-        },
-      }),
-    );
+    writeSidecarInfo(dbPath, { watermark: 8, walFragmentNo: 20 });
+
+    const report = inspectReplicaSidecarWedge(dbPath);
+
+    expect(report.wedged).toBe(true);
+    expect(report.reason).toBe("watermark_past_wal_end");
+    expect(report.watermark).toBe(8);
+    expect(report.walFrameCount).toBe(0);
+  });
+
+  it("flags a watermark past the end of a WAL that still has frames", () => {
+    // The crash case: the old empty-WAL-only check returned false here, so pull()
+    // reached find_frame with an unsatisfiable watermark and aborted the process.
+    const dbPath = makeTempDb();
+    writeWal(dbPath, 12);
+    writeSidecarInfo(dbPath, { watermark: 4849, walFragmentNo: 2 });
+
+    const report = inspectReplicaSidecarWedge(dbPath);
+
+    expect(report.wedged).toBe(true);
+    expect(report.reason).toBe("watermark_past_wal_end");
+    expect(report.walFrameCount).toBe(12);
+  });
+
+  it("flags a watermark recorded against a missing WAL", () => {
+    const dbPath = makeTempDb();
+    writeSidecarInfo(dbPath, { watermark: 8 });
 
     expect(detectReplicaSidecarWedge(dbPath)).toBe(true);
-    fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("returns false when WAL has frames", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "papr-wedge-"));
-    const dbPath = path.join(dir, "data.db");
-    fs.writeFileSync(dbPath, "sqlite");
-    fs.writeFileSync(`${dbPath}-wal`, "frame-data");
-    fs.writeFileSync(
-      `${dbPath}-info`,
-      JSON.stringify({
-        synced_revision: {
-          revision: JSON.stringify({ wal_fragment_no: 85 }),
-        },
-      }),
-    );
+  it("does not flag a checkpointed replica whose remote fragment is non-zero", () => {
+    // Healthy resting state: the WAL was checkpointed into data.db and
+    // wal_fragment_no tracks the *remote* revision, not local frames.
+    const dbPath = makeTempDb();
+    fs.writeFileSync(`${dbPath}-wal`, "");
+    writeSidecarInfo(dbPath, { watermark: 0, walFragmentNo: 85 });
+
+    const report = inspectReplicaSidecarWedge(dbPath);
+
+    expect(report.wedged).toBe(false);
+    expect(report.reason).toBe("ok");
+  });
+
+  it("does not flag a watermark the WAL can satisfy", () => {
+    const dbPath = makeTempDb();
+    writeWal(dbPath, 40);
+    writeSidecarInfo(dbPath, { watermark: 12, walFragmentNo: 3 });
 
     expect(detectReplicaSidecarWedge(dbPath)).toBe(false);
-    fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("repairReplicaSidecarWedge removes wedged sidecars and keeps data.db", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "papr-wedge-repair-"));
-    const dbPath = path.join(dir, "data.db");
-    fs.writeFileSync(dbPath, "sqlite-data");
-    fs.writeFileSync(`${dbPath}-wal`, "");
-    fs.writeFileSync(
-      `${dbPath}-info`,
-      JSON.stringify({
-        revert_since_wal_watermark: 12,
-        synced_revision: {
-          revision: JSON.stringify({ wal_fragment_no: 3 }),
-        },
-      }),
-    );
-    fs.writeFileSync(`${dbPath}-changes`, "{}");
+  it("does not flag a watermark exactly at the last frame", () => {
+    const dbPath = makeTempDb();
+    writeWal(dbPath, 5);
+    writeSidecarInfo(dbPath, { watermark: 5 });
 
-    const repaired = repairReplicaSidecarWedge(dbPath);
-    expect(repaired).toBe(true);
-    expect(fs.existsSync(dbPath)).toBe(true);
+    expect(detectReplicaSidecarWedge(dbPath)).toBe(false);
+  });
+
+  it("does not flag when the WAL cannot be parsed", () => {
+    // An unparseable WAL is not proof the watermark is unsatisfiable, and repair
+    // is destructive — stay out of the way and let the checkpoint-error path handle it.
+    const dbPath = makeTempDb();
+    fs.writeFileSync(`${dbPath}-wal`, Buffer.alloc(9000, 0xab));
+    writeSidecarInfo(dbPath, { watermark: 99 });
+
+    const report = inspectReplicaSidecarWedge(dbPath);
+
+    expect(report.wedged).toBe(false);
+    expect(report.reason).toBe("wal_unreadable");
+  });
+
+  it("does not flag when there is no sidecar info", () => {
+    const dbPath = makeTempDb();
+
+    expect(inspectReplicaSidecarWedge(dbPath).reason).toBe("no_sidecar_info");
+  });
+
+  it("does not flag a path with no database file", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "papr-wedge-"));
+    tempDirs.push(dir);
+
+    expect(inspectReplicaSidecarWedge(path.join(dir, "data.db")).reason).toBe(
+      "missing_db",
+    );
+  });
+
+  it("tolerates malformed sidecar info", () => {
+    const dbPath = makeTempDb();
+    fs.writeFileSync(`${dbPath}-info`, "{not json");
+
+    expect(detectReplicaSidecarWedge(dbPath)).toBe(false);
+  });
+});
+
+describe("repairReplicaSidecarWedge", () => {
+  it("removes wedged sidecars and keeps data.db", () => {
+    const dbPath = makeTempDb();
+    fs.writeFileSync(`${dbPath}-wal`, "");
+    fs.writeFileSync(`${dbPath}-changes`, "{}");
+    writeSidecarInfo(dbPath, { watermark: 12, walFragmentNo: 3 });
+
+    expect(repairReplicaSidecarWedge(dbPath)).toBe(true);
     expect(fs.readFileSync(dbPath, "utf8")).toBe("sqlite-data");
     expect(fs.existsSync(`${dbPath}-info`)).toBe(false);
+    expect(fs.existsSync(`${dbPath}-changes`)).toBe(false);
     expect(detectReplicaSidecarWedge(dbPath)).toBe(false);
+  });
 
-    fs.rmSync(dir, { recursive: true, force: true });
+  it("leaves a healthy replica untouched", () => {
+    const dbPath = makeTempDb();
+    writeWal(dbPath, 40);
+    writeSidecarInfo(dbPath, { watermark: 12, walFragmentNo: 3 });
+
+    expect(repairReplicaSidecarWedge(dbPath)).toBe(false);
+    expect(fs.existsSync(`${dbPath}-info`)).toBe(true);
+    expect(fs.existsSync(`${dbPath}-wal`)).toBe(true);
   });
 });

--- a/tests/turso-replica-wal-frames.test.ts
+++ b/tests/turso-replica-wal-frames.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { readReplicaWalShape } from "../src/gateway/services/tursoReplica/tursoReplicaWalFrames.js";
+
+const WAL_HEADER_BYTES = 32;
+const WAL_FRAME_HEADER_BYTES = 24;
+const WAL_MAGIC_BE = 0x377f0682;
+
+const tempDirs: string[] = [];
+
+function makeTempDb(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "papr-wal-frames-"));
+  tempDirs.push(dir);
+  const dbPath = path.join(dir, "data.db");
+  fs.writeFileSync(dbPath, "sqlite");
+  return dbPath;
+}
+
+/** Build a structurally valid WAL carrying `frameCount` frames of `pageSize` bytes. */
+function writeWal(
+  dbPath: string,
+  options: { pageSize: number; frameCount: number; magic?: number },
+): void {
+  const { pageSize, frameCount } = options;
+  const header = Buffer.alloc(WAL_HEADER_BYTES);
+  header.writeUInt32BE(options.magic ?? WAL_MAGIC_BE, 0);
+  header.writeUInt32BE(3007000, 4);
+  header.writeUInt32BE(pageSize, 8);
+  header.writeUInt32BE(1, 12);
+
+  const frames = Buffer.alloc((WAL_FRAME_HEADER_BYTES + pageSize) * frameCount);
+  fs.writeFileSync(`${dbPath}-wal`, Buffer.concat([header, frames]));
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("readReplicaWalShape", () => {
+  it("reports zero known frames when the WAL file is absent", () => {
+    const shape = readReplicaWalShape(makeTempDb());
+
+    expect(shape.exists).toBe(false);
+    expect(shape.frameCount).toBe(0);
+    expect(shape.frameCountKnown).toBe(true);
+  });
+
+  it("reports zero known frames for a checkpointed (0-byte) WAL", () => {
+    const dbPath = makeTempDb();
+    fs.writeFileSync(`${dbPath}-wal`, "");
+
+    const shape = readReplicaWalShape(dbPath);
+
+    expect(shape.exists).toBe(true);
+    expect(shape.sizeBytes).toBe(0);
+    expect(shape.frameCount).toBe(0);
+    expect(shape.frameCountKnown).toBe(true);
+  });
+
+  it("counts frames using the page size from the WAL header", () => {
+    const dbPath = makeTempDb();
+    writeWal(dbPath, { pageSize: 4096, frameCount: 7 });
+
+    const shape = readReplicaWalShape(dbPath);
+
+    expect(shape.pageSizeBytes).toBe(4096);
+    expect(shape.frameCount).toBe(7);
+    expect(shape.frameCountKnown).toBe(true);
+  });
+
+  it("counts frames for a non-default page size", () => {
+    const dbPath = makeTempDb();
+    writeWal(dbPath, { pageSize: 512, frameCount: 3 });
+
+    const shape = readReplicaWalShape(dbPath);
+
+    expect(shape.pageSizeBytes).toBe(512);
+    expect(shape.frameCount).toBe(3);
+  });
+
+  it("accepts the alternate checksum-endianness magic", () => {
+    const dbPath = makeTempDb();
+    writeWal(dbPath, { pageSize: 4096, frameCount: 2, magic: 0x377f0683 });
+
+    const shape = readReplicaWalShape(dbPath);
+
+    expect(shape.frameCountKnown).toBe(true);
+    expect(shape.frameCount).toBe(2);
+  });
+
+  it("ignores a trailing partial frame", () => {
+    const dbPath = makeTempDb();
+    writeWal(dbPath, { pageSize: 4096, frameCount: 2 });
+    fs.appendFileSync(`${dbPath}-wal`, Buffer.alloc(100));
+
+    expect(readReplicaWalShape(dbPath).frameCount).toBe(2);
+  });
+
+  it("does not claim a frame count for a WAL with a bad magic", () => {
+    const dbPath = makeTempDb();
+    writeWal(dbPath, { pageSize: 4096, frameCount: 4, magic: 0xdeadbeef });
+
+    const shape = readReplicaWalShape(dbPath);
+
+    expect(shape.frameCountKnown).toBe(false);
+    expect(shape.frameCount).toBe(0);
+  });
+
+  it("does not claim a frame count for an implausible page size", () => {
+    const dbPath = makeTempDb();
+    writeWal(dbPath, { pageSize: 5000, frameCount: 1 });
+
+    expect(readReplicaWalShape(dbPath).frameCountKnown).toBe(false);
+  });
+
+  it("treats a sub-header-sized WAL as definitively empty", () => {
+    const dbPath = makeTempDb();
+    fs.writeFileSync(`${dbPath}-wal`, Buffer.alloc(20, 1));
+
+    const shape = readReplicaWalShape(dbPath);
+
+    // Below one header: zero frames is still a fact, not a parse failure.
+    expect(shape.frameCount).toBe(0);
+    expect(shape.frameCountKnown).toBe(true);
+  });
+});


### PR DESCRIPTION
## The crash

Papr Work is dying with `EXC_CRASH (SIGABRT)` in `libuv-worker`, inside
`@tursodatabase/sync-darwin-arm64`:

```
WalFile::find_frame
panic_abort::__rust_start_panic
```

A replica records a WAL watermark in `data.db-info`
(`revert_since_wal_watermark`). If `data.db-wal` cannot satisfy it, resolving the
watermark trips an assert in `find_frame`, which fires as a Rust `panic!` inside
the napi worker and **aborts the process**. There is no JS-catchable error — by
the time `pull()` runs we have already lost. So this has to be a *precondition*
check, not error handling.

Upstream: tursodatabase/turso#6617.

## What was wrong with the existing detection

There was already a `detectReplicaSidecarWedge`, and it was wrong in both
directions:

**Too narrow** — it only fired when the WAL was *empty*. A WAL holding some
frames but fewer than the watermark read as healthy and went straight into the
crash. That is exactly the reported abort.

**Too broad** — it treated `wal_fragment_no > 0` as evidence of a wedge. That
field tracks the *remote* revision, not local frames; a checkpointed WAL plus a
non-zero fragment number is the normal resting state of a healthy replica. On my
machine that misread **2 of 4** live databases. Startup purge acts on the same
predicate, so healthy sidecars were being deleted and re-bootstrapped on every
gateway start.

## The fix

Use the condition that actually predicts the panic. Parse the WAL header for its
page size, derive the real frame count, and flag only `watermark > frameCount`.

A WAL we cannot parse is reported as *unknown*, not assumed empty — repair is
destructive and a parse failure is not evidence of a wedge. A real wedge still
gets caught by the existing checkpoint-error path.

Then run that check before every sync entry point (pull, push, write, exec) and
on connect, closing any open handle first so repair never unlinks a `-wal` the
engine is still holding.

## Verification

Against the 7 real replicas on this machine: the 2 genuinely unsatisfiable ones
(watermarks 8 and 4849, both against empty WALs) are flagged; the previously
misflagged healthy ones are left alone.

21 new tests, `tests/turso-replica-wal-frames.test.ts` and
`tests/turso-replica-sidecar-wedge.test.ts` — frame counting across missing /
truncated / bad-magic / implausible-page-size WALs, and the narrowed predicate
including the non-empty-WAL wedge that used to slip through.

## Behaviour change worth noting

`sidecarWedge` in `papr_db_sync_status` changes meaning. A wedge is now
self-healing on connect, so the field reports "still wedged after we tried"
rather than "needs a manual reset". Tool description and the affected test are
updated to match.

## Test plan

- [x] `tests/turso-replica-wal-frames.test.ts` (9)
- [x] `tests/turso-replica-sidecar-wedge.test.ts` (12)
- [x] `tests/turso-replica-checkpoint-recovery.test.ts` (6) — still green
- [x] `tsc -p tsconfig.gateway.json`, `oxlint` clean
- [ ] Soak on a machine that reproduced the abort

Follow-up: #134 removes the engine's ability to abort us at all, for the
next invariant we have not thought of.

Made with [Cursor](https://cursor.com)
