### PR TITLE
Reload an open chat when its store entry is wiped under the mounted pane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4856,4 +4856,32 @@ Head-of-line blocking with a poison pill at the front: the queue could only grow
 
 ---
 
+### Issue 75: Open Chat Reverts to Empty "New Chat" Until You Switch Tabs ✅ FIXED
+**Added:** 2026-09-03
+**Problem:** An open conversation would spontaneously render the empty "What would you like to build?" welcome screen, as if the chat had been replaced by a new one. Switching to another tab and back brought the whole conversation straight back.
+**Root Cause:** `ChatContainer` hydrates its messages in an effect keyed on `chatId`:
+
+```300:303:ui/components/Chat/ChatContainer.tsx
+  useEffect(() => {
+    syncHistoryFromServer();
+  }, [chatId, syncHistoryFromServer]);
+```
+
+`resetForWorkspaceSwitch()` clears **every** entry (`chatStates: new Map()`) and the workspace reload restores tabs — via `hydrateWorkspaceFromCache` — without restoring message bodies. So the pane can outlive its own state: same `chatId`, no entry, effect never re-runs. `MessageList` renders `WelcomeMessage` whenever `filteredMessages.length === 0 && !isLoading`, so the pane sits there indefinitely. The recovery the user found is that same mechanism in reverse: inactive chat tabs are unmounted (`ContentArea` renders only the active pane, and unlike app tabs there is no chat keep-alive host), so switching away and back **remounts** the pane and re-runs the hydration effect.
+**Not the cause (checked):** the history fetch was healthy — `gateway.send` rejects on `success: false`/timeout, so a failed load would log `Failed to load messages`, and neither that nor `Request failed - Type: agent:history` appears anywhere in the captured logs. Worth knowing for future triage: the log pipeline forwards renderer **warnings and errors only**, so `console.log` lines such as `[WorkspaceSwitch]` never appear and their absence proves nothing.
+**Solution:** Recover when the entry disappears from under a mounted pane, rather than chasing each event that might clear it — the stranding is identical whatever wipes the store. `shouldRehydrateAfterStoreWipe()` fires on the present → absent transition only:
+- **Absence, not emptiness, is the signal.** A new chat is created holding `messages: []`, so keying off an empty array would fight every genuinely empty chat; only a wipe removes the entry outright.
+- **Cannot loop.** `loadMessages` always writes an entry back in its `finally`, which flips the flag and ends the sequence.
+- **Temp ids are skipped.** `migrateChatId` deletes the temp entry and then `await`s before the tab switches to the permanent id, so the pane can legitimately render with a temp id and no entry — and no temp chat exists server-side to load.
+- **Safe across a real workspace switch.** If the chat belongs to the workspace being left, the reload returns nothing and the pane correctly stays empty.
+**Files Created:**
+- `ui/utils/chatStateRecovery.ts` — the predicate
+- `tests/chat-state-recovery.test.ts` — 6 tests, including one pinning that `resetForWorkspaceSwitch` *removes* entries rather than writing empty ones (the invariant that absence-as-signal depends on; if that ever changed, the recovery would silently stop firing)
+**Files Changed:**
+- `ui/components/Chat/ChatContainer.tsx` — transition effect beside the existing hydration effect
+**Prevention:** A component that loads its data once, keyed on its own identity, is stranded by anything that clears that data without changing the identity. Either re-hydrate on the disappearance or have the wipe re-seed what it clears. Separately: know which console levels your log pipeline captures before reading absence as evidence.
+**Related:** Issue 72 (workspace switch regressions), Issue 74 (model selection leaking across chats — same `resetForWorkspaceSwitch` wipe, different casualty)
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**

--- a/tests/chat-state-recovery.test.ts
+++ b/tests/chat-state-recovery.test.ts
@@ -1,0 +1,95 @@
+/**
+ * A mounted chat pane must recover when its store entry is wiped underneath it.
+ *
+ * The bug these cover: the pane hydrates messages in an effect keyed on chatId,
+ * so a wipe of `chatStates` left the pane rendering the welcome screen with the
+ * conversation apparently gone. Switching to another tab and back restored it,
+ * because that unmounts and remounts the pane and re-runs the hydration effect.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { shouldRehydrateAfterStoreWipe } from "../ui/utils/chatStateRecovery";
+
+const CHAT = "8f2c1d90-4a6b-4c2e-9f11-7d3b5e6a1c04";
+
+describe("shouldRehydrateAfterStoreWipe", () => {
+  it("reloads when the entry disappears while the pane is mounted", () => {
+    expect(
+      shouldRehydrateAfterStoreWipe({
+        chatId: CHAT,
+        hadEntry: true,
+        hasEntry: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("stays quiet while the entry is present", () => {
+    expect(
+      shouldRehydrateAfterStoreWipe({
+        chatId: CHAT,
+        hadEntry: true,
+        hasEntry: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not fire on first mount, when the mount effect already loads", () => {
+    expect(
+      shouldRehydrateAfterStoreWipe({
+        chatId: CHAT,
+        hadEntry: false,
+        hasEntry: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("settles after the reload recreates the entry, so it cannot loop", () => {
+    // The reload always writes an entry back (loadMessages does so in its
+    // finally block), which flips hasEntry true and ends the sequence.
+    const first = shouldRehydrateAfterStoreWipe({
+      chatId: CHAT,
+      hadEntry: true,
+      hasEntry: false,
+    });
+    const second = shouldRehydrateAfterStoreWipe({
+      chatId: CHAT,
+      hadEntry: false,
+      hasEntry: true,
+    });
+    expect([first, second]).toEqual([true, false]);
+  });
+
+  it("ignores temp chats, whose entry is removed by id migration", () => {
+    // migrateChatId deletes the temp entry, then an await runs before the tab
+    // switches to the permanent id — so the pane can render with the temp id
+    // and no entry. There is nothing to load for a temp chat.
+    expect(
+      shouldRehydrateAfterStoreWipe({
+        chatId: "temp-1757030000000-abc123",
+        hadEntry: true,
+        hasEntry: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("store wipe shape the recovery depends on", () => {
+  it("resetForWorkspaceSwitch removes entries rather than emptying them", () => {
+    // The predicate keys off entry *absence*, which is only a valid signal
+    // while the wipe clears the map. If this ever changed to writing entries
+    // holding [], the recovery above would silently stop firing.
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const source = readFileSync(
+      path.join(here, "../ui/stores/chatStore.ts"),
+      "utf8",
+    );
+
+    const reset = source.slice(source.indexOf("resetForWorkspaceSwitch:"));
+    const body = reset.slice(0, reset.indexOf("}),") + 3);
+
+    expect(body).toContain("chatStates: new Map()");
+  });
+});

--- a/ui/components/Chat/ChatContainer.tsx
+++ b/ui/components/Chat/ChatContainer.tsx
@@ -37,6 +37,7 @@ import {
 import { artifactsToMessageAttachments } from "../../utils/messageAttachments";
 import { mapHistoryMessages } from "../../utils/historyMapper";
 import { extractFilesFromDataTransfer } from "../../utils/chatAttachmentFiles";
+import { shouldRehydrateAfterStoreWipe } from "../../utils/chatStateRecovery";
 import "./ChatContainer.css";
 import { trackEvent } from "../../lib/telemetry";
 import { chatHasLiveStreamBlockingHistory } from "../../lib/agentStreamRecovery";
@@ -271,6 +272,19 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
   useEffect(() => {
     syncHistoryFromServer();
   }, [chatId, syncHistoryFromServer]);
+
+  // The effect above only re-runs when chatId changes, so a store wipe while
+  // this pane stays mounted leaves it on the welcome screen until the user
+  // switches tabs and forces a remount. See shouldRehydrateAfterStoreWipe.
+  const hasChatState = chatState !== undefined;
+  const prevHasChatStateRef = useRef(hasChatState);
+  useEffect(() => {
+    const hadEntry = prevHasChatStateRef.current;
+    prevHasChatStateRef.current = hasChatState;
+    if (shouldRehydrateAfterStoreWipe({ chatId, hadEntry, hasEntry: hasChatState })) {
+      syncHistoryFromServer();
+    }
+  }, [hasChatState, chatId, syncHistoryFromServer]);
 
   // Listen for new messages delivered from jobs/sub-agents
   useEffect(() => {

--- a/ui/utils/chatStateRecovery.ts
+++ b/ui/utils/chatStateRecovery.ts
@@ -1,0 +1,34 @@
+/**
+ * A mounted chat pane hydrates its messages once, in an effect keyed on chatId.
+ * Anything that drops the chat's entry from the store while the pane stays
+ * mounted therefore strands it: the pane renders the welcome screen and nothing
+ * re-runs the fetch. `resetForWorkspaceSwitch()` clears every entry and the
+ * workspace reload restores tabs without restoring message bodies, so the pane
+ * can outlive its own state.
+ *
+ * This predicate decides whether such a disappearance should trigger a reload.
+ */
+export interface ChatStateRecoveryInput {
+  chatId: string;
+  /** Whether the store held an entry for this chat on the previous render. */
+  hadEntry: boolean;
+  /** Whether the store holds an entry for this chat now. */
+  hasEntry: boolean;
+}
+
+export function shouldRehydrateAfterStoreWipe({
+  chatId,
+  hadEntry,
+  hasEntry,
+}: ChatStateRecoveryInput): boolean {
+  // Only the present -> absent transition indicates a wipe. An entry that is
+  // merely empty belongs to a new chat, which has nothing to load.
+  if (!hadEntry || hasEntry) return false;
+
+  // A temp chat has no server-side rows to load, and migrateChatId removes the
+  // temp entry a tick before the tab switches to the permanent id — so this
+  // transition is expected there and must not fire a fetch.
+  if (chatId.startsWith("temp-")) return false;
+
+  return true;
+}


### PR DESCRIPTION
## Symptom

An open conversation suddenly shows the empty **"What would you like to build?"** welcome screen, as if the chat had been replaced by a new one. Switching to another tab and back brings the whole conversation straight back.

## Root cause

`ChatContainer` hydrates its messages in an effect keyed on `chatId`:

```300:303:ui/components/Chat/ChatContainer.tsx
  useEffect(() => {
    syncHistoryFromServer();
  }, [chatId, syncHistoryFromServer]);
```

`resetForWorkspaceSwitch()` clears **every** entry (`chatStates: new Map()`), and the workspace reload restores the tab bar through `hydrateWorkspaceFromCache` **without** restoring message bodies. The pane therefore outlives its own state: same `chatId`, no entry, effect never re-runs. `MessageList` renders `WelcomeMessage` for any chat with no messages and `isLoading` false, so it sits there indefinitely.

The recovery users discovered is that same mechanism in reverse. Inactive chat tabs are unmounted — `ContentArea` renders only the active pane, and unlike app tabs there is no chat keep-alive host — so switching away and back **remounts** the pane and re-runs the hydration effect.

## What was ruled out, not assumed

A failed history load would produce the same empty pane, so it was checked rather than dismissed. `gateway.send` **rejects** on `success: false` and on timeout, so a failed load logs `Failed to load messages` — and neither that nor `Request failed - Type: agent:history` appears anywhere in the captured logs. The fetch path was healthy.

Worth recording for future triage: the log pipeline forwards renderer **warnings and errors only**. `console.log` lines such as `[WorkspaceSwitch]` never reach it, so their absence is not evidence either way.

## The fix

Recover from the disappearance itself rather than chasing each event that might clear the store — the stranding is identical whatever caused it. `shouldRehydrateAfterStoreWipe()` fires on the **present → absent** transition only:

- **Absence, not emptiness, is the signal.** A new chat is created holding `messages: []`, so keying off an empty array would fight every genuinely empty chat. Only a wipe removes the entry outright.
- **It cannot loop.** `loadMessages` always writes an entry back in its `finally`, which flips the flag and ends the sequence.
- **Temp ids are skipped.** `migrateChatId` deletes the temp entry and then `await`s before the tab switches to the permanent id, so the pane can legitimately render with a temp id and no entry — and no temp chat exists server-side to load.
- **Safe across a real workspace switch.** If the chat belongs to the workspace being left, the reload returns nothing and the pane correctly stays empty.

## Tests

`tests/chat-state-recovery.test.ts` — 6 tests: the wipe transition, quiet while present, no double-fetch on first mount, the settle-after-reload sequence, temp-id exclusion, and one pinning that `resetForWorkspaceSwitch` **removes** entries rather than writing empty ones. That last one guards the invariant absence-as-signal depends on: if the reset ever changed to writing `messages: []`, the recovery would silently stop firing.

```
✓ tests/chat-state-recovery.test.ts (6 tests)
```

`ChatContainer.tsx` and `chatStateRecovery.ts` are both clean under `tsc --noEmit` and `oxlint`.

## Related

- Issue 72 — workspace switch regressions
- #142 — model selection leaking across chats: the same `resetForWorkspaceSwitch` wipe, a different casualty

Made with [Cursor](https://cursor.com)