### PR TITLE
Fix Claude Opus 5 and Fable 5.1 returning an empty response on the API-key path

### DIFF
--- a/src/gateway/services/AgentService.ts
+++ b/src/gateway/services/AgentService.ts
@@ -1813,7 +1813,11 @@ export class AgentService {
           console.log(`${'─'.repeat(80)}`);
         });
         console.log(`\nTools available: ${Object.keys(streamTextOptions.tools || {}).length}`);
-        console.log(`Max tokens: ${streamTextOptions.maxTokens}`);
+        // Read the field the SDK actually honours. This line used to print
+        // `maxTokens`, the pre-v6 name, so it reported the cap we intended
+        // while the request went out with the provider default of 4096 — the
+        // reason this bug stayed invisible in the logs for so long.
+        console.log(`Max output tokens: ${streamTextOptions.maxOutputTokens}`);
         console.log(`Max steps: ${streamTextOptions.stopWhen ? 'custom' : 'default'}`);
         console.log(`${'='.repeat(80)}\n`);
         

--- a/src/gateway/services/AgentService.ts
+++ b/src/gateway/services/AgentService.ts
@@ -50,6 +50,7 @@ import {
   compactStaleToolResults,
   estimateMessagesTokens,
 } from "./agent/compactToolResults.js";
+import { anthropicModelUsesAdaptiveThinking } from "../utils/anthropicAdaptiveThinking.js";
 import {
   computeHistoryTokenBudget,
   isContextLengthError,
@@ -1015,6 +1016,9 @@ export class AgentService {
             min_p?: number;
           };
         };
+        anthropic?: {
+          thinking?: { type: "adaptive"; display?: "summarized" };
+        };
       } = {};
 
       // For OpenAI GPT-5.x models with reasoning effort and summary
@@ -1061,6 +1065,24 @@ export class AgentService {
           providerOptions,
           buildMoonshotProviderOptions(config.model, config.reasoning),
         );
+      }
+
+      // For Anthropic models that self-enable thinking (Fable 5.1, Sonnet 5, Opus 5).
+      // Without display:"summarized" they stream empty thinking deltas, so the turn
+      // shows nothing after reasoning-start.
+      //
+      // sendReasoning is deliberately left at its default (true): the SDK replays a
+      // thinking block only when it still holds the signature Anthropic issued, and
+      // drops unsigned reasoning with a warning rather than sending a block the API
+      // would reject. Turning it off would discard the model's own signed reasoning
+      // between tool steps for no safety gain.
+      if (
+        config.provider === "anthropic" &&
+        anthropicModelUsesAdaptiveThinking(config.model)
+      ) {
+        providerOptions.anthropic = {
+          thinking: { type: "adaptive", display: "summarized" },
+        };
       }
 
       // For Ollama models (Qwen, Gemma, etc.) — thinking + adaptive context
@@ -1185,7 +1207,10 @@ export class AgentService {
           ...(tools as unknown as ToolSet),
           ...nativeSearchTools, // Merge native search tools
         },
-        maxTokens: effectiveMaxTokens,
+        // `ai` v6 renamed this from maxTokens. Passing the old name is not an error —
+        // it is dropped as an unknown key with no warning, and @ai-sdk/anthropic then
+        // substitutes its own 4096 default, silently truncating every reply.
+        maxOutputTokens: effectiveMaxTokens,
         // Allow up to maxSteps tool roundtrips before stopping.
         // Hard limit at maxSteps (default 100), but we force stop at 95 to give
         // the model a chance to respond gracefully before hitting the limit.
@@ -1226,6 +1251,7 @@ export class AgentService {
         ...(providerOptions.openai ||
         providerOptions.google ||
         providerOptions.ollama ||
+        providerOptions.anthropic ||
         config.provider === "zai" ||
         config.provider === "groq" ||
         config.provider === "moonshot"

--- a/src/gateway/services/providers/piAiAnthropicAdaptiveThinking.ts
+++ b/src/gateway/services/providers/piAiAnthropicAdaptiveThinking.ts
@@ -6,6 +6,8 @@
  * We patch the outgoing Messages API payload via pi-ai's onPayload hook.
  */
 
+import { anthropicModelUsesAdaptiveThinking } from "../../utils/anthropicAdaptiveThinking.js";
+
 export type PiAiReasoningLevel =
   | "minimal"
   | "low"
@@ -50,15 +52,15 @@ export interface PiAiAnthropicStreamOptions {
 /** Minimum Claude Code CLI version Anthropic accepts for OAuth-backed frontier models. */
 export const CLAUDE_CODE_OAUTH_USER_AGENT_VERSION = "2.1.251";
 
-/** Models pi-ai misconfigures (budget thinking) but Anthropic requires adaptive-only. */
+/**
+ * Models pi-ai misconfigures (budget thinking) but Anthropic requires adaptive-only.
+ *
+ * Shares one list with the AI SDK path so the OAuth and API-key routes cannot drift
+ * apart — a model handled here but missed there streams empty thinking deltas and
+ * the turn renders as nothing at all.
+ */
 export function requiresPiAiAdaptiveThinkingOverride(modelId: string): boolean {
-  return (
-    modelId.includes("fable") ||
-    modelId.includes("opus-5") ||
-    modelId.includes("opus-4-8") ||
-    modelId.includes("opus-4.8") ||
-    modelId.includes("sonnet-5")
-  );
+  return anthropicModelUsesAdaptiveThinking(modelId);
 }
 
 export function mapPiAiReasoningToAnthropicEffort(

--- a/src/gateway/utils/anthropicAdaptiveThinking.ts
+++ b/src/gateway/utils/anthropicAdaptiveThinking.ts
@@ -1,0 +1,28 @@
+/**
+ * Which Anthropic models need adaptive thinking configured explicitly.
+ *
+ * Fable 5.1 and Sonnet 5 switch thinking on by themselves as soon as tools are
+ * present, and the thinking text is withheld: the stream carries an empty
+ * `thinking_delta` followed only by a `signature_delta`. The turn therefore looks
+ * dead to the UI — `reasoning-start` arrives and nothing follows. Asking for
+ * `display: "summarized"` is what makes the text materialise.
+ *
+ * Verified against the live API (same prompt, tools present):
+ *   claude-opus-5     -> no thinking block
+ *   claude-fable-5-1  -> thinking block, 0 chars of text, signature required
+ *   claude-sonnet-5   -> thinking block, 0 chars of text, signature required
+ *
+ * The model list matches `requiresPiAiAdaptiveThinkingOverride` so the API-key
+ * (AI SDK) and OAuth (pi-ai) paths behave identically. Opus 5 does not
+ * self-enable thinking, but the pi-ai path already requests adaptive thinking for
+ * it, so it stays in the set to keep the two routes from diverging.
+ */
+export function anthropicModelUsesAdaptiveThinking(modelId: string): boolean {
+  return (
+    modelId.includes("fable") ||
+    modelId.includes("opus-5") ||
+    modelId.includes("opus-4-8") ||
+    modelId.includes("opus-4.8") ||
+    modelId.includes("sonnet-5")
+  );
+}

--- a/tests/anthropic-request-shape.test.ts
+++ b/tests/anthropic-request-shape.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Contract tests for the Anthropic request body the AI SDK builds for us.
+ *
+ * These exist because the failure they cover is invisible: `ai` v6 renamed
+ * `maxTokens` to `maxOutputTokens`, and passing the old name is not an error.
+ * It is dropped as an unknown key with no warning, and @ai-sdk/anthropic then
+ * substitutes its own 4096 default — so a model configured for 128K output was
+ * silently capped at 4096 on every request. Nothing in types, lint, or runtime
+ * logs catches that; only the wire format shows it.
+ *
+ * We assert against a local echo server rather than mocking the SDK, so the
+ * tests fail if a future SDK version renames or reinterprets these options.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { streamText, tool } from "ai";
+import type { ModelMessage } from "ai";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { anthropicModelUsesAdaptiveThinking } from "../src/gateway/utils/anthropicAdaptiveThinking.js";
+
+interface AnthropicRequestBody {
+  model: string;
+  max_tokens: number;
+  thinking?: { type: string; display?: string };
+  messages: Array<{ role: string; content: unknown }>;
+}
+
+let server: http.Server;
+let baseURL: string;
+const received: AnthropicRequestBody[] = [];
+
+/** Smallest SSE body that lets streamText resolve instead of throwing. */
+function writeMinimalStream(res: http.ServerResponse): void {
+  res.writeHead(200, { "content-type": "text/event-stream" });
+  res.write(
+    `event: message_start\ndata: ${JSON.stringify({
+      type: "message_start",
+      message: {
+        id: "msg_test",
+        type: "message",
+        role: "assistant",
+        model: "claude-fable-5-1",
+        content: [],
+        stop_reason: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    })}\n\n`,
+  );
+  res.write(
+    `event: message_delta\ndata: ${JSON.stringify({
+      type: "message_delta",
+      delta: { stop_reason: "end_turn" },
+      usage: { output_tokens: 1 },
+    })}\n\n`,
+  );
+  res.write(`event: message_stop\ndata: {"type":"message_stop"}\n\n`);
+  res.end();
+}
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      received.push(JSON.parse(body) as AnthropicRequestBody);
+      writeMinimalStream(res);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  baseURL = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});
+
+/** Issue one request through the real SDK and return the body Anthropic would see. */
+async function capture(
+  extra: Record<string, unknown>,
+  messages?: ModelMessage[],
+): Promise<AnthropicRequestBody> {
+  const anthropic = createAnthropic({
+    apiKey: "test-key-not-real",
+    baseURL,
+  });
+  const result = streamText({
+    model: anthropic("claude-fable-5-1"),
+    messages: messages ?? [{ role: "user", content: "hello" }],
+    tools: {
+      bash: tool({
+        description: "Run a shell command",
+        inputSchema: z.object({ command: z.string() }),
+      }),
+    },
+    ...extra,
+  });
+  // Draining is what actually issues the request.
+  for await (const _chunk of result.fullStream) {
+    void _chunk;
+  }
+  const body = received.at(-1);
+  if (!body) {
+    throw new Error("echo server captured no request");
+  }
+  return body;
+}
+
+describe("anthropic request shape", () => {
+  it("sends the configured output cap when using the v6 option name", async () => {
+    const body = await capture({ maxOutputTokens: 128000 });
+    expect(body.max_tokens).toBe(128000);
+  });
+
+  it("regression: the pre-v6 maxTokens name is silently ignored", async () => {
+    // This is the bug, pinned. `maxTokens` does not throw and does not warn — it
+    // is dropped, and the provider default takes over. If a future SDK starts
+    // honouring or rejecting it, this test tells us the workaround can change.
+    const body = await capture({ maxTokens: 128000 });
+    expect(body.max_tokens).toBe(4096);
+    expect(body.max_tokens).not.toBe(128000);
+  });
+
+  it("requests summarized adaptive thinking so reasoning text is not withheld", async () => {
+    // Fable 5.1 enables thinking by itself once tools are present and streams
+    // empty thinking deltas unless display is summarized, which renders as a
+    // turn that produces nothing at all.
+    const body = await capture({
+      maxOutputTokens: 128000,
+      providerOptions: {
+        anthropic: {
+          thinking: { type: "adaptive", display: "summarized" },
+        },
+      },
+    });
+    expect(body.thinking).toEqual({ type: "adaptive", display: "summarized" });
+  });
+
+  it("never puts an unsigned thinking block on the wire", async () => {
+    // Anthropic rejects a thinking block whose signature is missing or does not
+    // match ("thinking.signature: Field required" / "Invalid `signature`"). Our
+    // stored history carries reasoning text but no signature, so this is the
+    // invariant that keeps a replayed turn from 400ing. The SDK drops such a
+    // part and emits an "unsupported reasoning metadata" warning instead, which
+    // is why we leave sendReasoning at its default rather than disabling it.
+    const messages: ModelMessage[] = [
+      { role: "user", content: "check the repo" },
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "Prior reasoning with no signature." },
+          { type: "text", text: "Let me look." },
+        ],
+      },
+      { role: "user", content: "continue" },
+    ];
+
+    const body = await capture({ maxOutputTokens: 1000 }, messages);
+    const sentBlockTypes = body.messages
+      .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+      .filter((c): c is { type: string } => typeof c === "object" && c !== null)
+      .map((c) => c.type);
+
+    expect(sentBlockTypes).not.toContain("thinking");
+    // The text alongside the dropped reasoning must still survive.
+    expect(sentBlockTypes).toContain("text");
+  });
+});
+
+describe("anthropicModelUsesAdaptiveThinking", () => {
+  it("covers the models that self-enable thinking", () => {
+    // Verified against the live API: these return a thinking block with empty
+    // text when tools are present.
+    expect(anthropicModelUsesAdaptiveThinking("claude-fable-5-1")).toBe(true);
+    expect(anthropicModelUsesAdaptiveThinking("claude-fable-5")).toBe(true);
+    expect(anthropicModelUsesAdaptiveThinking("claude-sonnet-5")).toBe(true);
+  });
+
+  it("stays in step with the pi-ai override list", () => {
+    expect(anthropicModelUsesAdaptiveThinking("claude-opus-5")).toBe(true);
+    expect(anthropicModelUsesAdaptiveThinking("claude-opus-4-8")).toBe(true);
+    expect(anthropicModelUsesAdaptiveThinking("claude-opus-4.8")).toBe(true);
+  });
+
+  it("leaves budget-thinking and non-Claude models alone", () => {
+    expect(anthropicModelUsesAdaptiveThinking("claude-opus-4-7")).toBe(false);
+    expect(anthropicModelUsesAdaptiveThinking("claude-opus-4-6")).toBe(false);
+    expect(anthropicModelUsesAdaptiveThinking("claude-sonnet-4-6")).toBe(false);
+    expect(anthropicModelUsesAdaptiveThinking("claude-haiku-4-5")).toBe(false);
+    expect(anthropicModelUsesAdaptiveThinking("gpt-5-6-sol")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What this fixes

Two independent defects that are survivable alone and produce a **completely empty assistant response** together. Originally reported against Fable 5.1; a live API probe shows Opus 5 is affected identically, so the title/scope are broadened.

### 1. The output cap was never applied

`streamText` was called with `maxTokens`, the pre-v6 name. `ai` v6 renamed it to `maxOutputTokens` and ignores unknown keys, so the cap was silently dropped and `@ai-sdk/anthropic` fell back to its default of **4096**.

### 2. Adaptive thinking blocks stream empty

Claude Opus 5 and Fable 5.1 emit a `thinking` block by default, and its text is **empty** unless `display: "summarized"` is requested. Probed live against the API — no tools, no thinking config, bare `"hi"`:

```
claude-opus-5 → {"type":"thinking","thinking":"","signature":"CAIS3AIKjgEIERgC..."}
```

A/B on `claude-opus-5`, `max_tokens: 4096`:

| request | content blocks | output tokens |
|---|---|---|
| default (what master sends) | `thinking(0ch), text(326ch)` | 211 |
| `thinking:{type:adaptive,display:summarized}` | `thinking(64ch), text(383ch)` | 246 |

### Why they compound into nothing

With a large context and tools, thinking grows. Capped at 4096 instead of 128000, the entire output budget is consumed inside a thinking block that streams as empty deltas, so the turn ends on `finish_reason: length` having produced zero text. From a real session on `claude-opus-5`:

```
Step 1 - input: 336667 tokens, output: 4096 tokens
Model stopped due to TOKEN LIMIT!
Finish chunk received, reason: length
Stream complete - Text: 0KB, Thinking: 0KB
Sequence built: 0 items
Silent retry also returned empty completion. Skipping save to keep chat clean.
```

Each defect alone is survivable: with the cap correct, thinking has room and text follows; with `summarized`, the thinking is at least visible. Together, on a big context, the user sees nothing happen.

## Changes

- `maxTokens` → `maxOutputTokens` on the `streamText` call
- Request `thinking: { type: "adaptive", display: "summarized" }` for Anthropic models that use adaptive thinking, via a shared `anthropicModelUsesAdaptiveThinking()` predicate (matches fable, opus-5, opus-4-8, sonnet-5) so the AI-SDK and pi-ai paths cannot disagree
- Fix the debug header, which read the **ignored** `maxTokens` and so printed `Max tokens: 128000` while the request carried 4096. A log reporting intent rather than what was sent is why this needed a live probe to find

`max_tokens: 128000` was verified accepted by the API for both `claude-opus-5` and `claude-fable-5-1`, so raising the real cap does not trade a silent truncation for a 400.

## Not the cause: SDK version

We are a major behind (`ai` 6.0.168 vs 7.0.92, `@ai-sdk/anthropic` 3.0.71 vs 4.0.49). Upgrading would **not** have fixed this — v7 also ignores an unrecognised `maxTokens`. Worth doing separately, on its own risk budget.

## Verification

- Live A/B against `api.anthropic.com` for both models (table above)
- Gateway `tsc --noEmit` clean
- `oxlint` — 2 warnings, identical to master's baseline for this file
- `tests/anthropic-request-shape.test.ts` — 7 contract tests on the outgoing request body