### PR TITLE
Keep model selection scoped to its own chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4856,4 +4856,27 @@ Head-of-line blocking with a poison pill at the front: the queue could only grow
 
 ---
 
+### Issue 74: Model Selection Leaking Across Chats ✅ FIXED
+**Added:** 2026-09-03
+**Problem:** Returning to an Opus 5 chat showed — and ran — Claude Fable 5.1, in a chat where Fable had never been used. Not cosmetic: the picker value is sent as `config.model`, so the wrong model answered.
+**Evidence:** In one real chat, 32 assistant turns ran on `claude-opus-5` and 2 on `claude-fable-5`, *interleaved* rather than appended (so not a user switching midway). Across 30 days, 16 of 288 chats had more than one model answer, including cross-provider pairs like `claude-opus-5` + `gpt-5-6-sol-high`.
+**Root Cause:** `getLastSelectedModel(chatId)` fell through to a single global `localStorage["paprwork_last_model_id"]` when the chat had no in-memory entry — returning **another chat's** model. Per-chat selection lived only in a Zustand map with no `persist`, so three ordinary events emptied it: app restart, `resetForWorkspaceSwitch()`, and any chat that never touched the picker (`defaultChatState` omits `lastSelectedModelId`). Chat tabs also unmount on switch-away, so every return re-ran hydration and re-read the global.
+**Solution:** Separate the two conflated questions. "Which model is *this chat* on" is now persisted per `chatId` (bounded, LRU); "which model should a *new chat* start on" stays global, because there that is correct. Precedence: this chat's explicit pick → the model that last answered **in this chat** (from `messages.model`, server-side truth, no schema change) → global (**new chats only**) → app defaults. `hasHistory` comes from `messageCount`, so a reopened chat never flashes another chat's model while history loads.
+**Files Created:**
+- `ui/utils/chatModelMemory.ts` — durable per-chat store with rename/forget
+- `ui/utils/resolveChatModel.ts` — pure precedence rule + history lookup
+- `tests/chat-model-scoping.test.ts` — 21 tests
+- `docs/PER_CHAT_MODEL_SCOPING.md` — complete documentation
+**Files Changed:**
+- `ui/stores/chatStore.ts` — global fallback removed; `getDefaultModelForNewChat` added; selection carried across temp→permanent id rename
+- `ui/components/Chat/ChatContainer.tsx` — hydration uses the precedence rule
+- `ui/utils/historyMapper.ts`, `ui/types/chat.ts` — carry `model` per message
+- `ui/hooks/useChat.ts` — forget a deleted chat's model
+- `ui/App.tsx` — boot seeds the new-chat default, not per-chat state
+**Prevention:** A read for a specific key must not fall back to a global value — returning *something* looks robust but silently answers a question that was not asked. If per-entity state is worth reading after a restart, persist it per entity; an in-memory map plus a global fallback degrades into the global on every restart.
+**Related:** Fable 5.1 producing no output at all is a separate defect (AI SDK v6 `maxOutputTokens` rename + Anthropic `display: "summarized"` adaptive thinking) — see PR #140.
+**See:** `docs/PER_CHAT_MODEL_SCOPING.md`
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**

--- a/docs/PER_CHAT_MODEL_SCOPING.md
+++ b/docs/PER_CHAT_MODEL_SCOPING.md
@@ -1,0 +1,122 @@
+# Per-Chat Model Scoping
+
+**Fixed:** 2026-09-03
+
+## Symptom
+
+Open three chats — two on Claude Opus 5, one on Claude Fable 5.1. Return to an
+Opus chat and the picker reads **Fable 5.1**, in a chat where Fable was never
+used.
+
+This is not only a mislabelled picker. The picker's value is what
+`ChatContainer` sends as `config.model`, so the displayed model is the model
+that answers.
+
+## Evidence
+
+From a real installation (`chats.db`, read-only):
+
+```sql
+SELECT model, COUNT(*) FROM messages
+WHERE chat_id = 'e7008114-…' AND role = 'assistant'
+GROUP BY model ORDER BY MIN(timestamp);
+
+claude-opus-5  | 32   -- 2026-09-02T16:08 … 2026-09-03T23:30
+claude-fable-5 |  2   -- 2026-09-02T23:41 … 2026-09-03T01:04
+```
+
+Two turns of an Opus conversation were served by Fable, *interleaved* with the
+Opus turns rather than appended — so this was not the user switching models
+partway through. Across 30 days, 16 of 288 chats had more than one model answer,
+including cross-provider pairs such as `claude-opus-5` + `gpt-5-6-sol-high`.
+
+## Root cause
+
+Model selection had three layers, and only the weakest one was durable:
+
+| Layer | Scope | Survived restart? |
+|---|---|---|
+| `ChatContainer` `useState` | one mounted chat | no |
+| `chatStates[chatId].lastSelectedModelId` | per chat | **no** (plain Zustand map) |
+| `localStorage["paprwork_last_model_id"]` | **global** | yes |
+
+`getLastSelectedModel(chatId)` fell through to the global value whenever the
+requested chat had no in-memory entry:
+
+```ts
+const fromChat = state.chatStates.get(chatId)?.lastSelectedModelId;
+if (fromChat) return fromChat;
+return localStorage.getItem("paprwork_last_model_id"); // ← another chat's model
+```
+
+Three ordinary events empty the per-chat map, after which *every* chat reads the
+global:
+
+1. **App restart** — the store has no `persist` middleware.
+2. **Workspace switch** — `resetForWorkspaceSwitch()` clears `chatStates`.
+3. **A chat that never touched the picker** — `defaultChatState` omits
+   `lastSelectedModelId`, so it is only ever written by an explicit change.
+
+Chat tabs also unmount when you switch away (unlike app tabs, they are not
+kept alive), so returning to a chat re-runs hydration and re-reads the global.
+
+## The fix
+
+Separate the two questions that were conflated:
+
+- **Which model is *this chat* on?** Persisted per chat, keyed by `chatId`
+  (`ui/utils/chatModelMemory.ts`), so it survives restarts and workspace
+  switches. Bounded at `MAX_REMEMBERED_CHATS` (200), evicting least-recently-used.
+- **Which model should a *new chat* start on?** The global last pick. Still
+  global, because here that is the correct answer.
+
+Precedence is now (`ui/utils/resolveChatModel.ts`):
+
+1. This chat's explicit selection.
+2. The model that last answered **in this chat**, read from `messages.model` in
+   its own history. This is server-side truth and needs no new schema — it works
+   even after local storage is cleared or the app is reinstalled.
+3. The global default — **only** when the chat has no history. An existing chat
+   never inherits another chat's model.
+4. The app's ordinary defaults (`sonnet-5` → `gpt-5-6-sol` → …).
+
+`hasHistory` comes from chat metadata (`messageCount`), so it is known before
+history finishes loading. A reopened chat therefore never flashes another chat's
+model while waiting.
+
+Re-deriving is idempotent: an explicit per-chat pick outranks history, so the
+hydration effect can re-run when history arrives without walking back a
+selection the user just made.
+
+## Files
+
+| File | Change |
+|---|---|
+| `ui/utils/chatModelMemory.ts` | **New** — durable per-chat store, bounded, with rename/forget |
+| `ui/utils/resolveChatModel.ts` | **New** — precedence rule and history lookup, pure |
+| `ui/stores/chatStore.ts` | Global fallback removed from `getLastSelectedModel`; added `getDefaultModelForNewChat`; selection carried across the temp→permanent id rename |
+| `ui/components/Chat/ChatContainer.tsx` | Hydration uses the precedence rule |
+| `ui/utils/historyMapper.ts`, `ui/types/chat.ts` | Carry `model` per message so a chat can recover its own model |
+| `ui/hooks/useChat.ts` | Forget a deleted chat's model |
+| `ui/App.tsx` | Boot seeds the *new-chat* default, not per-chat state |
+| `tests/chat-model-scoping.test.ts` | 21 tests |
+
+## Tests
+
+```bash
+npx vitest run tests/chat-model-scoping.test.ts --config vitest.config.unit.ts
+```
+
+Covers per-chat isolation, survival across a simulated restart, the reported
+regression (existing chat + global Fable → does *not* return Fable), new-chat
+seeding, the temp→permanent rename, LRU eviction, corrupted/tampered storage,
+and a missing `window`.
+
+## Prevention
+
+"Which model is this chat on" and "which model should a new chat use" are
+different questions with different scopes. A read for a specific key must not
+fall back to a global value — returning *something* looks robust but silently
+answers a question that was not asked. If per-entity state is worth reading
+after a restart, it has to be persisted per entity; an in-memory map plus a
+global fallback degrades into the global on every restart.

--- a/tests/chat-model-scoping.test.ts
+++ b/tests/chat-model-scoping.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Model selection must not cross between chats.
+ *
+ * The bug these cover: per-chat selection lived only in an in-memory map, so a
+ * restart emptied it and every chat then fell back to one global "last model
+ * picked anywhere". Opening an Opus chat showed Fable — and, because the picker
+ * value is what gets sent as `config.model`, Fable actually answered. In one
+ * real chat, 32 turns ran on claude-opus-5 and 2 turns silently ran on Fable.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  MAX_REMEMBERED_CHATS,
+  forgetChatModel,
+  readChatModel,
+  readNewChatDefaultModel,
+  renameChatModel,
+  writeChatModel,
+  writeNewChatDefaultModel,
+} from "../ui/utils/chatModelMemory";
+import {
+  findHistoryModelId,
+  resolveChatModelId,
+} from "../ui/utils/resolveChatModel";
+
+/** Minimal localStorage so these run without a DOM. */
+class MemoryStorage implements Storage {
+  private data = new Map<string, string>();
+  get length(): number {
+    return this.data.size;
+  }
+  clear(): void {
+    this.data.clear();
+  }
+  getItem(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.data.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.data.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.data.set(key, String(value));
+  }
+}
+
+const OPUS = "claude-opus-5";
+const FABLE = "claude-fable-5-1";
+
+beforeEach(() => {
+  const storage = new MemoryStorage();
+  // @ts-expect-error -- test shim for a browser global
+  globalThis.window = { localStorage: storage };
+});
+
+describe("chatModelMemory", () => {
+  it("keeps each chat's model separate", () => {
+    writeChatModel("chat-opus", OPUS);
+    writeChatModel("chat-fable", FABLE);
+
+    expect(readChatModel("chat-opus")).toBe(OPUS);
+    expect(readChatModel("chat-fable")).toBe(FABLE);
+  });
+
+  it("regression: picking a model in one chat does not change another", () => {
+    writeChatModel("chat-a", OPUS);
+    writeChatModel("chat-b", OPUS);
+
+    writeChatModel("chat-b", FABLE);
+
+    expect(readChatModel("chat-a")).toBe(OPUS);
+    expect(readChatModel("chat-b")).toBe(FABLE);
+  });
+
+  it("survives a restart — this is what the in-memory map could not do", () => {
+    writeChatModel("chat-opus", OPUS);
+
+    // A restart drops React/Zustand state but not localStorage.
+    expect(readChatModel("chat-opus")).toBe(OPUS);
+  });
+
+  it("returns undefined for a chat it has never seen", () => {
+    writeChatModel("chat-fable", FABLE);
+    expect(readChatModel("chat-unknown")).toBeUndefined();
+  });
+
+  it("tracks the new-chat default separately from any chat", () => {
+    writeChatModel("chat-opus", OPUS);
+    writeNewChatDefaultModel(FABLE);
+
+    expect(readNewChatDefaultModel()).toBe(FABLE);
+    expect(readChatModel("chat-opus")).toBe(OPUS);
+  });
+
+  it("carries the selection across the temp -> permanent chat id rename", () => {
+    writeChatModel("temp-123", FABLE);
+    renameChatModel("temp-123", "real-456");
+
+    expect(readChatModel("real-456")).toBe(FABLE);
+    expect(readChatModel("temp-123")).toBeUndefined();
+  });
+
+  it("forgets a deleted chat", () => {
+    writeChatModel("chat-gone", OPUS);
+    forgetChatModel("chat-gone");
+    expect(readChatModel("chat-gone")).toBeUndefined();
+  });
+
+  it("bounds growth, evicting least recently used chats first", () => {
+    for (let i = 0; i < MAX_REMEMBERED_CHATS; i++) {
+      writeChatModel(`chat-${i}`, OPUS);
+    }
+    // Revisit the oldest so it is no longer least-recently-used.
+    writeChatModel("chat-0", FABLE);
+    writeChatModel("chat-overflow", OPUS);
+
+    expect(readChatModel("chat-0")).toBe(FABLE);
+    expect(readChatModel("chat-overflow")).toBe(OPUS);
+    expect(readChatModel("chat-1")).toBeUndefined();
+  });
+
+  it("shrugs off a corrupted blob instead of throwing", () => {
+    window.localStorage.setItem("paprwork_chat_model_ids", "{not json");
+    expect(readChatModel("chat-any")).toBeUndefined();
+
+    writeChatModel("chat-any", OPUS);
+    expect(readChatModel("chat-any")).toBe(OPUS);
+  });
+
+  it("ignores non-string entries in a tampered blob", () => {
+    window.localStorage.setItem(
+      "paprwork_chat_model_ids",
+      JSON.stringify({ good: OPUS, bad: 42, empty: "" }),
+    );
+    expect(readChatModel("good")).toBe(OPUS);
+    expect(readChatModel("bad")).toBeUndefined();
+    expect(readChatModel("empty")).toBeUndefined();
+  });
+
+  it("does not throw when there is no window (SSR / worker)", () => {
+    // @ts-expect-error -- removing the test shim
+    delete globalThis.window;
+    expect(() => writeChatModel("chat-a", OPUS)).not.toThrow();
+    expect(readChatModel("chat-a")).toBeUndefined();
+    expect(readNewChatDefaultModel()).toBeUndefined();
+  });
+});
+
+describe("resolveChatModelId", () => {
+  it("prefers the chat's own explicit selection", () => {
+    expect(
+      resolveChatModelId({
+        perChatModelId: OPUS,
+        historyModelId: FABLE,
+        newChatDefaultModelId: FABLE,
+        hasHistory: true,
+      }),
+    ).toBe(OPUS);
+  });
+
+  it("falls back to the model that answered in this chat", () => {
+    expect(
+      resolveChatModelId({
+        historyModelId: OPUS,
+        newChatDefaultModelId: FABLE,
+        hasHistory: true,
+      }),
+    ).toBe(OPUS);
+  });
+
+  it("regression: an existing chat never inherits the global default", () => {
+    // The exact reported case: an Opus chat, no local selection left after a
+    // restart, and Fable was the last model picked in some other chat.
+    expect(
+      resolveChatModelId({
+        newChatDefaultModelId: FABLE,
+        hasHistory: true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("seeds a brand-new chat from the global default", () => {
+    expect(
+      resolveChatModelId({
+        newChatDefaultModelId: FABLE,
+        hasHistory: false,
+      }),
+    ).toBe(FABLE);
+  });
+
+  it("returns undefined when there is nothing to go on", () => {
+    expect(resolveChatModelId({ hasHistory: false })).toBeUndefined();
+  });
+
+  it("keeps two parallel chats on their own models", () => {
+    const opusChat = resolveChatModelId({
+      perChatModelId: OPUS,
+      newChatDefaultModelId: FABLE,
+      hasHistory: true,
+    });
+    const fableChat = resolveChatModelId({
+      perChatModelId: FABLE,
+      newChatDefaultModelId: FABLE,
+      hasHistory: true,
+    });
+
+    expect(opusChat).toBe(OPUS);
+    expect(fableChat).toBe(FABLE);
+  });
+});
+
+describe("findHistoryModelId", () => {
+  it("returns the model that answered most recently", () => {
+    expect(
+      findHistoryModelId([
+        { role: "user" },
+        { role: "assistant", model: FABLE },
+        { role: "user" },
+        { role: "assistant", model: OPUS },
+      ]),
+    ).toBe(OPUS);
+  });
+
+  it("skips a streaming turn that has no model yet", () => {
+    expect(
+      findHistoryModelId([
+        { role: "assistant", model: OPUS },
+        { role: "user" },
+        { role: "assistant" },
+      ]),
+    ).toBe(OPUS);
+  });
+
+  it("ignores user messages", () => {
+    expect(
+      findHistoryModelId([{ role: "user", model: FABLE }]),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for an empty chat", () => {
+    expect(findHistoryModelId([])).toBeUndefined();
+  });
+});

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -29,6 +29,7 @@ import { PaprQuotaBanner } from "./components/PaprQuotaBanner/PaprQuotaBanner";
 import { ConnectionIndicator } from "./components/ConnectionIndicator/ConnectionIndicator";
 import { useAppStatePersistence } from "./hooks/useAppStatePersistence";
 import { useChatStore } from "./stores/chatStore";
+import { writeNewChatDefaultModel } from "./utils/chatModelMemory";
 import {
   initializeAmplitudeBrowser,
   setTelemetryPaprUserId,
@@ -132,9 +133,10 @@ export function App() {
         if (response.success && response.data?.uiPreferences) {
           const { lastModelId } = response.data.uiPreferences;
           
-          // Populate localStorage for fast access (model selection only)
+          // Seeds *new* chats only. Existing chats resolve their own model from
+          // their per-chat selection or their history, never from this value.
           if (lastModelId) {
-            localStorage.setItem("paprwork_last_model_id", lastModelId);
+            writeNewChatDefaultModel(lastModelId);
           }
           
           console.log('[App] UI preferences loaded from settings:', { lastModelId });

--- a/ui/components/Chat/ChatContainer.tsx
+++ b/ui/components/Chat/ChatContainer.tsx
@@ -36,6 +36,10 @@ import {
 } from "../../stores/artifactsStore";
 import { artifactsToMessageAttachments } from "../../utils/messageAttachments";
 import { mapHistoryMessages } from "../../utils/historyMapper";
+import {
+  findHistoryModelId,
+  resolveChatModelId,
+} from "../../utils/resolveChatModel";
 import { extractFilesFromDataTransfer } from "../../utils/chatAttachmentFiles";
 import "./ChatContainer.css";
 import { trackEvent } from "../../lib/telemetry";
@@ -234,11 +238,33 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
 
   const isWaitingForModel = selectedModel.provider === 'ollama' && installing === selectedModel.id;
 
+  /** Model that last answered in *this* chat — the durable per-chat record. */
+  const historyModelId = useMemo(() => findHistoryModelId(messages), [messages]);
+
+  /**
+   * Does this chat already hold a conversation? Answered from chat metadata so
+   * it is known before history finishes loading; an existing chat must never be
+   * seeded from the global "last model picked anywhere".
+   */
+  const chatHasHistory = useChatStore((state) => {
+    const known = state.chats.find((chat) => chat.id === chatId);
+    if (known) return known.messageCount > 0;
+    return (state.chatStates.get(chatId)?.messages.length ?? 0) > 0;
+  });
+
   // When chatId or auth status changes: pick best default
-  // Priority: last selected (persisted in localStorage) > default order (sonnet-5 → gpt-5-6-sol → gemini-3-flash) > first available
+  // Priority: this chat's own selection > this chat's own history > global
+  // default (new chats only) > default order (sonnet-5 → gpt-5-6-sol →
+  // gemini-3-flash) > first available
   useEffect(() => {
     setSelectedModel((prev) => {
-      const lastId = useChatStore.getState().getLastSelectedModel(chatId);
+      const store = useChatStore.getState();
+      const lastId = resolveChatModelId({
+        perChatModelId: store.getLastSelectedModel(chatId),
+        historyModelId,
+        newChatDefaultModelId: store.getDefaultModelForNewChat(),
+        hasHistory: chatHasHistory,
+      });
       if (lastId) {
         const migratedId = migratePickerModelId(lastId);
         const lastModel = getModelById(migratedId);
@@ -256,7 +282,11 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
       if (!isModelAvailable(prev)) return fallbackModel;
       return prev;
     });
-  }, [chatId, authStatus, pickerModels]);
+    // historyModelId is a dependency because history arrives after mount: a
+    // chat reopened before its messages load must correct itself once they do.
+    // Re-running is safe — an explicit per-chat pick outranks history, so this
+    // cannot walk back a selection the user just made.
+  }, [chatId, authStatus, pickerModels, historyModelId, chatHasHistory]);
 
   // Focus input when this chat's container mounts
   useEffect(() => {

--- a/ui/hooks/useChat.ts
+++ b/ui/hooks/useChat.ts
@@ -9,6 +9,7 @@ import { useTabStore } from "../stores/tabStore";
 import { gateway } from "../src/lib/gateway";
 import { mapHistoryMessages } from "../utils/historyMapper";
 import { fetchChatHistory } from "../utils/chatHistoryApi";
+import { forgetChatModel } from "../utils/chatModelMemory";
 import {
   chatHasLiveStreamBlockingHistory,
   mergeHistoryWithLocal,
@@ -305,6 +306,7 @@ export function useChat() {
     async (chatId: string) => {
       try {
         await gateway.send("chat:delete", { chatId });
+        forgetChatModel(chatId);
         await loadChats(true);
         // Note: Tab management handled by tabStore (closeTab)
       } catch (error) {

--- a/ui/stores/chatStore.ts
+++ b/ui/stores/chatStore.ts
@@ -17,6 +17,13 @@ import type { MemoryAudience } from "../constants/memoryScope";
 import type { ToolCall } from "../types/core";
 import { gateway } from "../src/lib/gateway";
 import { trackEvent } from "../lib/telemetry";
+import {
+  readChatModel,
+  readNewChatDefaultModel,
+  renameChatModel,
+  writeChatModel,
+  writeNewChatDefaultModel,
+} from "../utils/chatModelMemory";
 
 // Re-export types for backward compatibility
 export type { ChatMetadata, ChatMessage, ChatState, StreamingState, SequenceItem, MessageAttachment };
@@ -79,7 +86,10 @@ interface ChatStore {
 
   // Model selection per chat
   setLastSelectedModel: (chatId: string, modelId: string) => void;
+  /** The model this chat is on, or undefined — never another chat's model. */
   getLastSelectedModel: (chatId: string) => string | undefined;
+  /** Seed for chats with no history of their own. */
+  getDefaultModelForNewChat: () => string | undefined;
 
   // ──────────────────────────────────────────────────────────────────────
   // Live streaming slice (ephemeral, separate from chatStates.messages)
@@ -291,6 +301,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   migrateChatId: (oldChatId, newChatId) =>
     set((state) => {
       if (oldChatId === newChatId) return state;
+
+      // Carry the persisted model across the rename, or the chat loses it the
+      // moment its first message gives it a permanent id.
+      renameChatModel(oldChatId, newChatId);
 
       const oldState = state.chatStates.get(oldChatId);
       const newChatStates = new Map(state.chatStates);
@@ -555,32 +569,34 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         } catch { /* ignore */ }
       }
 
-      if (typeof window !== "undefined") {
-        try {
-          localStorage.setItem("paprwork_last_model_id", modelId);
-          // Also save to Gateway settings for reliable persistence
-          gateway.send('settings:save-ui-preferences', { lastModelId: modelId }).catch(() => {});
-        } catch {
-          /* ignore */
-        }
+      // Two separate facts: this chat is on this model, and a new chat should
+      // start here. Keeping them apart is what stops one chat's pick from
+      // becoming another chat's model.
+      writeChatModel(chatId, modelId);
+      writeNewChatDefaultModel(modelId);
+      try {
+        gateway
+          .send("settings:save-ui-preferences", { lastModelId: modelId })
+          .catch(() => {});
+      } catch {
+        /* ignore */
       }
       return { chatStates: newChatStates };
     }),
 
+  /**
+   * The model *this* chat is on — never another chat's. Returns undefined when
+   * the chat has no selection of its own; callers decide what to fall back to
+   * (see ChatContainer, which prefers the chat's own history over any global).
+   */
   getLastSelectedModel: (chatId) => {
-    const state = get();
-    const fromChat = state.chatStates.get(chatId)?.lastSelectedModelId;
+    const fromChat = get().chatStates.get(chatId)?.lastSelectedModelId;
     if (fromChat) return fromChat;
-    if (typeof window !== "undefined") {
-      try {
-        const persisted = localStorage.getItem("paprwork_last_model_id");
-        if (persisted) return persisted;
-      } catch {
-        /* ignore */
-      }
-    }
-    return undefined;
+    return readChatModel(chatId);
   },
+
+  /** What a brand-new chat should open on: the last model picked anywhere. */
+  getDefaultModelForNewChat: () => readNewChatDefaultModel(),
 
   // Load UI preferences from settings (called on app mount)
   loadUIPreferences: async () => {

--- a/ui/stores/chatStore.ts
+++ b/ui/stores/chatStore.ts
@@ -12,6 +12,7 @@ import type {
   StreamingState,
   SequenceItem,
   StreamRecoveryReason,
+  MessageAttachment,
 } from "../types/chat";
 import type { MemoryAudience } from "../constants/memoryScope";
 import type { ToolCall } from "../types/core";
@@ -602,12 +603,17 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   loadUIPreferences: async () => {
     try {
       const response = await gateway.send('settings:get', {});
-      if (response.success && response.data?.uiPreferences) {
-        const { lastModelId } = response.data.uiPreferences;
-        if (lastModelId) {
-          // Store in localStorage for fast access
-          localStorage.setItem("paprwork_last_model_id", lastModelId);
-        }
+      // `GatewayResponse.data` is `unknown` by design; narrow it the same way
+      // the other settings:get callers do rather than widening the response.
+      const uiPreferences = response.success
+        ? (response.data as { uiPreferences?: { lastModelId?: string } })
+            ?.uiPreferences
+        : undefined;
+      const lastModelId = uiPreferences?.lastModelId;
+      if (lastModelId) {
+        // Seeds *new* chats only. An existing chat resolves its own model from
+        // its per-chat selection or its history — see resolveChatModelId.
+        writeNewChatDefaultModel(lastModelId);
       }
     } catch (error) {
       console.error('[ChatStore] Failed to load UI preferences:', error);

--- a/ui/types/chat.ts
+++ b/ui/types/chat.ts
@@ -47,6 +47,11 @@ export interface ChatMessage extends CoreMessage {
   streamingContent?: string;
   /** Context files/docs attached when the user sent this message */
   attachments?: MessageAttachment[];
+  /**
+   * Model that produced this assistant message, as persisted by the gateway.
+   * Read back to restore a chat's own model on reopen.
+   */
+  model?: string;
 
   // V1-style sequence for interleaving text and tool calls
   sequence?: SequenceItem[];

--- a/ui/utils/chatModelMemory.ts
+++ b/ui/utils/chatModelMemory.ts
@@ -1,0 +1,177 @@
+/**
+ * Which model each chat is using, and which model a *new* chat should start on.
+ *
+ * These are two different questions, and conflating them let one chat's model
+ * bleed into another. Per-chat selection used to live only in an in-memory
+ * Zustand map, so every app restart and every workspace switch emptied it —
+ * after which a read for chat A fell back to the single global "last model" and
+ * returned whatever had been picked last in *any* chat. That is not cosmetic:
+ * the picker value is what gets sent as `config.model`, so the wrong model
+ * actually answered.
+ *
+ * So per-chat selection is persisted here, keyed by chat, and the global value
+ * is kept strictly as the seed for chats that have no history of their own.
+ */
+
+/** chatId -> modelId. Insertion-ordered; oldest entries are evicted first. */
+const PER_CHAT_KEY = "paprwork_chat_model_ids";
+
+/** Single value: what a brand-new chat should open on. */
+const NEW_CHAT_DEFAULT_KEY = "paprwork_last_model_id";
+
+/**
+ * Cap on remembered chats. Selections are tiny, but this map is written on
+ * every model change for the life of the install, so it needs a ceiling.
+ */
+export const MAX_REMEMBERED_CHATS = 200;
+
+type ChatModelMap = Record<string, string>;
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch {
+    // Storage can throw outright when disabled by policy.
+    return null;
+  }
+}
+
+function readMap(): ChatModelMap {
+  const store = storage();
+  if (!store) {
+    return {};
+  }
+  try {
+    const raw = store.getItem(PER_CHAT_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    // Drop anything that is not a plain string pair rather than trusting the blob.
+    const clean: ChatModelMap = {};
+    for (const [chatId, modelId] of Object.entries(parsed)) {
+      if (
+        typeof chatId === "string" &&
+        typeof modelId === "string" &&
+        modelId
+      ) {
+        clean[chatId] = modelId;
+      }
+    }
+    return clean;
+  } catch {
+    return {};
+  }
+}
+
+function writeMap(map: ChatModelMap): void {
+  const store = storage();
+  if (!store) {
+    return;
+  }
+  try {
+    store.setItem(PER_CHAT_KEY, JSON.stringify(map));
+  } catch {
+    /* quota or disabled storage — selection degrades to in-memory only */
+  }
+}
+
+/** The model this specific chat is on, if it has ever been established. */
+export function readChatModel(chatId: string): string | undefined {
+  if (!chatId) {
+    return undefined;
+  }
+  return readMap()[chatId];
+}
+
+/**
+ * Record the model for one chat. Re-writing an existing chat refreshes its
+ * position, so the chats a user actually returns to are the last to be evicted.
+ */
+export function writeChatModel(chatId: string, modelId: string): void {
+  if (!chatId || !modelId) {
+    return;
+  }
+
+  const map = readMap();
+  delete map[chatId];
+  map[chatId] = modelId;
+
+  const chatIds = Object.keys(map);
+  if (chatIds.length > MAX_REMEMBERED_CHATS) {
+    for (const stale of chatIds.slice(
+      0,
+      chatIds.length - MAX_REMEMBERED_CHATS,
+    )) {
+      delete map[stale];
+    }
+  }
+
+  writeMap(map);
+}
+
+/** Forget a chat's model — call when the chat is deleted. */
+export function forgetChatModel(chatId: string): void {
+  if (!chatId) {
+    return;
+  }
+  const map = readMap();
+  if (!(chatId in map)) {
+    return;
+  }
+  delete map[chatId];
+  writeMap(map);
+}
+
+/**
+ * Carry a selection across the temp-id -> permanent-id rename that happens on
+ * the first message of a new chat. Without this, the chat loses its model the
+ * moment it is persisted.
+ */
+export function renameChatModel(oldChatId: string, newChatId: string): void {
+  if (!oldChatId || !newChatId || oldChatId === newChatId) {
+    return;
+  }
+  const map = readMap();
+  const modelId = map[oldChatId];
+  if (!modelId) {
+    return;
+  }
+  delete map[oldChatId];
+  map[newChatId] = modelId;
+  writeMap(map);
+}
+
+/**
+ * What a brand-new chat should open on: the last model the user picked
+ * anywhere. Deliberately global — this is the one place that is correct.
+ */
+export function readNewChatDefaultModel(): string | undefined {
+  const store = storage();
+  if (!store) {
+    return undefined;
+  }
+  try {
+    return store.getItem(NEW_CHAT_DEFAULT_KEY) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeNewChatDefaultModel(modelId: string): void {
+  const store = storage();
+  if (!store || !modelId) {
+    return;
+  }
+  try {
+    store.setItem(NEW_CHAT_DEFAULT_KEY, modelId);
+  } catch {
+    /* ignore */
+  }
+}

--- a/ui/utils/historyMapper.ts
+++ b/ui/utils/historyMapper.ts
@@ -182,6 +182,12 @@ export function mapHistoryMessages(
       reasoning,
       toolCalls,
       sequence: sequenceRaw, // Include sequence for interleaved rendering
+      // Which model actually answered. This is the durable record of what a
+      // chat was running on, so reopening it can restore that model instead of
+      // inheriting whatever was last picked in some other chat.
+      ...(typeof candidate.model === "string" && candidate.model
+        ? { model: candidate.model }
+        : {}),
       // Persisted by the gateway when a turn never finished. Carrying it through
       // keeps an interrupted turn labelled as such after a reload, instead of
       // reappearing as a finished answer.

--- a/ui/utils/resolveChatModel.ts
+++ b/ui/utils/resolveChatModel.ts
@@ -1,0 +1,61 @@
+/**
+ * Which model should a chat open on?
+ *
+ * The old rule was "whatever was picked last, anywhere", which is why opening
+ * an Opus chat could show — and then actually run — Fable. Precedence now
+ * starts from the chat itself and only reaches for a global value when the chat
+ * has nothing of its own to go on.
+ */
+
+export interface ChatModelCandidates {
+  /** Explicit selection made for this chat. */
+  perChatModelId?: string;
+  /** Model that answered most recently *in this chat* (from persisted history). */
+  historyModelId?: string;
+  /** Last model picked anywhere. Only meaningful for a chat with no history. */
+  newChatDefaultModelId?: string;
+  /**
+   * Whether this chat already holds a conversation. When true, a global default
+   * is never used: an existing chat must not inherit another chat's model.
+   */
+  hasHistory: boolean;
+}
+
+/**
+ * Returns the model id to open with, or undefined to fall back to the app's
+ * ordinary defaults. The returned id is raw — callers still migrate retired ids
+ * and check availability, since a chat may name a model the user can no longer
+ * reach.
+ */
+export function resolveChatModelId(
+  candidates: ChatModelCandidates,
+): string | undefined {
+  if (candidates.perChatModelId) {
+    return candidates.perChatModelId;
+  }
+
+  // The chat's own history is the truthful record of what it was running on,
+  // and it survives restarts and cleared local storage.
+  if (candidates.historyModelId) {
+    return candidates.historyModelId;
+  }
+
+  if (!candidates.hasHistory && candidates.newChatDefaultModelId) {
+    return candidates.newChatDefaultModelId;
+  }
+
+  return undefined;
+}
+
+/** Model that most recently answered in this chat, if any assistant turn did. */
+export function findHistoryModelId(
+  messages: ReadonlyArray<{ role: string; model?: string }>,
+): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message?.role === "assistant" && message.model) {
+      return message.model;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Symptom

Three chats open — two on Claude Opus 5, one on Claude Fable 5.1. Return to an Opus chat and the picker reads **Fable 5.1**, in a chat where Fable was never used.

This is not just a mislabelled picker. The picker's value is what `ChatContainer` sends as `config.model`, so the displayed model is the model that answers.

## Evidence

From a real installation (`chats.db`, read-only):

```
SELECT model, COUNT(*) FROM messages
WHERE chat_id = 'e7008114-…' AND role = 'assistant' GROUP BY model;

claude-opus-5  | 32   -- 2026-09-02T16:08 … 2026-09-03T23:30
claude-fable-5 |  2   -- 2026-09-02T23:41 … 2026-09-03T01:04
```

Two turns of an Opus conversation were served by Fable, **interleaved** with the Opus turns rather than appended — so this was not the user switching models partway through. Across 30 days, **16 of 288 chats** had more than one model answer, including cross-provider pairs such as `claude-opus-5` + `gpt-5-6-sol-high`.

## Root cause

Model selection had three layers, and only the weakest one was durable:

| Layer | Scope | Survived restart? |
|---|---|---|
| `ChatContainer` `useState` | one mounted chat | no |
| `chatStates[chatId].lastSelectedModelId` | per chat | **no** (plain Zustand map) |
| `localStorage["paprwork_last_model_id"]` | **global** | yes |

`getLastSelectedModel(chatId)` fell through to the global value whenever the requested chat had no in-memory entry:

```ts
const fromChat = state.chatStates.get(chatId)?.lastSelectedModelId;
if (fromChat) return fromChat;
return localStorage.getItem("paprwork_last_model_id"); // ← another chat's model
```

Three ordinary events empty the per-chat map, after which *every* chat reads the global:

1. **App restart** — the store has no `persist` middleware.
2. **Workspace switch** — `resetForWorkspaceSwitch()` clears `chatStates`.
3. **A chat that never touched the picker** — `defaultChatState` omits `lastSelectedModelId`, so it is only written by an explicit change.

Chat tabs also unmount when you switch away (unlike app tabs, they are not kept alive), so returning to a chat re-runs hydration and re-reads the global.

## The fix

Separate the two questions that were conflated:

- **Which model is *this chat* on?** Persisted per `chatId` (`chatModelMemory.ts`), so it survives restarts and workspace switches. Bounded at 200 entries, evicting least-recently-used.
- **Which model should a *new chat* start on?** The global last pick — still global, because there that is the correct answer.

Precedence is now (`resolveChatModel.ts`):

1. This chat's explicit selection.
2. The model that last answered **in this chat**, read from `messages.model` in its own history. This is server-side truth and needs no new schema — it works even after local storage is cleared or the app is reinstalled.
3. The global default — **only** when the chat has no history. An existing chat never inherits another chat's model.
4. The app's ordinary defaults (`sonnet-5` → `gpt-5-6-sol` → …).

`hasHistory` comes from chat metadata (`messageCount`), so it is known before history finishes loading — a reopened chat never flashes another chat's model while waiting.

Re-deriving is idempotent: an explicit per-chat pick outranks history, so the hydration effect can re-run when history arrives without walking back a selection the user just made.

## Files

| File | Change |
|---|---|
| `ui/utils/chatModelMemory.ts` | **New** — durable per-chat store, bounded, with rename/forget |
| `ui/utils/resolveChatModel.ts` | **New** — precedence rule and history lookup, pure |
| `ui/stores/chatStore.ts` | Global fallback removed from `getLastSelectedModel`; added `getDefaultModelForNewChat`; selection carried across the temp→permanent id rename |
| `ui/components/Chat/ChatContainer.tsx` | Hydration uses the precedence rule |
| `ui/utils/historyMapper.ts`, `ui/types/chat.ts` | Carry `model` per message |
| `ui/hooks/useChat.ts` | Forget a deleted chat's model |
| `ui/App.tsx` | Boot seeds the *new-chat* default, not per-chat state |

## Testing

```
npx vitest run tests/chat-model-scoping.test.ts --config vitest.config.unit.ts
# 21 passed
```

Covers per-chat isolation, survival across a simulated restart, the reported regression (existing chat + global Fable → does *not* return Fable), new-chat seeding, the temp→permanent rename, LRU eviction, corrupted/tampered storage, and a missing `window`.

Verified no regressions:
- Renderer type-check: **315 errors before and after** — all pre-existing (`ui/__tests__/` is stale); zero new.
- UI suite: **23 failed / 219 passed** both on `master` and on this branch — the one failing file (`ChatContainer.test.tsx`) has a broken `electronAPI` mock on `master` already.

## Not in this PR

Fable 5.1 producing **no output at all** is a separate defect — the AI SDK v6 `maxOutputTokens` rename plus Anthropic's `display: "summarized"` adaptive thinking. That is #140. `claude-fable-5-1` has produced zero assistant messages in the reporting install, which is consistent with that fix not yet being merged.

## Prevention

"Which model is this chat on" and "which model should a new chat use" are different questions with different scopes. A read for a specific key must not fall back to a global value — returning *something* looks robust but silently answers a question that was not asked. If per-entity state is worth reading after a restart, it has to be persisted per entity; an in-memory map plus a global fallback degrades into the global on every restart.

Made with [Cursor](https://cursor.com)