### PR TITLE
Stop reporting a turn as finished while plan steps are pending

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4856,4 +4856,38 @@ Head-of-line blocking with a poison pill at the front: the queue could only grow
 
 ---
 
+### Issue 73: "Finished Working" With Pending Plan Steps ✅ FIXED
+**Added:** 2026-09-03
+**Problem:** Turns ran 6–77 tool calls, ended on a sentence announcing the *next* action, and the UI reported the turn as finished while the plan sat at 0/7. Users then saw apparent context loss on the following message.
+**Evidence:** In 54 logged turns, 9 ended with plan steps outstanding, all with `reason:"model_stop"` / `modelFinishReason:"stop"` — no step limit, no token cap, no abort. The gateway already flagged 6 of them: `"likelyCause":"model_stop_with_pending_plan_steps (not gateway wrap-up)"`.
+**Root Causes:** The turn-end decision was binary and *both* outcomes end the turn:
+1. **Terminal wrap-up fired over unfinished work.** When a turn ended on a tool call with no text, the gateway injected `WRAP_UP_AFTER_TOOLS_NO_TEXT` — "This turn is complete … do not call tools" — regardless of plan state. On one opus-5 turn that fired with 4 steps pending, so the false "finished" claim was the *gateway's*, not the model's.
+2. **Any trailing text skipped all intervention** (`skipReason: "trailing_text_after_tools"`, 47/54 turns). A mid-work preamble ("Now let me see how the launcher invokes…") is indistinguishable from a closing summary under that rule.
+3. **Plan state was queried at turn end but only logged** — "Plan lookup is best-effort for diagnostics only."
+**Not a context bug:** `loadActivePlansContext` was verified to run on both routes and inject step statuses, progress, and "continue where you left off." The perceived amnesia is a *consequence* — a turn ending on "I'll do X next" leaves no evidence X happened, so the next turn re-derives state.
+**Solution:** Three-way turn-end decision (`wrap_up` | `continue` | `none`) in `agent/turnContinuation.ts`:
+- Continuation is **gated on an active plan with pending steps** — no plan means no reliable signal, so those turns keep the old behavior (bounds the blast radius)
+- The terminal wrap-up can no longer fire over pending steps; `WRAP_UP_WITH_PLAN_INCOMPLETE` asks for an honest status instead of claiming completion
+- `trailingTextAwaitsUser` suppresses continuation when the tail (last 400 chars) ends in a question or an approval phrase, so genuine handoffs ("say the word", "for your approval", "tell me which") are not steamrolled
+- Nudge names the next pending step, requires `update_plan`, forbids new plans, and offers an escape hatch ("ask one direct question and stop") so it can't loop against a real blocker
+- Bounded at `MAX_PLAN_CONTINUATIONS_PER_TURN = 2`
+**Where continuation happens:**
+- **pi-ai (OAuth):** in-loop via a `resolveModelStop` callback at the `model_stop` exit — resuming the existing loop keeps every budget (steps, memory, tokens, repetition) in force and keeps the turn as one message/one card. Callback lives in AgentService so the provider layer stays free of PlanService.
+- **ai-sdk:** post-stream. `stopWhen` is only consulted after a step with tool calls, so `finishReason: "stop"` can't be overridden from inside; `runAiSdkPlanContinuation` issues a fresh `streamText` with options spread (tools/stopWhen/prepareStep intact) and merges via `mergeContinuationIntoState`.
+**Files Created:**
+- `src/gateway/services/agent/turnContinuation.ts` — decision matrix, handoff detection, nudge builder
+- `tests/turn-continuation.test.ts` — 30 tests; handoff cases use verbatim trailing text from the logged failures
+- `docs/PLAN_AWARE_TURN_CONTINUATION.md` — full write-up
+**Files Changed:**
+- `src/gateway/services/agent/wrapUpContinuation.ts` — `WRAP_UP_WITH_PLAN_INCOMPLETE`, `applyPlanContinuationStep`, `runAiSdkPlanContinuation`, `mergeContinuationIntoState`, optional `wrapUpMessage`
+- `src/gateway/services/providers/PiCodexStreamWithToolLoop.ts` — `resolveModelStop` hook, per-step trailing-text tracking
+- `src/gateway/services/AgentService.ts` — `loadPendingPlanState`, resolver wiring, plan-aware wrap-up wording, ai-sdk continuation loop
+**Known limitation:** token usage from an ai-sdk continuation is not merged into reported usage (matches the pre-existing wrap-up path).
+**Observability:** `[TurnEnd:plan-continuation]` logs each resume (chat, step, pending count, attempt). Success looks like `activePlanPendingSteps: 0` on turns that previously logged `likelyCause: "model_stop_with_pending_plan_steps"`.
+**Prevention:** A turn-end policy needs a third option. "Summarize and stop" and "do nothing" both end the turn, so with only those two the gateway cannot represent "keep going" — and a terminal prompt asserting completion must never be sent without checking whether the work is actually complete.
+**Related:** Issue 30 (GPT-5.4 duplicate plans — tool-level enforcement), Issue 49 (send button stuck), Enhancement 17 (GPT-5.4 context limit)
+**See:** `docs/PLAN_AWARE_TURN_CONTINUATION.md`
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**

--- a/docs/PLAN_AWARE_TURN_CONTINUATION.md
+++ b/docs/PLAN_AWARE_TURN_CONTINUATION.md
@@ -1,0 +1,144 @@
+# Plan-Aware Turn Continuation
+
+**Added:** 2026-09-03
+
+Fixes turns that report "Finished Working" while the active plan still has
+pending steps.
+
+## Symptom
+
+A turn runs 6–77 tool calls, ends with a sentence that announces the *next*
+action, and the UI shows the turn as finished. The plan sits at 0/7 with step 1
+still "In Progress". On the next message the model appears to have lost context —
+it re-derives state it already established.
+
+## Evidence
+
+From production logs (54 turns), 9 ended with plan steps outstanding. The
+gateway's own diagnostic already named it:
+
+```
+"activePlans":1,"activePlanPendingSteps":2,"trailingTextAfterTools":true,
+"postStreamWrapUp":"trailing_text_after_tools",
+"likelyCause":"model_stop_with_pending_plan_steps (not gateway wrap-up)"
+```
+
+Every one had `reason:"model_stop"` and `modelFinishReason:"stop"` — no step
+limit, no token cap, no abort. The trailing text was consistently a preamble,
+not a conclusion:
+
+| Model | Pending | Trailing text |
+|---|---|---|
+| fable-5 | 2 | "…Now let me survey the training ma…" |
+| fable-5 | 1 | "Now let me see how the v56a launcher invokes `autonomous_loop`…" |
+| fable-5 | 1 | "Let me pull the actual μ numbers…" |
+| opus-5 | 4 | "Running the apply now. I'll stage it: **nodes first**…" |
+
+## Root cause
+
+The turn-end decision was binary, and both outcomes end the turn:
+
+1. **Terminal wrap-up.** When the sequence ended on a tool call with no text,
+   the gateway injected `WRAP_UP_AFTER_TOOLS_NO_TEXT` — *"This turn is complete
+   … do not call tools."* It fired regardless of plan state, so on the opus-5
+   turn above the gateway itself converted 4 pending steps into a report of
+   completion. The "finished" claim was the gateway's, not the model's.
+
+2. **Silent skip.** Any trailing text at all returned
+   `skipReason: "trailing_text_after_tools"` and nothing happened — 47 of 54
+   turns. A mid-work preamble is indistinguishable from a closing summary under
+   that rule.
+
+Plan state was already queried at turn end, but only for the log line:
+*"Plan lookup is best-effort for diagnostics only."*
+
+The apparent context loss is a consequence, not a separate bug. A turn that ends
+narrating intent leaves a history saying "I'll do X next" with no evidence X
+happened, so the next turn re-derives state. Plan context itself was verified
+correct: `loadActivePlansContext` runs on both routes and injects step status
+icons, progress counts, and "continue where you left off."
+
+## Fix
+
+The decision is now three-way — `wrap_up`, `continue`, or `none` — in
+`src/gateway/services/agent/turnContinuation.ts`.
+
+| Pending steps | Turn ended | Action |
+|---|---|---|
+| 0 | on a tool, no text | `wrap_up` (terminal — unchanged) |
+| 0 | with text | `none` (unchanged) |
+| > 0 | either | `continue` (tools stay on) |
+| > 0 | text hands off to user | `none` |
+| > 0 | budget spent, no text | `wrap_up` (states what remains) |
+
+Three properties matter:
+
+- **Continuation is gated on an active plan.** No plan means no reliable signal
+  that work remains, so those turns behave exactly as before. This bounds the
+  blast radius to plan-driven work.
+- **The terminal wrap-up can no longer fire over pending steps.** It is replaced
+  by `WRAP_UP_WITH_PLAN_INCOMPLETE`, which asks for what was done, what is
+  outstanding, and what is needed — and forbids claiming completion.
+- **Handoffs are respected.** `trailingTextAwaitsUser` inspects the last 400
+  characters for a trailing question mark or an approval phrase ("for your
+  approval", "say the word", "your call", "tell me which"). A question early in
+  a long report does not count; a question at the end does. Without this, a turn
+  ending "Tell me which, and whether you want the gate-3 graft before launch"
+  would be steamrolled.
+
+The nudge names the next pending step, requires `update_plan`, forbids
+re-summarizing or creating a new plan, and leaves an explicit escape hatch:
+*"If you truly cannot proceed without a decision from the user, ask one direct
+question and stop."* Without that hatch the model would loop against a real
+blocker until the budget ran out.
+
+Bounded at `MAX_PLAN_CONTINUATIONS_PER_TURN = 2`.
+
+## Where continuation happens
+
+**pi-ai (OAuth) — in-loop.** `createPiCodexStreamWithToolLoop` takes a
+`resolveModelStop` callback, consulted at the `model_stop` exit. Returning a
+nudge appends the assistant's own closing message (so the resumed step can see
+what it just said), pushes the nudge, and does `continue stepLoop`. Because it
+resumes the existing loop, every budget already in place — step limit, memory
+checks, token accounting, repetition detection — keeps applying, and the whole
+turn stays one assistant message and one UI card.
+
+The callback lives in `AgentService` so the provider layer stays free of
+`PlanService`.
+
+**ai-sdk — post-stream.** `streamText` owns its tool loop and `stopWhen` is only
+consulted after a step that produced tool calls, so a `finishReason: "stop"`
+cannot be overridden from inside. `runAiSdkPlanContinuation` instead issues a
+fresh `streamText` with the spread options (tools, `stopWhen` and `prepareStep`
+intact) and merges the full result via `mergeContinuationIntoState`.
+
+Known limitation, matching the pre-existing wrap-up path: token usage from an
+ai-sdk continuation is not merged into the turn's reported usage.
+
+## Files
+
+**Added**
+- `src/gateway/services/agent/turnContinuation.ts` — decision matrix, handoff
+  detection, nudge builder
+- `tests/turn-continuation.test.ts` — 30 tests; the handoff cases use verbatim
+  trailing text from the logged failures
+
+**Changed**
+- `agent/wrapUpContinuation.ts` — `WRAP_UP_WITH_PLAN_INCOMPLETE`,
+  `applyPlanContinuationStep`, `runAiSdkPlanContinuation`,
+  `mergeContinuationIntoState`, optional `wrapUpMessage` on both runners
+- `providers/PiCodexStreamWithToolLoop.ts` — `resolveModelStop` hook, per-step
+  trailing-text tracking, continuation at the `model_stop` exit
+- `AgentService.ts` — `loadPendingPlanState`, resolver wiring, plan-aware
+  wrap-up wording, ai-sdk continuation loop
+
+## Observability
+
+`[TurnEnd:plan-continuation]` records each resume with chat, step, pending step
+count, and which attempt it was. `[TurnEnd]` still carries `activePlans` and
+`activePlanPendingSteps`, now re-read after continuation so the numbers reflect
+the final state.
+
+A healthy fix shows `activePlanPendingSteps: 0` on turns that previously logged
+`likelyCause: "model_stop_with_pending_plan_steps"`.

--- a/src/gateway/services/AgentService.ts
+++ b/src/gateway/services/AgentService.ts
@@ -12,7 +12,7 @@
 import { resolvePaprUserDataPath } from "../../core/utils/paprWorkspace.js";
 import { v4 as uuidv4 } from "uuid";
 import { streamText, generateObject, jsonSchema } from "ai";
-import type { LanguageModel, ToolSet, StepResult } from "ai";
+import type { LanguageModel, ModelMessage, ToolSet, StepResult } from "ai";
 import { ToolRegistry } from "../../core/agents/ToolRegistry.js";
 import {
   initializeMemorySearchGate,
@@ -1738,6 +1738,32 @@ export class AgentService {
           maxSteps,
           piHistoryTrimBounds,
           piToolContext,
+          // Resume the loop when the model stops with plan work outstanding.
+          async (stopInfo) => {
+            const { decideTurnEnd, buildPlanContinuationNudge } = await import(
+              "./agent/turnContinuation.js"
+            );
+            const planState = await this.loadPendingPlanState(chatId);
+            const decision = decideTurnEnd({
+              pendingPlanSteps: planState.pendingSteps,
+              trailingText: stopInfo.trailingText,
+              endsOnToolWithoutText: stopInfo.trailingText.trim().length === 0,
+              toolCallCount: stopInfo.totalToolCalls,
+              aborted: abortController.signal.aborted,
+              hasInterruptedTools: false,
+              continuationsUsed: stopInfo.continuationsUsed,
+            });
+            if (decision.action !== "continue") {
+              return null;
+            }
+            return {
+              nudge: buildPlanContinuationNudge({
+                pendingSteps: planState.pendingSteps,
+                nextStepDescription: planState.nextStepDescription,
+              }),
+              pendingSteps: planState.pendingSteps,
+            };
+          },
         );
         piWrapUpContext = piContext;
         piWrapUpDeps = {
@@ -2055,18 +2081,142 @@ export class AgentService {
         return;
       }
 
+      // pi-ai resumes a stopped-mid-plan turn inside its own tool loop. The AI
+      // SDK route has no in-loop hook, so resume here instead. Plan state is
+      // re-read each attempt, so finishing the plan ends the loop immediately.
+      if (
+        !usePiAi &&
+        aiSdkStreamResult &&
+        !abortController.signal.aborted &&
+        !options?._isWrapUpContinuation
+      ) {
+        const {
+          decideTurnEnd,
+          buildPlanContinuationNudge,
+          trailingTextAfterLastTool,
+          MAX_PLAN_CONTINUATIONS_PER_TURN,
+        } = await import("./agent/turnContinuation.js");
+        const { runAiSdkPlanContinuation, mergeContinuationIntoState } =
+          await import("./agent/wrapUpContinuation.js");
+
+        // Widened from the SDK's narrower assistant|tool response type so the
+        // continuation's own messages can be threaded back in.
+        let continuationMessages: ModelMessage[] = (
+          await aiSdkStreamResult.response
+        ).messages;
+
+        for (
+          let attempt = 0;
+          attempt < MAX_PLAN_CONTINUATIONS_PER_TURN;
+          attempt++
+        ) {
+          const planState = await this.loadPendingPlanState(chatId);
+          const decision = decideTurnEnd({
+            pendingPlanSteps: planState.pendingSteps,
+            trailingText: trailingTextAfterLastTool(sequence),
+            endsOnToolWithoutText:
+              sequenceEndsWithToolWithoutTrailingText(sequence),
+            toolCallCount: toolCalls.length,
+            aborted: abortController.signal.aborted,
+            hasInterruptedTools: false,
+            continuationsUsed: attempt,
+          });
+
+          if (decision.action !== "continue") {
+            break;
+          }
+
+          console.warn(
+            `[TurnEnd:plan-continuation] ${JSON.stringify({
+              ts: new Date().toISOString(),
+              chatId,
+              route: "ai-sdk",
+              pendingSteps: planState.pendingSteps,
+              continuation: attempt + 1,
+            })}`,
+          );
+
+          try {
+            const continuationIterator = runAiSdkPlanContinuation({
+              messages: continuationMessages,
+              nudge: buildPlanContinuationNudge({
+                pendingSteps: planState.pendingSteps,
+                nextStepDescription: planState.nextStepDescription,
+              }),
+              streamTextOptions: streamTextOptions as {
+                model: LanguageModel;
+                [key: string]: unknown;
+              },
+              chatId,
+              apiKeys: getApiKeysForSanitization(),
+              provider: config.provider,
+              abortSignal: abortController.signal,
+            });
+
+            let continuationResult: Awaited<
+              ReturnType<typeof continuationIterator.next>
+            >["value"] = null;
+            while (true) {
+              const nextChunk = await continuationIterator.next();
+              if (nextChunk.done) {
+                continuationResult = nextChunk.value;
+                break;
+              }
+              yield nextChunk.value;
+            }
+
+            if (!continuationResult) {
+              break;
+            }
+
+            const merged = mergeContinuationIntoState(
+              { assistantText, thinkingText, toolCalls, toolResults, sequence },
+              continuationResult.state,
+            );
+            assistantText = merged.assistantText;
+            thinkingText = merged.thinkingText;
+            toolCalls = merged.toolCalls;
+            toolResults = merged.toolResults;
+            sequence = merged.sequence;
+            continuationMessages = continuationResult.messages;
+          } catch (continuationError) {
+            console.warn(
+              `[AgentService] Plan continuation failed for ${chatId}:`,
+              continuationError,
+            );
+            break;
+          }
+        }
+      }
+
       // After the assistant stream fully finishes: if the turn ended on tool(s)
       // without trailing user text, one text-only summary step for the user.
-      if (
-        shouldRequestWrapUpSummary({
-          sequence,
-          toolCallCount: toolCalls.length,
-          aborted: abortController.signal.aborted,
-          isWrapUpContinuation: Boolean(options?._isWrapUpContinuation),
-        })
-      ) {
+      //
+      // The wording depends on plan state. The default wrap-up asserts "this
+      // turn is complete"; sending that while steps are still pending reports
+      // unfinished work to the user as done, so pending steps switch it to an
+      // honest status request instead.
+      const { WRAP_UP_WITH_PLAN_INCOMPLETE } = await import(
+        "./agent/wrapUpContinuation.js"
+      );
+      const turnEndPlanState = await this.loadPendingPlanState(chatId);
+      const wrapUpNeeded = shouldRequestWrapUpSummary({
+        sequence,
+        toolCallCount: toolCalls.length,
+        aborted: abortController.signal.aborted,
+        isWrapUpContinuation: Boolean(options?._isWrapUpContinuation),
+      });
+      const wrapUpMessage =
+        turnEndPlanState.pendingSteps > 0
+          ? WRAP_UP_WITH_PLAN_INCOMPLETE
+          : undefined;
+
+      if (wrapUpNeeded) {
         console.log(
-          `[AgentService] Running wrap-up summary for ${chatId} — tools completed without a user-facing reply`,
+          `[AgentService] Running wrap-up summary for ${chatId} — tools completed without a user-facing reply` +
+            (wrapUpMessage
+              ? ` (${turnEndPlanState.pendingSteps} plan step(s) still pending — asking for status, not completion)`
+              : ""),
         );
 
         yield {
@@ -2093,6 +2243,7 @@ export class AgentService {
               chatId,
               apiKeys: getApiKeysForSanitization(),
               abortSignal: abortController.signal,
+              wrapUpMessage,
             });
             while (true) {
               const wrapUpNext = await wrapUpIterator.next();
@@ -2113,6 +2264,7 @@ export class AgentService {
               apiKeys: getApiKeysForSanitization(),
               provider: config.provider,
               abortSignal: abortController.signal,
+              wrapUpMessage,
             });
             while (true) {
               const wrapUpNext = await wrapUpIterator.next();
@@ -2170,23 +2322,11 @@ export class AgentService {
           aborted: abortController.signal.aborted,
           isWrapUpContinuation: Boolean(options?._isWrapUpContinuation),
         });
-        let activePlanCount = 0;
-        let activePlanPendingSteps = 0;
-        try {
-          const { getPlanService } = await import("./PlanService.js");
-          const plans = await getPlanService().getActivePlansForChat(chatId);
-          activePlanCount = plans.length;
-          activePlanPendingSteps = plans.reduce(
-            (sum, plan) =>
-              sum +
-              plan.steps.filter(
-                (s) => s.status !== "completed" && s.status !== "skipped",
-              ).length,
-            0,
-          );
-        } catch {
-          // Plan lookup is best-effort for diagnostics only.
-        }
+        // Re-read: a continuation step may have completed steps since the
+        // pre-wrap-up snapshot.
+        const finalPlanState = await this.loadPendingPlanState(chatId);
+        const activePlanCount = finalPlanState.planCount;
+        const activePlanPendingSteps = finalPlanState.pendingSteps;
         logAgentTurnEnd({
           chatId,
           route: usePiAi ? "pi-ai" : "ai-sdk",
@@ -4485,6 +4625,38 @@ ${last15.substring(0, 8_000)}`;
     } catch (error) {
       console.warn("[AgentService] Failed to load active plans:", error);
       return undefined;
+    }
+  }
+
+  /**
+   * Unfinished plan work for this chat. Drives turn-end policy: a model that
+   * stops while steps are pending is usually mid-task, not done.
+   */
+  private async loadPendingPlanState(chatId: string): Promise<{
+    planCount: number;
+    pendingSteps: number;
+    nextStepDescription?: string;
+  }> {
+    try {
+      const { getPlanService } = await import("./PlanService.js");
+      const plans = await getPlanService().getActivePlansForChat(chatId);
+      const unfinished = plans.flatMap((plan) =>
+        plan.steps.filter(
+          (step) => step.status !== "completed" && step.status !== "skipped",
+        ),
+      );
+      // Prefer the step the model said it was working on.
+      const next =
+        unfinished.find((step) => step.status === "in_progress") ??
+        unfinished[0];
+      return {
+        planCount: plans.length,
+        pendingSteps: unfinished.length,
+        nextStepDescription: next?.description,
+      };
+    } catch {
+      // Best-effort: an unavailable PlanService must not change turn behavior.
+      return { planCount: 0, pendingSteps: 0 };
     }
   }
 

--- a/src/gateway/services/agent/turnContinuation.ts
+++ b/src/gateway/services/agent/turnContinuation.ts
@@ -1,0 +1,184 @@
+/**
+ * Turn-end policy: end the turn, close it with a summary, or push the model to
+ * keep going.
+ *
+ * The decision used to be binary — request a terminal wrap-up or do nothing —
+ * and both outcomes end the turn. A model that stopped mid-plan was therefore
+ * reported to the user as finished, and when it had stopped on a tool call the
+ * gateway went further and injected "This turn is complete … do not call tools",
+ * manufacturing a completion over unfinished work.
+ *
+ * Continuation is gated on an active plan with pending steps: with no plan there
+ * is no reliable signal that work remains, so those turns keep the old behavior.
+ */
+
+/** Continuations allowed per turn before we stop pushing and report honestly. */
+export const MAX_PLAN_CONTINUATIONS_PER_TURN = 2;
+
+export type TurnEndAction = "wrap_up" | "continue" | "none";
+
+/**
+ * `complete` closes the turn ("you are done, do not call tools").
+ * `plan_incomplete` asks for a summary that states what remains — never claims
+ * the work is finished.
+ */
+export type WrapUpKind = "complete" | "plan_incomplete";
+
+export interface TurnEndDecision {
+  action: TurnEndAction;
+  /** Stable identifier for logs and tests. */
+  reason: string;
+  wrapUpKind?: WrapUpKind;
+}
+
+/**
+ * Phrases that mean the model handed control back rather than stopping
+ * mid-task. Continuing past one of these would steamroll a question the user
+ * has to answer, so it counts as a legitimate stop even with steps pending.
+ */
+const AWAITS_USER_PATTERNS: RegExp[] = [
+  /\blet me know\b/i,
+  /\bfor your approval\b/i,
+  /\byour call\b/i,
+  /\bsay the word\b/i,
+  /\bshall i\b/i,
+  /\bshould i\b/i,
+  /\bwant me to\b/i,
+  /\bdo you want\b/i,
+  /\bwould you (like|prefer|rather)\b/i,
+  /\bwhich (one|would you|do you)\b/i,
+  /\btell me (which|whether|if)\b/i,
+  /\bawaiting your\b/i,
+  /\bwaiting on you\b/i,
+  /\bneed your (input|decision|call|sign-?off)\b/i,
+  /\bconfirm before\b/i,
+];
+
+/**
+ * Only the tail is inspected: a question early in a long progress report is not
+ * a handoff, but a question at the very end is.
+ */
+const AWAITS_USER_TAIL_CHARS = 400;
+
+/** True when the trailing text reads as handing control back to the user. */
+export function trailingTextAwaitsUser(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  const tail = trimmed.slice(-AWAITS_USER_TAIL_CHARS);
+
+  // A trailing question mark is the clearest handoff signal. Ignore a trailing
+  // markdown list/emphasis marker so "…which one? **" still counts.
+  if (/\?["'`*_)\]\s]*$/.test(tail)) {
+    return true;
+  }
+
+  return AWAITS_USER_PATTERNS.some((pattern) => pattern.test(tail));
+}
+
+/**
+ * Text the model emitted after its last tool call. This is what distinguishes a
+ * closing summary from a mid-work preamble like "Now let me check the launcher:".
+ */
+export function trailingTextAfterLastTool(
+  sequence: Array<{ type: string; data: unknown }>,
+): string {
+  let lastToolIndex = -1;
+  for (let i = sequence.length - 1; i >= 0; i--) {
+    if (sequence[i]?.type === "tool") {
+      lastToolIndex = i;
+      break;
+    }
+  }
+
+  const parts: string[] = [];
+  for (let i = lastToolIndex + 1; i < sequence.length; i++) {
+    const item = sequence[i];
+    if (item?.type === "text" && typeof item.data === "string") {
+      parts.push(item.data);
+    }
+  }
+  return parts.join("");
+}
+
+export interface TurnEndInput {
+  /** Unfinished (not completed, not skipped) steps across active plans. */
+  pendingPlanSteps: number;
+  /** Model text emitted after the last tool call, if any. */
+  trailingText: string;
+  /** True when the visible sequence ends on tool call(s) with no text after. */
+  endsOnToolWithoutText: boolean;
+  toolCallCount: number;
+  aborted: boolean;
+  /** Tool calls left hanging — a different failure, handled elsewhere. */
+  hasInterruptedTools: boolean;
+  /** Continuations already spent this turn. */
+  continuationsUsed: number;
+  maxContinuations?: number;
+}
+
+export function decideTurnEnd(input: TurnEndInput): TurnEndDecision {
+  const maxContinuations =
+    input.maxContinuations ?? MAX_PLAN_CONTINUATIONS_PER_TURN;
+
+  if (input.aborted) {
+    return { action: "none", reason: "aborted" };
+  }
+  if (input.toolCallCount === 0) {
+    // Nothing ran, so the model answered directly. Pushing it to "continue"
+    // here would fight a deliberate text-only reply.
+    return { action: "none", reason: "no_tool_calls" };
+  }
+  if (input.hasInterruptedTools) {
+    return { action: "none", reason: "interrupted_tools" };
+  }
+
+  if (input.pendingPlanSteps <= 0) {
+    // Original behavior: close the turn only when the model went silent.
+    return input.endsOnToolWithoutText
+      ? {
+          action: "wrap_up",
+          reason: "tools_without_reply",
+          wrapUpKind: "complete",
+        }
+      : { action: "none", reason: "trailing_text_after_tools" };
+  }
+
+  if (trailingTextAwaitsUser(input.trailingText)) {
+    return { action: "none", reason: "awaiting_user_input" };
+  }
+
+  if (input.continuationsUsed < maxContinuations) {
+    return { action: "continue", reason: "plan_steps_pending" };
+  }
+
+  // Out of continuations. Never claim completion — if the model also went
+  // silent, ask for a summary that says what is still outstanding.
+  return input.endsOnToolWithoutText
+    ? {
+        action: "wrap_up",
+        reason: "continuation_budget_exhausted",
+        wrapUpKind: "plan_incomplete",
+      }
+    : { action: "none", reason: "continuation_budget_exhausted" };
+}
+
+export function buildPlanContinuationNudge(args: {
+  pendingSteps: number;
+  nextStepDescription?: string;
+}): string {
+  const stepLabel = args.pendingSteps === 1 ? "step" : "steps";
+  const next = args.nextStepDescription?.trim()
+    ? `\nNext pending step: "${args.nextStepDescription.trim()}"`
+    : "";
+
+  return (
+    `[SYSTEM: Your active plan still has ${args.pendingSteps} unfinished ${stepLabel}, ` +
+    `and you stopped without completing them or telling the user you were done.${next}\n` +
+    `Continue now: do the work for that step with tools, then call update_plan to record progress. ` +
+    `Do not re-summarize what you already did, and do not create a new plan. ` +
+    `If you truly cannot proceed without a decision from the user, ask one direct question and stop.]`
+  );
+}

--- a/src/gateway/services/agent/wrapUpContinuation.ts
+++ b/src/gateway/services/agent/wrapUpContinuation.ts
@@ -17,6 +17,28 @@ export const WRAP_UP_AFTER_TOOLS_NO_TEXT =
   "Write a brief user-facing summary of what you accomplished. Do not plan further edits, " +
   "do not say you will update files next, and do not call tools.]";
 
+/**
+ * Used instead of WRAP_UP_AFTER_TOOLS_NO_TEXT when the plan still has pending
+ * steps. The terminal wording above would tell the user the work was finished
+ * when it was not, so this asks for an honest status instead.
+ */
+export const WRAP_UP_WITH_PLAN_INCOMPLETE =
+  "[SYSTEM: Your last action was a tool call with no closing message, and your plan still has " +
+  "unfinished steps. Write a brief user-facing status: what you completed, what is still " +
+  "outstanding, and what you need in order to finish. Do not claim the task is complete, " +
+  "and do not call tools.]";
+
+/** Queue one continuation step with tools left intact so the loop keeps working. */
+export function applyPlanContinuationStep(
+  context: { messages: unknown[] },
+  nudge: string,
+): void {
+  context.messages.push({
+    role: "user",
+    content: nudge,
+  });
+}
+
 /** Disable tools and queue one text-only model step (memory pressure or hard limits). */
 export function applyForcedTextOnlyWrapUpStep(
   context: { messages: unknown[]; tools?: unknown[] },
@@ -43,6 +65,29 @@ export function shouldRequestWrapUpSummary(args: {
   isWrapUpContinuation: boolean;
 }): boolean {
   return explainPostStreamWrapUp(args).requested;
+}
+
+/**
+ * Merge a continuation's full result — text, thinking, tools and sequence — so
+ * the resumed work persists as one assistant turn and renders in one card.
+ *
+ * Token usage from the continuation is not merged, matching the existing
+ * wrap-up path.
+ */
+export function mergeContinuationIntoState(
+  base: StreamOrchestratorResult,
+  continuation: StreamOrchestratorResult,
+): StreamOrchestratorResult {
+  const trimmed = continuation.assistantText.trim();
+  const separator = base.assistantText.trim() && trimmed ? "\n\n" : "";
+
+  return {
+    assistantText: base.assistantText + separator + trimmed,
+    thinkingText: base.thinkingText + continuation.thinkingText,
+    toolCalls: [...base.toolCalls, ...continuation.toolCalls],
+    toolResults: [...base.toolResults, ...continuation.toolResults],
+    sequence: [...base.sequence, ...continuation.sequence],
+  };
 }
 
 export function mergeWrapUpTextIntoState(
@@ -74,6 +119,8 @@ type AiSdkWrapUpArgs = {
   apiKeys: string[];
   provider: string;
   abortSignal: AbortSignal;
+  /** Defaults to the terminal wording; pass WRAP_UP_WITH_PLAN_INCOMPLETE when steps remain. */
+  wrapUpMessage?: string;
 };
 
 /** Text-only continuation after AI SDK stream ends on tools without a user reply. */
@@ -87,7 +134,10 @@ export async function* runAiSdkWrapUpContinuation(
   const response = await args.aiSdkResult.response;
   const wrapUpMessages: ModelMessage[] = [
     ...response.messages,
-    { role: "user", content: WRAP_UP_AFTER_TOOLS_NO_TEXT },
+    {
+      role: "user",
+      content: args.wrapUpMessage ?? WRAP_UP_AFTER_TOOLS_NO_TEXT,
+    },
   ];
 
   const wrapUpResult = streamText({
@@ -127,6 +177,75 @@ export async function* runAiSdkWrapUpContinuation(
   }
 }
 
+type AiSdkPlanContinuationArgs = {
+  /** Conversation so far, from the finished stream's response. */
+  messages: ModelMessage[];
+  nudge: string;
+  /** Spread as-is so tools, stopWhen and prepareStep stay in force. */
+  streamTextOptions: {
+    model: LanguageModel;
+    [key: string]: unknown;
+  };
+  chatId: string;
+  apiKeys: string[];
+  provider: string;
+  abortSignal: AbortSignal;
+};
+
+/**
+ * Resume an AI SDK turn that stopped with plan work outstanding.
+ *
+ * Unlike the wrap-up runners this keeps tools enabled, so the model can
+ * actually do the remaining work rather than narrate it. The AI SDK runs its
+ * own tool loop, so one call can span many steps.
+ */
+export async function* runAiSdkPlanContinuation(
+  args: AiSdkPlanContinuationArgs,
+): AsyncGenerator<
+  StreamChunk & { chatId: string },
+  { state: StreamOrchestratorResult; messages: ModelMessage[] } | null,
+  undefined
+> {
+  const result = streamText({
+    ...args.streamTextOptions,
+    messages: [...args.messages, { role: "user", content: args.nudge }],
+    abortSignal: args.abortSignal,
+  });
+
+  let fullStream: AsyncIterable<unknown> = result.fullStream;
+  if (args.provider === "groq") {
+    const { adaptGroqAISDKFullStream } = await import(
+      "../../utils/groqProvider.js"
+    );
+    fullStream = adaptGroqAISDKFullStream(result.fullStream);
+  } else if (args.provider === "moonshot") {
+    const { adaptMoonshotAISDKFullStream } = await import(
+      "../../utils/moonshotProvider.js"
+    );
+    fullStream = adaptMoonshotAISDKFullStream(result.fullStream);
+  }
+
+  const iterator = orchestrateModelStream(fullStream, args.chatId, args.apiKeys, {
+    textBufferMin:
+      args.provider === "groq" || args.provider === "moonshot" ? 1 : undefined,
+  });
+
+  while (true) {
+    const next = await iterator.next();
+    if (next.done) {
+      const state = next.value;
+      const producedWork =
+        state.assistantText.trim().length > 0 || state.toolCalls.length > 0;
+      if (!producedWork) {
+        return null;
+      }
+      const response = await result.response;
+      return { state, messages: response.messages };
+    }
+    yield next.value;
+  }
+}
+
 type PiAiWrapUpArgs = {
   piContext: { messages: unknown[] };
   streamSimple: (
@@ -139,6 +258,8 @@ type PiAiWrapUpArgs = {
   chatId: string;
   apiKeys: string[];
   abortSignal: AbortSignal;
+  /** Defaults to the terminal wording; pass WRAP_UP_WITH_PLAN_INCOMPLETE when steps remain. */
+  wrapUpMessage?: string;
 };
 
 /** Text-only continuation for pi-ai when the tool loop did not produce a summary. */
@@ -151,7 +272,7 @@ export async function* runPiAiWrapUpContinuation(
 > {
   args.piContext.messages.push({
     role: "user",
-    content: WRAP_UP_AFTER_TOOLS_NO_TEXT,
+    content: args.wrapUpMessage ?? WRAP_UP_AFTER_TOOLS_NO_TEXT,
   });
 
   const contextWithoutTools = {

--- a/src/gateway/services/providers/PiCodexStreamWithToolLoop.ts
+++ b/src/gateway/services/providers/PiCodexStreamWithToolLoop.ts
@@ -14,7 +14,11 @@
  */
 
 import type { AssistantMessageEvent } from "@mariozechner/pi-ai";
-import { applyForcedTextOnlyWrapUpStep, WRAP_UP_AFTER_TOOLS_NO_TEXT } from "../agent/wrapUpContinuation.js";
+import {
+  applyForcedTextOnlyWrapUpStep,
+  applyPlanContinuationStep,
+  WRAP_UP_AFTER_TOOLS_NO_TEXT,
+} from "../agent/wrapUpContinuation.js";
 import {
   sanitizeToolOutput,
 } from "../../../core/tools/index.js";
@@ -373,6 +377,17 @@ export async function* createPiCodexStreamWithToolLoop(
     jobEnv?: Record<string, string>;
     delegationJobId?: string;
   },
+  /**
+   * Consulted when the model stops on its own. Returning a nudge keeps the loop
+   * running with tools intact, which is how a turn that stopped mid-plan gets
+   * resumed. Owned by AgentService so this layer stays free of PlanService.
+   */
+  resolveModelStop?: (info: {
+    trailingText: string;
+    step: number;
+    totalToolCalls: number;
+    continuationsUsed: number;
+  }) => Promise<{ nudge: string; pendingSteps: number } | null>,
 ): AsyncGenerator<OurChunk> {
   const context = {
     ...initialContext,
@@ -412,6 +427,10 @@ export async function* createPiCodexStreamWithToolLoop(
   let turnEndLogged = false;
   let lastModelFinishReason: string | null = null;
   let streamedTextChars = 0;
+
+  /** Text streamed during the current step — i.e. after the previous step's tools. */
+  let stepText = "";
+  let planContinuationsUsed = 0;
 
   const emitTurnEnd = (
     reason: PiTurnEndReason,
@@ -569,6 +588,7 @@ export async function* createPiCodexStreamWithToolLoop(
       toolCallsThisTurn.length = 0;
       lastFinishReason = null;
       finalMessage = null;
+      stepText = "";
 
       let capacityError: unknown | null = null;
       let shouldRetryCapacity = false;
@@ -732,6 +752,7 @@ export async function* createPiCodexStreamWithToolLoop(
               const delta = (chunk as { text?: string }).text;
               if (typeof delta === "string") {
                 streamedTextChars += delta.length;
+                stepText += delta;
               }
             }
             if (chunk) yield chunk;
@@ -1021,8 +1042,59 @@ export async function* createPiCodexStreamWithToolLoop(
         continue stepLoop;
       }
     } else {
-      // Model stopped without pending tools — turn is done; post-stream wrap-up
-      // in AgentService adds user text if the sequence ends on tool(s).
+      // Model stopped without pending tools. If an active plan still has
+      // pending steps this is usually a stop mid-work, not a finished turn —
+      // resume the loop (tools intact) instead of ending. Bounded by
+      // MAX_PLAN_CONTINUATIONS_PER_TURN in the resolver.
+      if (
+        resolveModelStop &&
+        lastFinishReason !== "length" &&
+        !textOnlyWrapUpStepUsed &&
+        !streamOptions.signal?.aborted &&
+        finalMessage != null
+      ) {
+        let continuation: { nudge: string; pendingSteps: number } | null = null;
+        try {
+          continuation = await resolveModelStop({
+            trailingText: stepText,
+            step,
+            totalToolCalls,
+            continuationsUsed: planContinuationsUsed,
+          });
+        } catch (err) {
+          // Never let the policy check break a turn that already succeeded.
+          console.warn(
+            `[PiCodexToolLoop] Plan continuation check failed:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+
+        if (continuation) {
+          planContinuationsUsed += 1;
+          console.warn(
+            `[TurnEnd:plan-continuation] ${JSON.stringify({
+              ts: new Date().toISOString(),
+              chatId: toolContext?.chatId ?? null,
+              sessionId: streamOptions.sessionId,
+              step,
+              totalToolCalls,
+              pendingSteps: continuation.pendingSteps,
+              continuation: planContinuationsUsed,
+              trailingTextChars: stepText.trim().length,
+            })}`,
+          );
+          // The assistant's own closing text must land in context before the
+          // nudge, or the resumed step cannot see what it just said.
+          appendToolTurnToContext(context, finalMessage, [], cumulativeTokens);
+          applyPlanContinuationStep(context, continuation.nudge);
+          stripAllAssistantReasoning(context.messages as unknown[]);
+          step++;
+          continue stepLoop;
+        }
+      }
+
+      // Turn is done; post-stream wrap-up in AgentService adds user text if the
+      // sequence ends on tool(s).
       emitTurnEnd(
         lastFinishReason === "length" ? "model_length" : "model_stop",
       );

--- a/tests/turn-continuation.test.ts
+++ b/tests/turn-continuation.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPlanContinuationNudge,
+  decideTurnEnd,
+  MAX_PLAN_CONTINUATIONS_PER_TURN,
+  trailingTextAfterLastTool,
+  trailingTextAwaitsUser,
+  type TurnEndInput,
+} from "../src/gateway/services/agent/turnContinuation.js";
+
+/** A turn that ran tools and then stopped with a mid-work preamble. */
+function preambleStop(overrides: Partial<TurnEndInput> = {}): TurnEndInput {
+  return {
+    pendingPlanSteps: 2,
+    trailingText: "Now let me check the launcher config:",
+    endsOnToolWithoutText: false,
+    toolCallCount: 12,
+    aborted: false,
+    hasInterruptedTools: false,
+    continuationsUsed: 0,
+    ...overrides,
+  };
+}
+
+describe("decideTurnEnd", () => {
+  it("resumes a turn that stopped mid-plan after a preamble", () => {
+    // The regression: trailing text used to skip every intervention, so the
+    // turn ended and the UI reported "Finished Working" over pending steps.
+    expect(decideTurnEnd(preambleStop())).toEqual({
+      action: "continue",
+      reason: "plan_steps_pending",
+    });
+  });
+
+  it("resumes when the model went silent mid-plan", () => {
+    const decision = decideTurnEnd(
+      preambleStop({ trailingText: "", endsOnToolWithoutText: true }),
+    );
+    expect(decision.action).toBe("continue");
+  });
+
+  it("never sends the terminal wrap-up while steps are pending", () => {
+    // Previously this returned a wrap-up whose prompt asserts "This turn is
+    // complete", manufacturing a completion over unfinished work.
+    const decision = decideTurnEnd(
+      preambleStop({
+        trailingText: "",
+        endsOnToolWithoutText: true,
+        continuationsUsed: MAX_PLAN_CONTINUATIONS_PER_TURN,
+      }),
+    );
+    expect(decision.action).toBe("wrap_up");
+    expect(decision.wrapUpKind).toBe("plan_incomplete");
+  });
+
+  it("keeps the terminal wrap-up when no plan work remains", () => {
+    const decision = decideTurnEnd(
+      preambleStop({
+        pendingPlanSteps: 0,
+        trailingText: "",
+        endsOnToolWithoutText: true,
+      }),
+    );
+    expect(decision).toEqual({
+      action: "wrap_up",
+      reason: "tools_without_reply",
+      wrapUpKind: "complete",
+    });
+  });
+
+  it("leaves plan-free turns with trailing text untouched", () => {
+    expect(decideTurnEnd(preambleStop({ pendingPlanSteps: 0 }))).toEqual({
+      action: "none",
+      reason: "trailing_text_after_tools",
+    });
+  });
+
+  it("does not interrupt a model that is waiting on the user", () => {
+    const decision = decideTurnEnd(
+      preambleStop({
+        trailingText:
+          "I'll do the one approved action, then lay out the full data-program plan for your approval.",
+      }),
+    );
+    expect(decision).toEqual({ action: "none", reason: "awaiting_user_input" });
+  });
+
+  it("stops pushing once the continuation budget is spent", () => {
+    const spent = decideTurnEnd(
+      preambleStop({ continuationsUsed: MAX_PLAN_CONTINUATIONS_PER_TURN }),
+    );
+    expect(spent).toEqual({
+      action: "none",
+      reason: "continuation_budget_exhausted",
+    });
+  });
+
+  it("respects abort over everything else", () => {
+    expect(decideTurnEnd(preambleStop({ aborted: true })).action).toBe("none");
+  });
+
+  it("does not push a text-only reply that called no tools", () => {
+    const decision = decideTurnEnd(preambleStop({ toolCallCount: 0 }));
+    expect(decision).toEqual({ action: "none", reason: "no_tool_calls" });
+  });
+
+  it("defers to the interrupted-tool path", () => {
+    const decision = decideTurnEnd(preambleStop({ hasInterruptedTools: true }));
+    expect(decision).toEqual({ action: "none", reason: "interrupted_tools" });
+  });
+});
+
+describe("trailingTextAwaitsUser", () => {
+  // Verbatim tails from turns that stopped mid-work in production logs.
+  const midWork = [
+    "Now let me see how the v56a launcher invokes `autonomous_loop` (the middle section), so gate 4 can mirror it exactly:",
+    "Let me pull the actual μ numbers for the coding tasks from the canvases so the document cites measured values.",
+    "I'll start by reading the current patent document and surveying the training materials.",
+    "Confirmed — granting Amir access to all three namespaces. Running the apply now. I'll stage it: **nodes first** (fast).",
+    "Decisive test — comparing v56a step500 vs MHAR step500 across all shared datasets:",
+  ];
+
+  it.each(midWork)("treats mid-work narration as resumable: %s", (text) => {
+    expect(trailingTextAwaitsUser(text)).toBe(false);
+  });
+
+  const handoffs = [
+    "Tell me which, and whether you want the gate-3 mixer swapped in.",
+    "Say the word and I'll run the smoke.",
+    "Which would you prefer?",
+    "Let me know how you want to proceed.",
+    "That's a real weakening of purity, and it's your call, not mine.",
+    "Do you want me to relaunch the campaign now?",
+    "I need your decision on the mixer before launching.",
+  ];
+
+  it.each(handoffs)("treats a handoff as a legitimate stop: %s", (text) => {
+    expect(trailingTextAwaitsUser(text)).toBe(true);
+  });
+
+  it("ignores a question buried early in a long report", () => {
+    const report = `Why did the router freeze? ${"Detail sentence. ".repeat(60)}Proceeding with the uniform-init fix now.`;
+    expect(trailingTextAwaitsUser(report)).toBe(false);
+  });
+
+  it("still detects a question ending in markdown emphasis", () => {
+    expect(trailingTextAwaitsUser("Which mixer should I use?**")).toBe(true);
+  });
+
+  it("treats empty text as mid-work, not a handoff", () => {
+    expect(trailingTextAwaitsUser("   ")).toBe(false);
+  });
+});
+
+describe("trailingTextAfterLastTool", () => {
+  it("returns only text emitted after the final tool call", () => {
+    const sequence = [
+      { type: "text", data: "Let me look." },
+      { type: "tool", data: { name: "bash" } },
+      { type: "text", data: "Found it. " },
+      { type: "text", data: "Now patching:" },
+    ];
+    expect(trailingTextAfterLastTool(sequence)).toBe("Found it. Now patching:");
+  });
+
+  it("is empty when the turn ends on a tool call", () => {
+    const sequence = [
+      { type: "text", data: "Checking." },
+      { type: "tool", data: { name: "bash" } },
+    ];
+    expect(trailingTextAfterLastTool(sequence)).toBe("");
+  });
+
+  it("returns all text when no tool ran", () => {
+    expect(
+      trailingTextAfterLastTool([{ type: "text", data: "Just an answer." }]),
+    ).toBe("Just an answer.");
+  });
+});
+
+describe("buildPlanContinuationNudge", () => {
+  it("names the next step and forbids re-summarizing", () => {
+    const nudge = buildPlanContinuationNudge({
+      pendingSteps: 3,
+      nextStepDescription: "Drain Parse grants to 0 pending",
+    });
+    expect(nudge).toContain("3 unfinished steps");
+    expect(nudge).toContain("Drain Parse grants to 0 pending");
+    expect(nudge).toContain("update_plan");
+    expect(nudge).toContain("do not create a new plan");
+    // Must leave an escape hatch, or it would loop against a real blocker.
+    expect(nudge).toContain("ask one direct question and stop");
+  });
+
+  it("keeps the sentence readable for a single step", () => {
+    const nudge = buildPlanContinuationNudge({ pendingSteps: 1 });
+    expect(nudge).toContain("1 unfinished step,");
+  });
+});


### PR DESCRIPTION
## What you saw

A turn runs 6–77 tool calls, ends on a sentence announcing what it will do *next*, and the UI says the turn is finished — with the plan still at 0/7. Then the following message looks like the model forgot everything.

Both of your reports are the same bug. The second is a consequence of the first: a turn that ends on "I'll write the drain runner next" leaves no evidence the runner was written, so the next turn re-derives state from scratch and reads as amnesia.

## Evidence

From the attached gateway logs, 54 turns:

- **9 ended with plan steps outstanding**, every one with `reason:"model_stop"` / `modelFinishReason:"stop"`. No step limit, no token cap, no abort — the model chose to stop.
- The gateway had **already diagnosed 6 of them**: `"likelyCause":"model_stop_with_pending_plan_steps (not gateway wrap-up)"`.
- **47/54** turns logged `skipReason:"trailing_text_after_tools"`.

## Why it happened

The turn-end decision had two outcomes and *both end the turn*:

1. **The terminal wrap-up fired over unfinished work.** When a turn ended on a tool call with no text, the gateway injected `WRAP_UP_AFTER_TOOLS_NO_TEXT` — "This turn is complete … do not call tools" — without checking plan state. On one `opus-5` turn that fired with 4 steps pending, so the false claim of completion was the gateway's, not the model's.
2. **Any trailing text skipped intervention entirely.** A mid-work preamble ("Now let me see how the launcher invokes…") is indistinguishable from a closing summary under a rule that only asks "is there text after the last tool?"
3. **Plan state was queried at turn end and only logged** — the code said so: "Plan lookup is best-effort for diagnostics only."

Not a context bug: `loadActivePlansContext` was verified to run on both routes and inject step statuses, progress, and "continue where you left off."

## The fix

A third option. `agent/turnContinuation.ts` decides `wrap_up | continue | none`:

- **Gated on an active plan with pending steps.** No plan means no reliable signal that work remains, so those turns keep today's behavior. This bounds the blast radius to exactly the turns that failed.
- **The terminal wrap-up can no longer fire over pending steps.** `WRAP_UP_WITH_PLAN_INCOMPLETE` asks for an honest status instead of asserting completion.
- **`trailingTextAwaitsUser` suppresses continuation** when the tail (last 400 chars) ends in a question or an approval phrase — "say the word", "for your approval", "tell me which". A genuine handoff is not steamrolled.
- **The nudge names the next pending step**, requires `update_plan`, forbids a new plan (so it can't collide with the Issue 30 duplicate-plan block), and offers an escape hatch — "if you truly cannot proceed without a decision, ask one direct question and stop" — so it can't loop against a real blocker.
- **Bounded at 2 continuations per turn.**

### Where continuation happens, and why the two routes differ

**pi-ai (OAuth): in-loop**, via a `resolveModelStop` callback at the `model_stop` exit. Resuming the existing loop keeps every budget in force (steps, memory, tokens, repetition) and keeps the turn as one message and one card. The callback lives in `AgentService` so the provider layer stays free of `PlanService`.

**AI SDK: post-stream.** `stopWhen` is only consulted after a step that made tool calls, so a `finishReason: "stop"` cannot be overridden from inside the loop. `runAiSdkPlanContinuation` issues a fresh `streamText` with the options spread (tools, `stopWhen`, `prepareStep` intact) and merges via `mergeContinuationIntoState`, so it persists as one assistant turn.

## Observability

`[TurnEnd:plan-continuation]` logs each resume with chat, step, pending count, and attempt number. Success looks like `activePlanPendingSteps: 0` on turns that previously logged `likelyCause: "model_stop_with_pending_plan_steps"`.

## Known limitation

Token usage from an AI SDK continuation is not merged into reported usage. This matches the pre-existing wrap-up path rather than fixing it here.

## Testing

- `tests/turn-continuation.test.ts` — 30 cases. The handoff tests use **verbatim trailing text from the logged failures** ("Say the word and I'll run the smoke — and tell me whether to keep the 56-param mixer…"), so a regression that steamrolls a real question fails the suite.
- `tsc --noEmit --project tsconfig.gateway.json` clean.
- `oxlint` introduces no new warnings.

Independent of #140 — rebased onto `master`, no overlap in the `AgentService.ts` hunks.
