### PR TITLE
Render one job/delegation card per id in the no-sequence path

### DIFF
--- a/ui/components/Chat/MessageItem.tsx
+++ b/ui/components/Chat/MessageItem.tsx
@@ -867,103 +867,121 @@ const MessageItemInner: React.FC<MessageItemProps> = ({
                   isStreaming={message.isStreaming}
                   narration={content} // Show agent's explanation after tool calls
                 />
-                {/* JobStatusCard for run_job (fallback when no sequence) */}
-                {message.toolCalls.map((tc) => {
-                  if (tc.toolName !== "run_job") return null;
-                  if (tc.result && tc.status === "success") {
-                    const jobData = parseJobStatusFromToolResult(
-                      tc.toolName,
-                      tc.result,
-                    );
-                    return jobData ? (
-                      <JobStatusCard
-                        key={`job-fallback-${jobData.jobId}`}
-                        data={jobData}
-                      />
-                    ) : null;
-                  }
-                  if (tc.status === "calling" && tc.args?.jobId) {
-                    const jobId = tc.args.jobId as string;
-                    const jobName = getJobName(jobId) || jobId;
-                    return (
-                      <JobStatusCard
-                        key={`job-fallback-${jobId}`}
-                        data={{
-                          type: "job_status",
-                          jobId,
-                          jobName,
-                          runId: "running",
-                          status: "running",
-                          startedAt: new Date().toISOString(),
-                        }}
-                      />
-                    );
-                  }
-                  return null;
-                })}
-                {message.toolCalls.map((tc) => {
-                  if (tc.toolName !== "delegate_task") return null;
+                {/* Job cards for run_job (fallback when no sequence) — one per
+                    jobId, latest state wins. A message can call run_job twice
+                    on the same job (a retry, or a finished run followed by an
+                    in-flight one); rendering both emitted two cards under one
+                    key, which React may drop, with contradictory status. The
+                    sequence path above already dedupes via addedJobIds. */}
+                {(() => {
+                  const jobMap = new Map<
+                    string,
+                    Parameters<typeof JobStatusCard>[0]["data"]
+                  >();
+                  message.toolCalls.forEach((tc) => {
+                    if (tc.toolName !== "run_job") return;
+                    if (tc.result && tc.status === "success") {
+                      const jobData = parseJobStatusFromToolResult(
+                        tc.toolName,
+                        tc.result,
+                      );
+                      if (jobData) jobMap.set(jobData.jobId, jobData);
+                      return;
+                    }
+                    if (tc.status === "calling" && tc.args?.jobId) {
+                      const jobId = tc.args.jobId as string;
+                      jobMap.set(jobId, {
+                        type: "job_status",
+                        jobId,
+                        jobName: getJobName(jobId) || jobId,
+                        runId: "running",
+                        status: "running",
+                        startedAt: new Date().toISOString(),
+                      });
+                    }
+                  });
+                  return Array.from(jobMap.entries()).map(([jobId, data]) => (
+                    <JobStatusCard key={`job-fallback-${jobId}`} data={data} />
+                  ));
+                })()}
+                {/* Delegation cards — one per delegationId, latest state wins.
+                    The in-flight branch identifies a card by the chat's
+                    subagent job, which is the same value for every concurrent
+                    delegate_task, so two would otherwise share one key. */}
+                {(() => {
+                  const delegationMap = new Map<
+                    string,
+                    React.ComponentProps<typeof MiniChatCard>
+                  >();
 
-                  if (tc.result) {
-                    const delegationData = parseDelegationFromToolResult(
-                      tc.toolName,
-                      tc.result,
-                    );
-                    if (!delegationData) return null;
-                    const miniStatus =
-                      delegationData.status === "pending" ||
-                      delegationData.status === "running"
-                        ? "active"
-                        : delegationData.status === "completed"
-                          ? "completed"
-                          : "failed";
-                    return (
+                  message.toolCalls.forEach((tc, index) => {
+                    if (tc.toolName !== "delegate_task") return;
+
+                    if (tc.result) {
+                      const delegationData = parseDelegationFromToolResult(
+                        tc.toolName,
+                        tc.result,
+                      );
+                      if (!delegationData) return;
+                      const miniStatus =
+                        delegationData.status === "pending" ||
+                        delegationData.status === "running"
+                          ? "active"
+                          : delegationData.status === "completed"
+                            ? "completed"
+                            : "failed";
+                      delegationMap.set(delegationData.id, {
+                        delegationId: delegationData.id,
+                        subAgentName:
+                          delegationData.agentName ?? delegationData.agentId,
+                        task: delegationData.task,
+                        status: miniStatus,
+                        context: delegationData.context,
+                        resultText: delegationData.resultText,
+                        error: delegationData.error,
+                        subAgentIcon: delegationData.agentIcon,
+                        defaultExpanded: false,
+                      });
+                      return;
+                    }
+
+                    if (tc.status === "calling") {
+                      const task = (tc.args?.task as string) || "Delegated task";
+                      const requestedAgentId = tc.args?.useAgentId as
+                        | string
+                        | undefined;
+                      const { agentId, agentName } =
+                        resolveDelegationAgentDisplay(
+                          requestedAgentId,
+                          subagentJobForChat,
+                          getAgentName,
+                        );
+                      const jobIdFromStore = subagentJobForChat?.jobId;
+                      // Index, not Date.now(): a timestamp changes on every
+                      // render, remounting the card and dropping its state.
+                      const placeholderId =
+                        jobIdFromStore || tc.id || `delegation-${index}`;
+                      if (!chatId && !jobIdFromStore) return;
+                      delegationMap.set(placeholderId, {
+                        delegationId: placeholderId,
+                        subAgentName: agentName ?? agentId,
+                        task,
+                        status: "active",
+                        context: (tc.args?.context as string) || undefined,
+                        defaultExpanded: false,
+                      });
+                    }
+                  });
+
+                  return Array.from(delegationMap.entries()).map(
+                    ([delegationId, props]) => (
                       <MiniChatCard
-                        key={`delegation-fallback-${delegationData.id}`}
-                        delegationId={delegationData.id}
-                        subAgentName={
-                          delegationData.agentName ?? delegationData.agentId
-                        }
-                        task={delegationData.task}
-                        status={miniStatus}
-                        context={delegationData.context}
-                        resultText={delegationData.resultText}
-                        error={delegationData.error}
-                        subAgentIcon={delegationData.agentIcon}
-                        defaultExpanded={false}
+                        key={`delegation-fallback-${delegationId}`}
+                        {...props}
                       />
-                    );
-                  }
-
-                  if (tc.status === "calling") {
-                    const task = (tc.args?.task as string) || "Delegated task";
-                    const requestedAgentId = tc.args?.useAgentId as
-                      | string
-                      | undefined;
-                    const { agentId, agentName } = resolveDelegationAgentDisplay(
-                      requestedAgentId,
-                      subagentJobForChat,
-                      getAgentName,
-                    );
-                    const jobIdFromStore = subagentJobForChat?.jobId;
-                    const placeholderId =
-                      jobIdFromStore || tc.id || `delegation-${Date.now()}`;
-                    if (!chatId && !jobIdFromStore) return null;
-                    return (
-                      <MiniChatCard
-                        key={`delegation-fallback-${placeholderId}`}
-                        delegationId={placeholderId}
-                        subAgentName={agentName ?? agentId}
-                        task={task}
-                        status="active"
-                        context={(tc.args?.context as string) || undefined}
-                        defaultExpanded={false}
-                      />
-                    );
-                  }
-
-                  return null;
-                })}
+                    ),
+                  );
+                })()}
               </>
             )}
 


### PR DESCRIPTION
## Symptom

From a live session log:

```
Warning: Encountered two children with the same key, `%s`. Keys should be unique...
  job-fallback-b5164dd1-6fe0-4a74-a612-c75754225f7f
    at MessageItemInner (ui/components/Chat/MessageItem.tsx:633:3)
```

React may duplicate or omit children when keys collide, so a job card could silently fail to render.

## Cause

The no-sequence fallback path rendered one `JobStatusCard` per `run_job` tool call. A single message can call `run_job` twice on the same job — a retry, or a finished run followed by an in-flight one — and both cards then carried the key `job-fallback-<jobId>`. The two cards also disagreed: one showed `success`, the other `running`.

The adjacent blocks in the same file already avoid this. Plan cards and key-request cards collapse into a `Map` keyed by id ("one per planId (latest state wins)"), and the sequence-based path guards with an `addedJobIds` set. The job fallback was the one place that didn't.

## Change

Collapse to one card per `jobId`, latest state wins, matching the surrounding idiom. Last-write-wins is correct here because `toolCalls` is chronological, so a completed run followed by a retry shows the retry.

The delegation block beside it had the same defect for a less obvious reason, so it gets the same treatment: its in-flight branch identifies a card by `subagentJobForChat?.jobId`, which is **chat-scoped** and therefore identical for every concurrent `delegate_task`. Two in-flight delegations in one message collided. That branch's placeholder id also fell back to `` `delegation-${Date.now()}` ``, which produces a new key on every render and remounts the card, dropping its expanded state; it now uses the tool-call index.

Precedence of `jobIdFromStore` over `tc.id` is deliberately left alone — it's what wires the card to live streaming.

## Verification

- `oxlint ui/components/Chat/MessageItem.tsx` — 0 warnings, 0 errors
- UI `tsc --noEmit` — 315 errors, **exactly** master's baseline; zero in `MessageItem.tsx`
- Diff is three hunks, all inside the two adjacent blocks (this file is not `oxfmt`-clean on master, so it was deliberately left unformatted to avoid unrelated churn)

Runtime confirmation is that the warning stops appearing on a message that runs the same job twice.

Made with [Cursor](https://cursor.com)