### PR TITLE
Run Turso replica sync in a worker process so an engine panic cannot kill the app

### DIFF
--- a/src/gateway/services/tursoReplica/TursoReplicaService.ts
+++ b/src/gateway/services/tursoReplica/TursoReplicaService.ts
@@ -21,7 +21,10 @@ import type {
 import {
   isTursoReplicaOnline,
   isTursoReplicaSyncFeatureEnabled,
+  isTursoSyncIsolationEnabled,
 } from "../../utils/tursoReplicaEnabled.js";
+import { runIsolatedReplicaSync } from "./tursoReplicaIsolatedSync.js";
+import { shutdownTursoReplicaSyncWorker } from "./TursoReplicaSyncWorkerClient.js";
 import {
   markTursoReplicaReachable,
   noteTursoReplicaTransportError,
@@ -243,6 +246,14 @@ export class TursoReplicaService {
       await this.withSerializedPath(localPath, async () => {
         if (isTursoReplicaOnline()) {
           await this.ensureSyncableSidecars(localPath, "push");
+          if (isTursoSyncIsolationEnabled()) {
+            await this.syncOutOfProcess(
+              localPath,
+              tursoDatabase,
+              options?.pullBeforePush === false ? "push" : "pullPush",
+            );
+            return;
+          }
         }
         const handle = await this.getOrOpen({
           localPath,
@@ -272,6 +283,9 @@ export class TursoReplicaService {
     return this.withSerializedPath(localPath, async () => {
       try {
         await this.ensureSyncableSidecars(localPath, "pull");
+        if (isTursoSyncIsolationEnabled()) {
+          return await this.syncOutOfProcess(localPath, tursoDatabase, "pull");
+        }
         const handle = await this.getOrOpen({
           localPath,
           tursoDatabase,
@@ -345,13 +359,25 @@ export class TursoReplicaService {
   }): Promise<import("../DbQueryPool.js").QueryResult> {
     return this.withSerializedPath(options.localPath, async () => {
       const executeRead = async (pullFirst: boolean) => {
+        const shouldPull = isTursoReplicaOnline() && pullFirst;
+        const isolated = isTursoSyncIsolationEnabled();
+
+        // Isolated sync has to run before we take a handle — the worker needs the files.
+        if (shouldPull && isolated) {
+          await this.syncOutOfProcess(
+            options.localPath,
+            options.tursoDatabase,
+            "pull",
+          );
+        }
+
         const handle = await this.getOrOpen({
           localPath: options.localPath,
           tursoDatabase: options.tursoDatabase,
           bootstrapIfEmpty: !fs.existsSync(options.localPath),
         });
 
-        if (isTursoReplicaOnline() && pullFirst) {
+        if (shouldPull && !isolated) {
           await withTimeout(
             handle.db.pull(),
             REPLICA_PULL_TIMEOUT_MS,
@@ -393,14 +419,9 @@ export class TursoReplicaService {
         }
 
         try {
-          const handle = await this.getOrOpen({
-            localPath: options.localPath,
-            tursoDatabase: options.tursoDatabase,
-            bootstrapIfEmpty: !fs.existsSync(options.localPath),
-          });
-          await withTimeout(
-            handle.db.pull(),
-            REPLICA_PULL_TIMEOUT_MS,
+          await this.pullForRecovery(
+            options.localPath,
+            options.tursoDatabase,
             "replica recovery pull",
           );
           await drainInboundReplicaCdcIfCaughtUp({
@@ -430,13 +451,20 @@ export class TursoReplicaService {
   ): Promise<import("../DbQueryPool.js").SchemaResult> {
     return this.withSerializedPath(localPath, async () => {
       const executeSchema = async (pullFirst: boolean) => {
+        const shouldPull = isTursoReplicaOnline() && pullFirst;
+        const isolated = isTursoSyncIsolationEnabled();
+
+        if (shouldPull && isolated) {
+          await this.syncOutOfProcess(localPath, tursoDatabase, "pull");
+        }
+
         const handle = await this.getOrOpen({
           localPath,
           tursoDatabase,
           bootstrapIfEmpty: !fs.existsSync(localPath),
         });
 
-        if (isTursoReplicaOnline() && pullFirst) {
+        if (shouldPull && !isolated) {
           await withTimeout(
             handle.db.pull(),
             REPLICA_PULL_TIMEOUT_MS,
@@ -488,14 +516,9 @@ export class TursoReplicaService {
           );
         }
         try {
-          const handle = await this.getOrOpen({
+          await this.pullForRecovery(
             localPath,
             tursoDatabase,
-            bootstrapIfEmpty: !fs.existsSync(localPath),
-          });
-          await withTimeout(
-            handle.db.pull(),
-            REPLICA_PULL_TIMEOUT_MS,
             "replica recovery pull",
           );
           return await executeSchema(false);
@@ -635,6 +658,11 @@ export class TursoReplicaService {
     tursoDatabase: string,
     handle: OpenReplicaHandle,
   ): Promise<void> {
+    if (isTursoSyncIsolationEnabled()) {
+      // Releases `handle` — callers must not use it after this point.
+      await this.syncOutOfProcess(localPath, tursoDatabase, "pullPush");
+      return;
+    }
     try {
       await this.pullAndPushReplica(handle);
     } catch (error) {
@@ -656,6 +684,11 @@ export class TursoReplicaService {
     tursoDatabase: string,
     handle: OpenReplicaHandle,
   ): Promise<void> {
+    if (isTursoSyncIsolationEnabled()) {
+      // Releases `handle` — callers must not use it after this point.
+      await this.syncOutOfProcess(localPath, tursoDatabase, "push");
+      return;
+    }
     try {
       await withTimeout(
         handle.db.push(),
@@ -705,6 +738,49 @@ export class TursoReplicaService {
         `${localPath} — ${describeReplicaSidecarWedge(report)}`,
     );
     return true;
+  }
+
+  /**
+   * Hand this replica's sync to the worker process.
+   *
+   * Our handle is closed first and deliberately not reopened: the worker owns the replica
+   * files for the duration, and the next read/write reopens lazily through getOrOpen(). Any
+   * handle the caller was holding is stale once this returns.
+   */
+  private async syncOutOfProcess(
+    localPath: string,
+    tursoDatabase: string,
+    op: "pull" | "push" | "pullPush",
+  ): Promise<boolean> {
+    await this.close(localPath);
+    const pulled = await runIsolatedReplicaSync({
+      op,
+      localPath,
+      tursoDatabase,
+    });
+    markTursoReplicaReachable();
+    return pulled;
+  }
+
+  /**
+   * Pull after a read wedge. Worth isolating: the replica just failed a read, so this is
+   * the pull most likely to hand the engine an inconsistent WAL.
+   */
+  private async pullForRecovery(
+    localPath: string,
+    tursoDatabase: string,
+    label: string,
+  ): Promise<void> {
+    if (isTursoSyncIsolationEnabled()) {
+      await this.syncOutOfProcess(localPath, tursoDatabase, "pull");
+      return;
+    }
+    const handle = await this.getOrOpen({
+      localPath,
+      tursoDatabase,
+      bootstrapIfEmpty: !fs.existsSync(localPath),
+    });
+    await withTimeout(handle.db.pull(), REPLICA_PULL_TIMEOUT_MS, label);
   }
 
   private async recoverSidecarsAfterCheckpointError(
@@ -848,6 +924,10 @@ export function getTursoReplicaService(): TursoReplicaService {
 
 /** Close all embedded replica handles (workspace switch, gateway shutdown). */
 export async function drainTursoReplicaConnections(context: string): Promise<void> {
+  // The worker can hold replica files while the parent holds none — under isolation that
+  // is the normal resting state — so stop it before the open-handle short-circuit below.
+  await shutdownTursoReplicaSyncWorker();
+
   if (!serviceInstance) {
     return;
   }

--- a/src/gateway/services/tursoReplica/TursoReplicaSyncWorkerClient.ts
+++ b/src/gateway/services/tursoReplica/TursoReplicaSyncWorkerClient.ts
@@ -1,0 +1,337 @@
+/**
+ * Parent-side driver for the out-of-process Turso sync worker.
+ *
+ * Owns one child process for the whole gateway. Requests run one at a time: the worker opens
+ * the replica, syncs, and closes it before replying, which keeps the "one sync engine per
+ * replica path" invariant even though two processes are involved.
+ *
+ * A native panic kills the child rather than the app. In-flight requests are rejected with
+ * {@link TursoSyncWorkerCrashError} so the caller can repair the replica and retry; the next
+ * request spawns a fresh worker.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  TursoSyncWorkerCrashError,
+  type TursoSyncWorkerOp,
+  type TursoSyncWorkerRequest,
+  type TursoSyncWorkerResponse,
+} from "./tursoReplicaSyncWorkerProtocol.js";
+
+const WORKER_BOOT_TIMEOUT_MS = 20_000;
+const STDERR_RING_BYTES = 4_000;
+/**
+ * An abort dumps a full native + JS stack across many chunks. Forward the first few for
+ * diagnosis and keep the rest in the ring buffer only, so one crash cannot flood the log.
+ */
+const STDERR_LOG_CHUNK_LIMIT = 5;
+
+export interface TursoSyncWorkerCommand {
+  command: string;
+  args: string[];
+}
+
+export interface RunSyncOptions {
+  op: TursoSyncWorkerOp;
+  localPath: string;
+  tursoUrl: string;
+  authToken: string;
+  clientName?: string;
+  bootstrapIfEmpty: boolean;
+  timeoutMs: number;
+}
+
+interface PendingRequest {
+  op: TursoSyncWorkerOp;
+  localPath: string;
+  resolve: (pulled: boolean) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+function defaultWorkerCommand(): TursoSyncWorkerCommand {
+  // The gateway always runs from dist/, so the compiled worker is a sibling of this module.
+  const entry = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "tursoReplicaSyncWorkerEntry.js",
+  );
+  // process.execPath is the Electron binary; ELECTRON_RUN_AS_NODE makes it a plain Node
+  // runtime with the same ABI the native module was built against.
+  return { command: process.execPath, args: [entry] };
+}
+
+export class TursoReplicaSyncWorkerClient {
+  private child: ChildProcess | null = null;
+  private booted: Promise<void> | null = null;
+  private stdoutBuffer = "";
+  private stderrRing = "";
+  private shuttingDown = false;
+  private readonly pending = new Map<string, PendingRequest>();
+
+  constructor(
+    private readonly resolveCommand: () => TursoSyncWorkerCommand = defaultWorkerCommand,
+  ) {}
+
+  async runSync(options: RunSyncOptions): Promise<boolean> {
+    await this.ensureBooted();
+    const child = this.child;
+    if (!child?.stdin?.writable) {
+      throw new Error("Turso sync worker is not writable");
+    }
+
+    const id = randomUUID();
+    const request: TursoSyncWorkerRequest = {
+      id,
+      op: options.op,
+      localPath: options.localPath,
+      tursoUrl: options.tursoUrl,
+      authToken: options.authToken,
+      clientName: options.clientName,
+      bootstrapIfEmpty: options.bootstrapIfEmpty,
+    };
+
+    return new Promise<boolean>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        // A wedged engine can hang instead of aborting; drop the worker so the next
+        // request starts clean rather than queueing behind it forever.
+        this.killChild("SIGKILL");
+        reject(
+          new Error(
+            `Turso sync worker ${options.op} timed out after ${options.timeoutMs}ms ` +
+              `on ${options.localPath}`,
+          ),
+        );
+      }, options.timeoutMs);
+
+      this.pending.set(id, {
+        op: options.op,
+        localPath: options.localPath,
+        resolve,
+        reject,
+        timer,
+      });
+
+      try {
+        child.stdin?.write(`${JSON.stringify(request)}\n`);
+      } catch (error) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    this.rejectAllPending(new Error("Turso sync worker shutting down"));
+    this.killChild("SIGTERM");
+    this.child = null;
+    this.booted = null;
+    this.shuttingDown = false;
+  }
+
+  isRunning(): boolean {
+    return this.child !== null && this.child.killed !== true;
+  }
+
+  private killChild(signal: NodeJS.Signals): void {
+    const child = this.child;
+    if (child && child.killed !== true) {
+      try {
+        child.kill(signal);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+
+  private ensureBooted(): Promise<void> {
+    if (this.booted) {
+      return this.booted;
+    }
+
+    this.booted = new Promise<void>((resolve, reject) => {
+      const { command, args } = this.resolveCommand();
+      const child = spawn(command, args, {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+      });
+      this.child = child;
+      this.stdoutBuffer = "";
+      this.stderrRing = "";
+
+      let settled = false;
+      const bootTimer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        this.killChild("SIGKILL");
+        reject(new Error("Turso sync worker boot timed out"));
+      }, WORKER_BOOT_TIMEOUT_MS);
+
+      const onReady = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(bootTimer);
+        resolve();
+      };
+
+      child.stdout?.on("data", (chunk: Buffer) => {
+        this.consumeStdout(chunk.toString("utf8"), onReady);
+      });
+
+      let stderrChunksLogged = 0;
+      child.stderr?.on("data", (chunk: Buffer) => {
+        const text = chunk.toString("utf8");
+        this.stderrRing = (this.stderrRing + text).slice(-STDERR_RING_BYTES);
+        if (text.trim().length === 0) {
+          return;
+        }
+        stderrChunksLogged += 1;
+        if (stderrChunksLogged <= STDERR_LOG_CHUNK_LIMIT) {
+          console.warn("[TursoSyncWorker]", text.trim().slice(0, 300));
+        } else if (stderrChunksLogged === STDERR_LOG_CHUNK_LIMIT + 1) {
+          console.warn(
+            "[TursoSyncWorker] further worker stderr suppressed; tail is included in the crash error",
+          );
+        }
+      });
+
+      child.on("error", (error) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(bootTimer);
+          reject(error);
+        }
+        this.handleChildGone(null, null);
+      });
+
+      child.on("close", (code, signal) => {
+        clearTimeout(bootTimer);
+        if (!settled) {
+          settled = true;
+          reject(
+            new Error(
+              `Turso sync worker exited during boot (code=${code}, signal=${signal})`,
+            ),
+          );
+        }
+        this.handleChildGone(code, signal);
+      });
+    }).catch((error: unknown) => {
+      this.child = null;
+      this.booted = null;
+      throw error;
+    });
+
+    return this.booted;
+  }
+
+  private consumeStdout(text: string, onReady: () => void): void {
+    this.stdoutBuffer += text;
+    let newlineIndex = this.stdoutBuffer.indexOf("\n");
+    while (newlineIndex >= 0) {
+      const line = this.stdoutBuffer.slice(0, newlineIndex).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      if (line.length > 0) {
+        this.dispatchLine(line, onReady);
+      }
+      newlineIndex = this.stdoutBuffer.indexOf("\n");
+    }
+  }
+
+  private dispatchLine(line: string, onReady: () => void): void {
+    let parsed: (TursoSyncWorkerResponse & { ready?: boolean }) | null = null;
+    try {
+      parsed = JSON.parse(line) as TursoSyncWorkerResponse & {
+        ready?: boolean;
+      };
+    } catch {
+      // Anything the SDK prints on stdout would land here; ignore rather than desync.
+      return;
+    }
+
+    if (parsed?.ready === true) {
+      onReady();
+      return;
+    }
+
+    const id = typeof parsed?.id === "string" ? parsed.id : null;
+    if (!id) {
+      return;
+    }
+    const pending = this.pending.get(id);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timer);
+    this.pending.delete(id);
+
+    if (parsed.ok === true) {
+      pending.resolve(Boolean(parsed.pulled));
+    } else {
+      pending.reject(new Error(parsed.error || "Turso sync worker error"));
+    }
+  }
+
+  /**
+   * The child is gone. Anything still in flight died with it — surface that as a crash so
+   * callers can distinguish "the engine aborted" from "sync returned an error".
+   */
+  private handleChildGone(
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): void {
+    this.child = null;
+    this.booted = null;
+    this.stdoutBuffer = "";
+
+    if (this.shuttingDown || this.pending.size === 0) {
+      this.pending.clear();
+      return;
+    }
+
+    const stderr = this.stderrRing;
+    for (const [id, pending] of this.pending.entries()) {
+      clearTimeout(pending.timer);
+      this.pending.delete(id);
+      pending.reject(
+        new TursoSyncWorkerCrashError({
+          op: pending.op,
+          localPath: pending.localPath,
+          exitCode: code,
+          signal,
+          stderr,
+        }),
+      );
+    }
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const [id, pending] of this.pending.entries()) {
+      clearTimeout(pending.timer);
+      this.pending.delete(id);
+      pending.reject(error);
+    }
+  }
+}
+
+let clientInstance: TursoReplicaSyncWorkerClient | null = null;
+
+export function getTursoReplicaSyncWorkerClient(): TursoReplicaSyncWorkerClient {
+  if (!clientInstance) {
+    clientInstance = new TursoReplicaSyncWorkerClient();
+  }
+  return clientInstance;
+}
+
+export async function shutdownTursoReplicaSyncWorker(): Promise<void> {
+  if (!clientInstance) {
+    return;
+  }
+  await clientInstance.shutdown();
+  clientInstance = null;
+}

--- a/src/gateway/services/tursoReplica/tursoReplicaIsolatedSync.ts
+++ b/src/gateway/services/tursoReplica/tursoReplicaIsolatedSync.ts
@@ -1,0 +1,71 @@
+/**
+ * Sync a replica through the out-of-process worker.
+ *
+ * The caller must have released its own handle on `localPath` first — the worker opens the
+ * same files, and two sync engines on one replica corrupt its WAL state.
+ */
+
+import * as fs from "fs";
+import { ensureTursoSyncBridge } from "../TursoSyncBridge.js";
+import { getTursoReplicaSyncWorkerClient } from "./TursoReplicaSyncWorkerClient.js";
+import {
+  isTursoSyncWorkerCrash,
+  type TursoSyncWorkerOp,
+} from "./tursoReplicaSyncWorkerProtocol.js";
+import { resetReplicaSidecars } from "./tursoReplicaSidecarWedge.js";
+
+const ISOLATED_SYNC_TIMEOUT_MS = 30_000;
+
+export interface IsolatedReplicaSyncOptions {
+  op: TursoSyncWorkerOp;
+  localPath: string;
+  tursoDatabase: string;
+}
+
+/**
+ * Returns the result of pull() (false for push-only ops).
+ *
+ * If the worker is killed by the engine, the replica is left in whatever state caused the
+ * abort — so reset its sidecars and retry once against a clean bootstrap before giving up.
+ * A second crash is reported as a normal error: the gateway stays up either way.
+ */
+export async function runIsolatedReplicaSync(
+  options: IsolatedReplicaSyncOptions,
+): Promise<boolean> {
+  const bridge = ensureTursoSyncBridge();
+  if (!bridge.enabled) {
+    throw new Error("Turso sync bridge not available — sign in to Papr");
+  }
+
+  const client = getTursoReplicaSyncWorkerClient();
+
+  const send = async (): Promise<boolean> => {
+    const localReplicaExists = fs.existsSync(options.localPath);
+    const creds = await bridge.resolveCredentialsForReplicaOpen(
+      options.tursoDatabase,
+      { localReplicaExists },
+    );
+    return client.runSync({
+      op: options.op,
+      localPath: options.localPath,
+      tursoUrl: creds.tursoUrl,
+      authToken: creds.authToken,
+      bootstrapIfEmpty: !localReplicaExists,
+      timeoutMs: ISOLATED_SYNC_TIMEOUT_MS,
+    });
+  };
+
+  try {
+    return await send();
+  } catch (error) {
+    if (!isTursoSyncWorkerCrash(error)) {
+      throw error;
+    }
+    console.warn(
+      `[TursoReplica] Sync worker aborted during ${options.op} on ${options.localPath} — ` +
+        `resetting sidecars and retrying once. ${(error as Error).message}`,
+    );
+    resetReplicaSidecars(options.localPath);
+    return await send();
+  }
+}

--- a/src/gateway/services/tursoReplica/tursoReplicaSyncWorkerEntry.ts
+++ b/src/gateway/services/tursoReplica/tursoReplicaSyncWorkerEntry.ts
@@ -1,0 +1,131 @@
+/**
+ * Child-process host for @tursodatabase/sync pull/push.
+ *
+ * Runs one request at a time, opening the replica and closing it again before replying, so
+ * exactly one process ever holds a sync engine for a given path. If the engine panics, only
+ * this process dies — the parent sees a crash exit and can repair and retry.
+ *
+ * stdout carries protocol JSON and nothing else; diagnostics go to stderr.
+ */
+
+import * as readline from "node:readline";
+import { connectTursoReplica } from "./tursoReplicaConnect.js";
+import type {
+  TursoSyncWorkerRequest,
+  TursoSyncWorkerResponse,
+} from "./tursoReplicaSyncWorkerProtocol.js";
+
+function reply(response: TursoSyncWorkerResponse): void {
+  process.stdout.write(`${JSON.stringify(response)}\n`);
+}
+
+function isSyncWorkerRequest(value: unknown): value is TursoSyncWorkerRequest {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.localPath === "string" &&
+    typeof candidate.tursoUrl === "string" &&
+    typeof candidate.authToken === "string" &&
+    (candidate.op === "pull" ||
+      candidate.op === "push" ||
+      candidate.op === "pullPush")
+  );
+}
+
+async function handleRequest(
+  request: TursoSyncWorkerRequest,
+): Promise<TursoSyncWorkerResponse> {
+  let db: Awaited<ReturnType<typeof connectTursoReplica>> | null = null;
+  try {
+    db = await connectTursoReplica({
+      localPath: request.localPath,
+      tursoUrl: request.tursoUrl,
+      authToken: request.authToken,
+      bootstrapIfEmpty: request.bootstrapIfEmpty,
+      clientName: request.clientName,
+    });
+
+    let pulled = false;
+    if (request.op === "pull" || request.op === "pullPush") {
+      pulled = Boolean(await db.pull());
+    }
+    if (request.op === "push" || request.op === "pullPush") {
+      await db.push();
+    }
+
+    return { id: request.id, ok: true, pulled };
+  } catch (error) {
+    return {
+      id: request.id,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    // Release the files before replying — the parent reopens as soon as it sees the response.
+    try {
+      await db?.close();
+    } catch (closeError) {
+      process.stderr.write(
+        `[TursoSyncWorker] close failed: ${String(closeError)}\n`,
+      );
+    }
+  }
+}
+
+/**
+ * Runs tasks one at a time in arrival order.
+ *
+ * Overlapping engines on a single replica is the thing we must never do, and the parent
+ * cannot see this queue, so ordering is enforced here.
+ */
+class SerialQueue {
+  private tail: Promise<void> = Promise.resolve();
+
+  push(task: () => Promise<void>): void {
+    this.tail = this.tail.then(task).catch((error: unknown) => {
+      // Never let a task rejection become an unhandled rejection that kills the worker.
+      process.stderr.write(`[TursoSyncWorker] task failed: ${String(error)}\n`);
+    });
+  }
+}
+
+function main(): void {
+  const rl = readline.createInterface({ input: process.stdin });
+  const queue = new SerialQueue();
+
+  rl.on("line", (line) => {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      process.stderr.write("[TursoSyncWorker] ignoring malformed request\n");
+      return;
+    }
+
+    if (!isSyncWorkerRequest(parsed)) {
+      process.stderr.write("[TursoSyncWorker] ignoring unrecognized request\n");
+      return;
+    }
+
+    const request = parsed;
+    queue.push(async () => {
+      reply(await handleRequest(request));
+    });
+  });
+
+  rl.on("close", () => {
+    process.exit(0);
+  });
+
+  process.stdout.write(`${JSON.stringify({ ready: true })}\n`);
+}
+
+main();

--- a/src/gateway/services/tursoReplica/tursoReplicaSyncWorkerProtocol.ts
+++ b/src/gateway/services/tursoReplica/tursoReplicaSyncWorkerProtocol.ts
@@ -1,0 +1,91 @@
+/**
+ * Wire protocol between the gateway and the out-of-process Turso sync worker.
+ *
+ * Newline-delimited JSON over stdin/stdout. Kept in its own module so the parent
+ * and the child agree on the shape without the parent importing anything that
+ * pulls in the native sync engine.
+ */
+
+export type TursoSyncWorkerOp = "pull" | "push" | "pullPush";
+
+export interface TursoSyncWorkerRequest {
+  id: string;
+  op: TursoSyncWorkerOp;
+  localPath: string;
+  tursoUrl: string;
+  authToken: string;
+  clientName?: string;
+  /** Passed through to connect(); false keeps an existing local file authoritative. */
+  bootstrapIfEmpty: boolean;
+}
+
+export interface TursoSyncWorkerOkResponse {
+  id: string;
+  ok: true;
+  /** Result of pull(); false for push-only operations. */
+  pulled: boolean;
+}
+
+export interface TursoSyncWorkerErrorResponse {
+  id: string;
+  ok: false;
+  error: string;
+}
+
+export type TursoSyncWorkerResponse =
+  | TursoSyncWorkerOkResponse
+  | TursoSyncWorkerErrorResponse;
+
+/** First line the worker emits once it can accept requests. */
+export interface TursoSyncWorkerReady {
+  ready: true;
+}
+
+/**
+ * The worker process died mid-request.
+ *
+ * This is the case the worker exists for: a Rust `panic!` in the sync engine aborts
+ * whatever process hosts it. Out-of-process that is a recoverable child crash; in-process
+ * it was the gateway going down with the app.
+ */
+export class TursoSyncWorkerCrashError extends Error {
+  readonly exitCode: number | null;
+  readonly signal: NodeJS.Signals | null;
+
+  constructor(options: {
+    op: TursoSyncWorkerOp;
+    localPath: string;
+    exitCode: number | null;
+    signal: NodeJS.Signals | null;
+    stderr?: string;
+  }) {
+    const how =
+      options.signal !== null
+        ? `signal ${options.signal}`
+        : `exit code ${options.exitCode}`;
+    const tail = options.stderr?.trim().slice(-400);
+    super(
+      `Turso sync worker crashed during ${options.op} on ${options.localPath} (${how})` +
+        (tail ? `: ${tail}` : ""),
+    );
+    this.name = "TursoSyncWorkerCrashError";
+    this.exitCode = options.exitCode;
+    this.signal = options.signal;
+  }
+}
+
+export function isTursoSyncWorkerCrash(
+  error: unknown,
+): error is TursoSyncWorkerCrashError {
+  if (error instanceof TursoSyncWorkerCrashError) {
+    return true;
+  }
+  // instanceof breaks when this module is loaded twice (bundle duplication, test module
+  // resets). Getting this wrong silently downgrades a crash to an ordinary error and skips
+  // recovery, so fall back to the name the constructor brands.
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { name?: unknown }).name === "TursoSyncWorkerCrashError"
+  );
+}

--- a/src/gateway/utils/tursoReplicaEnabled.ts
+++ b/src/gateway/utils/tursoReplicaEnabled.ts
@@ -28,6 +28,19 @@ export function isTursoReplicaSyncFeatureEnabled(): boolean {
   return tursoReplicaRolloutMode() !== "off";
 }
 
+/**
+ * Run pull()/push() in a child process so a panic in the native sync engine cannot abort
+ * the gateway along with the app.
+ *
+ * Opt-in. Isolation is not free: the parent has to release the replica while the worker
+ * holds it, so each sync costs an extra connect. Default off until a canary build confirms
+ * the added latency is acceptable on the write path.
+ */
+export function isTursoSyncIsolationEnabled(): boolean {
+  const raw = process.env.PAPR_TURSO_SYNC_ISOLATION?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "on";
+}
+
 /** Phase 1: online when cloud sync is on unless tests force offline. */
 let replicaOnlineOverride: boolean | null = null;
 

--- a/tests/turso-replica-isolated-sync.test.ts
+++ b/tests/turso-replica-isolated-sync.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { tursoReplicaBridgeMock } from "./helpers/tursoReplicaBridgeMock.js";
+import { TursoSyncWorkerCrashError } from "../src/gateway/services/tursoReplica/tursoReplicaSyncWorkerProtocol.js";
+
+const LOCAL_PATH = "/tmp/papr-isolated-sync/data.db";
+
+function abortCrash(): TursoSyncWorkerCrashError {
+  return new TursoSyncWorkerCrashError({
+    op: "pull",
+    localPath: LOCAL_PATH,
+    exitCode: null,
+    signal: "SIGABRT",
+  });
+}
+
+async function loadWithMocks(runSync: ReturnType<typeof vi.fn>): Promise<{
+  runIsolatedReplicaSync: typeof import("../src/gateway/services/tursoReplica/tursoReplicaIsolatedSync.js").runIsolatedReplicaSync;
+  resetReplicaSidecars: ReturnType<typeof vi.fn>;
+}> {
+  const resetReplicaSidecars = vi.fn();
+
+  vi.doMock(
+    "../src/gateway/services/TursoSyncBridge.js",
+    () => tursoReplicaBridgeMock(),
+  );
+  vi.doMock(
+    "../src/gateway/services/tursoReplica/TursoReplicaSyncWorkerClient.js",
+    () => ({ getTursoReplicaSyncWorkerClient: () => ({ runSync }) }),
+  );
+  vi.doMock(
+    "../src/gateway/services/tursoReplica/tursoReplicaSidecarWedge.js",
+    () => ({ resetReplicaSidecars }),
+  );
+
+  const { runIsolatedReplicaSync } = await import(
+    "../src/gateway/services/tursoReplica/tursoReplicaIsolatedSync.js"
+  );
+  return { runIsolatedReplicaSync, resetReplicaSidecars };
+}
+
+describe("runIsolatedReplicaSync", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("resets sidecars and retries once after the worker aborts", async () => {
+    const runSync = vi
+      .fn()
+      .mockRejectedValueOnce(abortCrash())
+      .mockResolvedValueOnce(true);
+
+    const { runIsolatedReplicaSync, resetReplicaSidecars } =
+      await loadWithMocks(runSync);
+
+    await expect(
+      runIsolatedReplicaSync({
+        op: "pull",
+        localPath: LOCAL_PATH,
+        tursoDatabase: "d-abc12345",
+      }),
+    ).resolves.toBe(true);
+
+    // The replica caused an abort, so it must be reset before it is handed back to an engine.
+    expect(resetReplicaSidecars).toHaveBeenCalledWith(LOCAL_PATH);
+    expect(runSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves sidecars alone when sync merely returns an error", async () => {
+    const runSync = vi
+      .fn()
+      .mockRejectedValue(new Error("remote rejected push: conflict"));
+
+    const { runIsolatedReplicaSync, resetReplicaSidecars } =
+      await loadWithMocks(runSync);
+
+    await expect(
+      runIsolatedReplicaSync({
+        op: "push",
+        localPath: LOCAL_PATH,
+        tursoDatabase: "d-abc12345",
+      }),
+    ).rejects.toThrow("remote rejected push");
+
+    // Resetting sidecars discards local WAL state — never do it for an ordinary failure.
+    expect(resetReplicaSidecars).not.toHaveBeenCalled();
+    expect(runSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops after a second crash instead of looping", async () => {
+    const runSync = vi.fn().mockRejectedValue(abortCrash());
+
+    const { runIsolatedReplicaSync, resetReplicaSidecars } =
+      await loadWithMocks(runSync);
+
+    await expect(
+      runIsolatedReplicaSync({
+        op: "pull",
+        localPath: LOCAL_PATH,
+        tursoDatabase: "d-abc12345",
+      }),
+    ).rejects.toThrow(/crashed during pull/);
+
+    expect(resetReplicaSidecars).toHaveBeenCalledTimes(1);
+    expect(runSync).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/turso-replica-sync-worker-client.test.ts
+++ b/tests/turso-replica-sync-worker-client.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { TursoReplicaSyncWorkerClient } from "../src/gateway/services/tursoReplica/TursoReplicaSyncWorkerClient.js";
+import { isTursoSyncWorkerCrash } from "../src/gateway/services/tursoReplica/tursoReplicaSyncWorkerProtocol.js";
+
+/**
+ * Stand-in workers. Each is a one-liner run by the same Node binary as the test, so the
+ * client is exercised against a real child process, real pipes and real exit signals —
+ * only the sync engine is faked.
+ */
+function fakeWorker(body: string): () => { command: string; args: string[] } {
+  const script = `
+    const readline = require("node:readline");
+    const rl = readline.createInterface({ input: process.stdin });
+    const reply = (o) => process.stdout.write(JSON.stringify(o) + "\\n");
+    rl.on("line", (line) => {
+      const req = JSON.parse(line);
+      ${body}
+    });
+    process.stdout.write(JSON.stringify({ ready: true }) + "\\n");
+  `;
+  return () => ({ command: process.execPath, args: ["-e", script] });
+}
+
+const REQUEST = {
+  op: "pull" as const,
+  localPath: "/tmp/does-not-need-to-exist/data.db",
+  tursoUrl: "libsql://example.turso.io",
+  authToken: "token",
+  bootstrapIfEmpty: false,
+  timeoutMs: 10_000,
+};
+
+describe("TursoReplicaSyncWorkerClient", () => {
+  it("resolves with the worker's pull result", async () => {
+    const client = new TursoReplicaSyncWorkerClient(
+      fakeWorker(`reply({ id: req.id, ok: true, pulled: true });`),
+    );
+
+    await expect(client.runSync(REQUEST)).resolves.toBe(true);
+    await client.shutdown();
+  });
+
+  it("surfaces a worker-reported failure as a plain error, not a crash", async () => {
+    const client = new TursoReplicaSyncWorkerClient(
+      fakeWorker(`reply({ id: req.id, ok: false, error: "remote rejected push" });`),
+    );
+
+    // This distinction drives recovery: a returned error must not trigger a sidecar reset.
+    await expect(client.runSync(REQUEST)).rejects.toThrow("remote rejected push");
+    await expect(client.runSync(REQUEST)).rejects.toSatisfy(
+      (error: unknown) => !isTursoSyncWorkerCrash(error),
+    );
+    await client.shutdown();
+  });
+
+  it("reports a native abort as a crash rather than hanging", async () => {
+    // process.abort() raises SIGABRT — the same way a Rust panic in the engine ends up.
+    const client = new TursoReplicaSyncWorkerClient(
+      fakeWorker(`process.abort();`),
+    );
+
+    const error = await client.runSync(REQUEST).catch((e: unknown) => e);
+
+    expect(isTursoSyncWorkerCrash(error)).toBe(true);
+    expect((error as Error).message).toContain("crashed during pull");
+    await client.shutdown();
+  });
+
+  it("recovers by spawning a fresh worker after a crash", async () => {
+    let spawnCount = 0;
+    const crashOnce = fakeWorker(`process.abort();`);
+    const healthy = fakeWorker(`reply({ id: req.id, ok: true, pulled: true });`);
+
+    const client = new TursoReplicaSyncWorkerClient(() => {
+      spawnCount += 1;
+      return spawnCount === 1 ? crashOnce() : healthy();
+    });
+
+    await expect(client.runSync(REQUEST)).rejects.toThrow(/crashed/);
+    // The retry must not be stuck talking to the dead child.
+    await expect(client.runSync(REQUEST)).resolves.toBe(true);
+    expect(spawnCount).toBe(2);
+
+    await client.shutdown();
+  });
+
+  it("times out and drops a worker that never replies", async () => {
+    const client = new TursoReplicaSyncWorkerClient(
+      fakeWorker(`/* swallow the request */`),
+    );
+
+    await expect(
+      client.runSync({ ...REQUEST, timeoutMs: 150 }),
+    ).rejects.toThrow(/timed out after 150ms/);
+
+    // A hung engine must not leave the worker holding the replica forever.
+    expect(client.isRunning()).toBe(false);
+    await client.shutdown();
+  });
+
+  it("ignores non-protocol stdout instead of desyncing", async () => {
+    const client = new TursoReplicaSyncWorkerClient(
+      fakeWorker(`
+        process.stdout.write("native engine chatter\\n");
+        process.stdout.write("{not json\\n");
+        reply({ id: req.id, ok: true, pulled: false });
+      `),
+    );
+
+    await expect(client.runSync(REQUEST)).resolves.toBe(false);
+    await client.shutdown();
+  });
+
+  it("rejects in-flight requests on shutdown without reporting a crash", async () => {
+    const client = new TursoReplicaSyncWorkerClient(
+      fakeWorker(`/* never replies */`),
+    );
+
+    const inflight = client.runSync(REQUEST).catch((e: unknown) => e);
+    // Let the request reach the worker before tearing it down.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await client.shutdown();
+
+    const error = await inflight;
+    expect(isTursoSyncWorkerCrash(error)).toBe(false);
+    expect((error as Error).message).toContain("shutting down");
+  });
+});


### PR DESCRIPTION
> **Stacked on #133.** Base is
> `fix/turso-replica-watermark-wedge-detection`, so this diff shows only the
> isolation work. Merge #133 first and this retargets to `master`.

## Why

#133 removes the *known* trigger for the `SIGABRT` in the native sync engine.
This PR addresses the structural problem underneath it: **a `panic!` in the
engine aborts whichever process hosts it, and today that is the gateway.** One
bad replica takes the whole app down mid-session, with no JS error to catch. The
next unsatisfiable invariant we have not thought of will find that same path.

## What

Move `pull()`/`push()` into a child process.

The worker opens the replica, syncs, and closes it before replying, so **exactly
one sync engine ever holds a given replica** even though two processes are
involved — the parent releases its handle before delegating and reopens lazily
afterwards. Two engines on one replica would corrupt its WAL state, so this
invariant is the thing to check hardest in review.

A crash now rejects the in-flight request as `TursoSyncWorkerCrashError` instead
of ending the process. The caller resets that replica's sidecars and retries once
against a clean bootstrap. A second crash surfaces as an ordinary error: sync
fails, the app lives.

Covers every path that reaches the engine — `pull`, `push`, the write/exec sync,
pull-before-read on queries and schema reads, and the post-wedge recovery pull.
That last one is the pull *most* likely to abort, since the replica has already
failed a read by then.

## Default off, deliberately

Behind `PAPR_TURSO_SYNC_ISOLATION`, **default off**.

Isolation is not free: the parent must release the replica while the worker holds
it, so every sync costs an extra connect, and that lands on the write path. I did
not want to hand you an unmeasured latency regression on every write in order to
fix a crash that #133 already prevents at the source.

Suggested sequencing: enable in a canary build, measure the write path, then flip
the default.

```bash
PAPR_TURSO_SYNC_ISOLATION=1 npm start
```

## Review notes

- **stdout is protocol-only.** Anything the SDK prints there is ignored rather
  than allowed to desync the stream. Worker stderr is forwarded to the log capped
  at a few chunks, because an abort dumps a full native stack.
- **Requests are queued serially in the worker.** The parent already serializes
  per path; this also serializes *across* paths. That is the conservative choice
  and the first thing to revisit if throughput matters.
- **Hung is handled separately from crashed.** A wedged engine can hang rather
  than abort, so requests time out and the worker is killed — it cannot sit on
  the replica indefinitely.
- **`drainTursoReplicaConnections` stops the worker before its open-handle
  short-circuit.** Under isolation the parent normally holds zero handles while
  the worker still has the files, so the old early return would have leaked the
  worker across workspace switches and shutdown.
- **`isTursoSyncWorkerCrash` falls back to a name brand, not just `instanceof`.**
  A duplicated module copy would otherwise silently downgrade a crash to an
  ordinary error and skip recovery. This is not hypothetical — it showed up under
  `vi.resetModules()` while writing the tests.
- **No `electron-builder.json` change needed.** `tsc` emits the worker as a
  sibling of its client and `dist/**/*` is already packaged; I verified the
  compiled worker boots and handshakes from `dist/`.

## Test plan

- [x] `tests/turso-replica-sync-worker-client.test.ts` (7) — crash detection,
      respawn, timeout, protocol desync, shutdown. Crashes are a **real child
      process killed with `SIGABRT` via `process.abort()`**, not a mocked
      rejection, so this exercises the actual pipe and exit-signal handling.
- [x] `tests/turso-replica-isolated-sync.test.ts` (3) — reset-and-retry-once on
      crash, no reset for an ordinary sync error, and no retry loop on a second
      crash.
- [x] Compiled worker boots from `dist/` and emits its handshake
- [x] `tsc -p tsconfig.gateway.json`, `oxlint` clean; 37 replica tests green
- [ ] Canary with `PAPR_TURSO_SYNC_ISOLATION=1` and measure write-path latency
- [ ] Confirm the app survives a forced abort where it previously died

Made with [Cursor](https://cursor.com)