### PR TITLE
fix(supervisor): stop the gateway supervisor from SIGKILLing its own process

### DIFF
--- a/src/electron/index.cjs
+++ b/src/electron/index.cjs
@@ -1134,6 +1134,7 @@ const {
   shouldKillUnhealthyGateway,
   parseGatewaySyncBusyState,
   isGatewaySyncBusyGraceActive,
+  selectOrphanPidsToKill,
   isValidTransition,
 } = require("./supervisor-logic.cjs");
 
@@ -1241,64 +1242,96 @@ class GatewayProcessSupervisor {
     this._transitionTo("stopped");
   }
 
+  /** PIDs we must never SIGKILL while clearing the port. */
+  _protectedPids() {
+    return [process.pid, process.ppid, this.process?.pid].filter(Boolean);
+  }
+
+  /** Listening PIDs on the gateway port. Listeners only — a client socket is not an orphan. */
+  _findPortListeners() {
+    try {
+      if (process.platform === "win32") {
+        const output = execSync(`netstat -ano | findstr :${this.port}`, {
+          encoding: "utf8",
+          timeout: 5000,
+        });
+        // findstr matches any state; keep only LISTENING rows.
+        const listening = output
+          .split(/\r?\n/)
+          .map((line) => line.match(/LISTENING\s+(\d+)/))
+          .filter(Boolean)
+          .map((match) => match[1])
+          .join("\n");
+        return selectOrphanPidsToKill(listening, this._protectedPids());
+      }
+      const output = execSync(`lsof -ti:${this.port} -sTCP:LISTEN`, {
+        encoding: "utf8",
+        timeout: 5000,
+      });
+      return selectOrphanPidsToKill(output, this._protectedPids());
+    } catch {
+      // Non-zero exit means nothing matched — that is the healthy case.
+      return [];
+    }
+  }
+
   _killOrphans() {
     try {
       console.log("[Supervisor] Checking for orphaned Gateway processes...");
-      
-      if (process.platform === "win32") {
-        // Windows: Use netstat to find PIDs listening on the port
+
+      const pids = this._findPortListeners();
+      if (pids.length === 0) {
+        return;
+      }
+
+      console.log(
+        `[Supervisor] Found ${pids.length} orphaned listener(s) on port ${this.port}: ${pids.join(", ")}`,
+      );
+
+      for (const pid of pids) {
         try {
-          const output = execSync(`netstat -ano | findstr :${this.port}`, {
-            encoding: "utf8",
-            timeout: 5000,
-          });
-          
-          const lines = output.trim().split("\n");
-          for (const line of lines) {
-            const match = line.match(/LISTENING\s+(\d+)/);
-            if (match) {
-              const pid = match[1];
-              console.log(`[Supervisor] Found orphaned process ${pid} on port ${this.port}`);
-              execSync(`taskkill /PID ${pid} /F`, { timeout: 5000 });
-              // Brief delay for cleanup
-              const start = Date.now();
-              while (Date.now() - start < 500) {
-                // Busy wait
-              }
-              console.log("[Supervisor] Orphaned process killed");
-            }
+          if (process.platform === "win32") {
+            execSync(`taskkill /PID ${pid} /F`, { timeout: 5000 });
+          } else {
+            execSync(`kill -9 ${pid}`, { timeout: 5000 });
           }
-        } catch (e) {
-          // No process on port or command failed — good
-        }
-      } else {
-        // Unix (macOS, Linux): Use lsof
-        try {
-          const output = execSync(`lsof -ti:${this.port}`, { encoding: "utf8" }).trim();
-          if (output) {
-            // Split by newline to handle multiple PIDs
-            const pids = output.split('\n').filter(p => p.trim());
-            console.log(`[Supervisor] Found ${pids.length} orphaned process(es) on port ${this.port}: ${pids.join(', ')}`);
-            
-            // Kill each PID individually
-            for (const pid of pids) {
-              try {
-                execSync(`kill -9 ${pid.trim()}`);
-                console.log(`[Supervisor] Killed orphaned process ${pid}`);
-              } catch (killErr) {
-                console.warn(`[Supervisor] Failed to kill PID ${pid}:`, killErr.message);
-              }
-            }
-            
-            execSync("sleep 0.5");
-            console.log("[Supervisor] Orphaned processes cleanup complete");
-          }
-        } catch (e) {
-          // No process on port — good
+          console.log(`[Supervisor] Killed orphaned process ${pid}`);
+        } catch (killErr) {
+          console.warn(`[Supervisor] Failed to kill PID ${pid}:`, killErr.message);
         }
       }
+
+      // Spawning before the port is actually released just trades a self-kill for
+      // an EADDRINUSE crash loop, so confirm it drained before returning.
+      const freed = this._waitForPortFree();
+      console.log(
+        freed
+          ? "[Supervisor] Orphaned processes cleanup complete"
+          : `[Supervisor] Port ${this.port} still held after cleanup — spawning anyway`,
+      );
     } catch (error) {
       console.warn("[Supervisor] Cleanup warning:", error.message);
+    }
+  }
+
+  /** Poll until no listener holds the port. Bounded so startup can never hang here. */
+  _waitForPortFree(timeoutMs = 2000, intervalMs = 150) {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      if (this._findPortListeners().length === 0) {
+        return true;
+      }
+      if (Date.now() + intervalMs >= deadline) {
+        return false;
+      }
+      // _killOrphans is synchronous and runs before spawn, so block the thread
+      // rather than spinning it — SIGKILL'd sockets usually drain in one tick.
+      Atomics.wait(
+        new Int32Array(new SharedArrayBuffer(4)),
+        0,
+        0,
+        intervalMs,
+      );
     }
   }
 

--- a/src/electron/supervisor-logic.cjs
+++ b/src/electron/supervisor-logic.cjs
@@ -108,6 +108,40 @@ function isGatewaySyncBusyGraceActive(
   return age >= 0 && age < maxAgeMs;
 }
 
+/**
+ * Pick which PIDs reported on the gateway port are safe to SIGKILL.
+ *
+ * `lsof -ti:PORT` reports every socket on the port, including *outbound client*
+ * connections. The Electron main process POSTs to the gateway while starting up,
+ * so when an orphaned gateway is answering on the port that POST connects and
+ * main's own PID joins the list. The supervisor then SIGKILLs itself ~0.6s into
+ * launch and the app never loads. Without an orphan the POST is refused, no
+ * socket exists, and the bug stays invisible — so filter here as well as passing
+ * `-sTCP:LISTEN`, and never return a PID we depend on.
+ */
+function selectOrphanPidsToKill(rawOutput, protectedPids = []) {
+  if (typeof rawOutput !== "string") {
+    return [];
+  }
+  const protectedSet = new Set(
+    protectedPids
+      .map((pid) => Number.parseInt(String(pid), 10))
+      .filter((pid) => Number.isInteger(pid) && pid > 0),
+  );
+
+  const seen = new Set();
+  const result = [];
+  for (const line of rawOutput.split(/\r?\n/)) {
+    const pid = Number.parseInt(line.trim(), 10);
+    // Drop blank lines, non-numeric noise, and pid 0 (kernel / whole process group).
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    if (protectedSet.has(pid) || seen.has(pid)) continue;
+    seen.add(pid);
+    result.push(pid);
+  }
+  return result;
+}
+
 const VALID_STATE_TRANSITIONS = {
   stopped: ["starting"],
   starting: ["running", "backoff", "stopped"],
@@ -130,6 +164,7 @@ module.exports = {
   shouldKillUnhealthyGateway,
   parseGatewaySyncBusyState,
   isGatewaySyncBusyGraceActive,
+  selectOrphanPidsToKill,
   isValidTransition,
   VALID_STATE_TRANSITIONS,
 };

--- a/tests/gateway-supervisor.test.ts
+++ b/tests/gateway-supervisor.test.ts
@@ -22,6 +22,7 @@ const {
   shouldKillUnhealthyGateway,
   parseGatewaySyncBusyState,
   isGatewaySyncBusyGraceActive,
+  selectOrphanPidsToKill,
   isValidTransition,
   VALID_STATE_TRANSITIONS,
 } = require("../src/electron/supervisor-logic.cjs");
@@ -321,6 +322,65 @@ describe("parseHealthResponse", () => {
       alive: false,
       ready: false,
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Orphan PID selection
+//
+// A Turso SIGABRT leaves the gateway orphaned on port 18789 still answering
+// /health. On the next launch the Electron main process POSTs to that port, the
+// socket connects, and unfiltered `lsof -ti:PORT` reports main's own PID beside
+// the orphan's. The supervisor then SIGKILLed itself ~0.6s into startup and the
+// app never loaded — reproduced with a detached squatter, which yielded exactly
+// "Found 2 orphaned process(es) on port 18789: 25799, 26221" (25799 = orphan,
+// 26221 = the app) followed by silence.
+// ---------------------------------------------------------------------------
+describe("selectOrphanPidsToKill", () => {
+  test("regression: never returns our own PID alongside a real orphan", () => {
+    const lsofOutput = "25799\n26221\n";
+    expect(selectOrphanPidsToKill(lsofOutput, [26221])).toEqual([25799]);
+  });
+
+  test("protects the parent PID too", () => {
+    expect(selectOrphanPidsToKill("111\n222\n333\n", [222, 333])).toEqual([111]);
+  });
+
+  test("returns a lone orphan", () => {
+    expect(selectOrphanPidsToKill("6036\n", [999])).toEqual([6036]);
+  });
+
+  test("no listeners yields nothing to kill", () => {
+    expect(selectOrphanPidsToKill("", [123])).toEqual([]);
+    expect(selectOrphanPidsToKill("   \n\n", [123])).toEqual([]);
+  });
+
+  test("everything protected yields nothing to kill", () => {
+    // Must be empty, not "kill them anyway" — that is the self-kill path.
+    expect(selectOrphanPidsToKill("26221\n", [26221])).toEqual([]);
+  });
+
+  test("drops non-numeric noise and pid 0", () => {
+    // pid 0 would signal the whole process group.
+    expect(selectOrphanPidsToKill("abc\n0\n-5\n404\n", [])).toEqual([404]);
+  });
+
+  test("deduplicates repeated PIDs", () => {
+    expect(selectOrphanPidsToKill("500\n500\n501\n", [])).toEqual([500, 501]);
+  });
+
+  test("handles CRLF from Windows netstat", () => {
+    expect(selectOrphanPidsToKill("700\r\n701\r\n", [701])).toEqual([700]);
+  });
+
+  test("non-string input is not trusted", () => {
+    expect(selectOrphanPidsToKill(undefined, [])).toEqual([]);
+    expect(selectOrphanPidsToKill(null, [])).toEqual([]);
+  });
+
+  test("tolerates protected PIDs given as strings", () => {
+    // process.ppid can arrive stringified through env plumbing.
+    expect(selectOrphanPidsToKill("800\n801\n", ["801"])).toEqual([800]);
   });
 });
 


### PR DESCRIPTION
## What went wrong

The app looked like it was "taking forever to load." It was not loading slowly — it was killing itself and restarting, repeatedly.

`GatewayProcessSupervisor._killOrphans` cleared the gateway port with:

```
lsof -ti:18789
```

`lsof -ti:PORT` reports **every** socket on that port, not just listeners. Electron main POSTs to the gateway early in startup. When an orphaned gateway is already answering on 18789, that POST *connects* — and main's own PID joins lsof's output as a client socket. The supervisor then `kill -9`s every PID in that list, including itself, about 0.6s into launch.

Without an orphan present, the POST is refused, no socket exists, and main's PID never appears. That is why this stayed invisible until a Turso `SIGABRT` (see #133/#134) left a gateway reparented to `launchd`, holding the port and answering `/health`.

## Reproduction

A detached Node squatter bound to 18789 and answering `/health` (matching the orphan's behaviour), then launching the app:

| | Launch outcome |
|---|---|
| Port free | app loads |
| Detached squatter on port | **process dies at 0.66s**, no window |

An earlier attempt with a non-detached squatter was invalid — the harness group-killed the squatter before launch, so the port was free and startup looked fine. The orphan has to outlive the shell to reproduce it.

## The fix

1. **`-sTCP:LISTEN`** — only listeners are considered candidates. On Windows, keep only `LISTENING` rows from `netstat` output (`findstr :PORT` matches any state, including `ESTABLISHED`).
2. **`selectOrphanPidsToKill(rawOutput, protectedPids)`** — a pure function in `supervisor-logic.cjs` that drops our own PID, our parent, and our own gateway child, plus pid 0 (which would signal the whole process group) and non-numeric noise. This is deliberate belt-and-braces: if the `lsof` flag is ever dropped or a platform reports differently, the filter still refuses to return a PID we depend on.
3. **Verify the port actually drains** — `_waitForPortFree` polls for up to 2s (blocking via `Atomics.wait`, not spinning) after the kills. Spawning before the socket is released only trades a self-kill for an `EADDRINUSE` crash loop.

## Tests

10 new tests in `tests/gateway-supervisor.test.ts` (68 total, all passing), including:

- **the regression itself**: `"25799\n26221\n"` with `26221` protected returns `[25799]` — the orphan, not us
- everything protected returns `[]`, not "kill them anyway" — that empty result *is* the fix
- pid 0 and non-numeric lines are dropped; duplicates collapse; CRLF from `netstat` parses; protected PIDs given as strings (as `process.ppid` can arrive through env plumbing) still match

## Notes for review

- `_killOrphans` runs synchronously before spawn, which is why `_waitForPortFree` blocks rather than awaiting. It is bounded, so startup can never hang there — worst case it logs "still held after cleanup" and spawns anyway, preserving today's behaviour.
- This is orthogonal to #133/#134: those stop the Turso `SIGABRT` that *creates* the orphan; this stops the orphan from bricking the next launch. Both are worth having — an orphan can also be left behind by a force-quit or any other abnormal exit.

Made with [Cursor](https://cursor.com)