### PR TITLE
Keep paginated turns above the fetched window when merging history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4856,4 +4856,30 @@ Head-of-line blocking with a poison pill at the front: the queue could only grow
 
 ---
 
+### Issue 76: History Sync Drops Paginated Turns Below the Newest Message ✅ FIXED
+**Added:** 2026-09-03
+**Problem:** In a long chat, the newest reply would appear part-way up the transcript with a block of *older* turns rendered beneath it. Scrolling to the bottom showed old messages; the actual latest answer sat above them.
+**Root Cause:** `mergeHistoryWithLocal` treats the server list as the spine, walks it in order, then appends any local message the server list didn't account for — on the assumption those are optimistic sends that outran the server:
+
+```300:304:ui/lib/agentStreamRecovery.ts
+  // Optimistic user sends + in-flight streaming placeholders not on server yet.
+  for (const localMsg of base) {
+    if (consumedLocalIds.has(localMsg.id)) continue;
+    merged.push(localMsg);
+  }
+```
+
+That assumption holds only while the server list is the *whole* history. It isn't: every sync fetches a **window** — `loadMessages(chatId, 30)`, and `LocalStorageProvider` reads `ORDER BY timestamp DESC LIMIT 30` then reverses, so it returns the newest 30. Once `loadOlderMessages` has paginated earlier turns into the store (it *prepends* them), those older turns are outside the window, land in the leftover loop, and get appended **after** the newest message. A 50-message store merged against a 30-message window comes back as `[newest 30, oldest 20]`.
+**Trigger is routine:** the sync fires on the `isSending` true→false transition, i.e. at the end of **every turn**. Scroll up in a long chat, send one message, and the transcript reorders itself. 56 chats in the local DB exceed 30 messages (largest: 517), so the precondition is near-permanent.
+**Solution:** Decide the side by **position, not time**. Server-mapped messages carry no `timestamp` at all (`mapHistoryMessages` never sets one) and local ones are inconsistent (`ChatContainer` writes a number where the type says string), so a timestamp comparison would have been a silent no-op. Both lists are chronological, so a leftover sitting before the first local message the window claimed is older than the window and belongs in front of it; anything after belongs behind. With nothing consumed there is no window to sit outside of, so the original append-at-the-end behaviour is kept rather than guessed at.
+**Also fixed by the same change:** `useAgent`'s stream-recovery path calls the same helper with the same `limit: 30`, so it had the identical defect.
+**Files Created:**
+- `tests/chat-history-merge-order.test.ts` — 6 tests, written failing first: the 50-vs-30 pagination case, an optimistic send still landing last, older and newer strays on their own sides, and the gap-filling the merge already did surviving the change
+**Files Changed:**
+- `ui/lib/agentStreamRecovery.ts` — leftover placement in `mergeHistoryWithLocal`
+**Prevention:** When one list is used as the ordering spine for another, state whether it is the complete set or a window — and if it is a window, "not found in it" cannot mean "newer than it." Reach for a field only after checking it is actually populated: the timestamp on these messages looks authoritative in the type and is absent at runtime.
+**Related:** Issue 75 (chat pane stranded after a store wipe — the same reload path, a different failure)
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**

--- a/tests/chat-history-merge-order.test.ts
+++ b/tests/chat-history-merge-order.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Merging server history into a chat must not reorder the conversation.
+ *
+ * The bug these cover: the server list is a *window* — loadMessages asks for
+ * the newest 30 — but the merge treated any local message missing from that
+ * window as an optimistic send and appended it to the end. Once the user had
+ * scrolled up and paginated older turns into view, the next history sync moved
+ * every one of those older turns *below* the newest message.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { ChatMessage } from "../ui/types/chat";
+
+// The module under test transitively imports the gateway client, which opens a
+// WebSocket in its constructor and schedules reconnect timers on failure. Stub
+// it so this stays a pure unit test instead of depending on a running gateway.
+vi.mock("../ui/src/lib/gateway", () => ({
+  gateway: { send: vi.fn(), onBroadcast: vi.fn(), isConnected: () => false },
+  GATEWAY_DISCONNECTED_ERROR: "Gateway disconnected",
+}));
+
+import { mergeHistoryWithLocal } from "../ui/lib/agentStreamRecovery";
+
+function msg(id: string, role: "user" | "assistant" = "user"): ChatMessage {
+  // Server-mapped messages carry no timestamp (see mapHistoryMessages), so the
+  // fixtures omit it too — placement must not depend on one.
+  return { id, role, content: `body ${id}` } as ChatMessage;
+}
+
+/** m01..mNN, chronological, as the store holds them. */
+function conversation(count: number): ChatMessage[] {
+  return Array.from({ length: count }, (_, i) =>
+    msg(
+      `m${String(i + 1).padStart(2, "0")}`,
+      i % 2 === 0 ? "user" : "assistant",
+    ),
+  );
+}
+
+const ids = (messages: ChatMessage[]) => messages.map((m) => m.id);
+
+describe("mergeHistoryWithLocal ordering", () => {
+  it("keeps paginated older turns above the fetched window", () => {
+    // The user scrolled up, so the store holds 50 turns. A routine history
+    // sync fetches only the newest 30.
+    const local = conversation(50);
+    const serverWindow = local.slice(20).map((m) => msg(m.id, m.role as never));
+
+    const merged = mergeHistoryWithLocal(local, serverWindow);
+
+    expect(ids(merged)).toEqual(ids(local));
+  });
+
+  it("still appends an optimistic send the server has not stored yet", () => {
+    const local = [...conversation(4), msg("pending-user")];
+    const serverWindow = conversation(4);
+
+    const merged = mergeHistoryWithLocal(local, serverWindow);
+
+    expect(ids(merged)).toEqual(["m01", "m02", "m03", "m04", "pending-user"]);
+  });
+
+  it("places older and newer strays on their own sides of the window", () => {
+    const local = [
+      msg("old-a"),
+      msg("old-b"),
+      ...conversation(3),
+      msg("pending-user"),
+    ];
+    const serverWindow = conversation(3);
+
+    const merged = mergeHistoryWithLocal(local, serverWindow);
+
+    expect(ids(merged)).toEqual([
+      "old-a",
+      "old-b",
+      "m01",
+      "m02",
+      "m03",
+      "pending-user",
+    ]);
+  });
+
+  it("leaves a full history untouched when nothing was paginated", () => {
+    const local = conversation(6);
+    const server = conversation(6);
+
+    expect(ids(mergeHistoryWithLocal(local, server))).toEqual(ids(local));
+  });
+
+  it("keeps local order when the server returns nothing", () => {
+    const local = conversation(3);
+
+    expect(ids(mergeHistoryWithLocal(local, []))).toEqual(ids(local));
+  });
+
+  it("adds server turns the store is missing, in place", () => {
+    // The gap-filling the merge already did must survive the fix.
+    const local = [msg("m01"), msg("m03")];
+    const server = [msg("m01"), msg("m02"), msg("m03")];
+
+    expect(ids(mergeHistoryWithLocal(local, server))).toEqual([
+      "m01",
+      "m02",
+      "m03",
+    ]);
+  });
+});

--- a/ui/lib/agentStreamRecovery.ts
+++ b/ui/lib/agentStreamRecovery.ts
@@ -297,13 +297,39 @@ export function mergeHistoryWithLocal(
     merged.push(serverMsg);
   }
 
-  // Optimistic user sends + in-flight streaming placeholders not on server yet.
-  for (const localMsg of base) {
-    if (consumedLocalIds.has(localMsg.id)) continue;
-    merged.push(localMsg);
+  // Locals the server list didn't account for. Usually optimistic sends and
+  // in-flight placeholders, which belong at the end — but the server list is a
+  // *window* (loadMessages asks for the newest N), so once pagination has
+  // pulled older turns into the store those fall outside the window too, and
+  // appending them would drop the earlier half of the conversation below its
+  // own latest message.
+  //
+  // Position decides which side, not time: server-mapped messages carry no
+  // timestamp at all (see mapHistoryMessages). Both lists are chronological, so
+  // a leftover sitting before the first message the window claimed is older
+  // than the window, and anything after it is newer.
+  let firstConsumedIndex = -1;
+  for (let i = 0; i < base.length; i++) {
+    if (consumedLocalIds.has(base[i].id)) {
+      firstConsumedIndex = i;
+      break;
+    }
   }
 
-  return merged;
+  const beforeWindow: ChatMessage[] = [];
+  const afterWindow: ChatMessage[] = [];
+  base.forEach((localMsg, index) => {
+    if (consumedLocalIds.has(localMsg.id)) return;
+    // With nothing consumed there is no window to sit outside of, so keep the
+    // original append-at-the-end behaviour rather than guessing.
+    if (firstConsumedIndex !== -1 && index < firstConsumedIndex) {
+      beforeWindow.push(localMsg);
+    } else {
+      afterWindow.push(localMsg);
+    }
+  });
+
+  return [...beforeWindow, ...merged, ...afterWindow];
 }
 
 /**


### PR DESCRIPTION
## Symptom

In a long chat, the newest reply appears part-way up the transcript with a block of **older** turns rendered beneath it. Scrolling to the bottom shows old messages; the actual latest answer is sitting above them.

## Root cause

`mergeHistoryWithLocal` uses the server list as the ordering spine, walks it in order, then appends any local message that list didn't account for — on the assumption those are optimistic sends that outran the server:

```300:304:ui/lib/agentStreamRecovery.ts
  // Optimistic user sends + in-flight streaming placeholders not on server yet.
  for (const localMsg of base) {
    if (consumedLocalIds.has(localMsg.id)) continue;
    merged.push(localMsg);
  }
```

That assumption holds only while the server list is the **whole** history. It isn't — every sync fetches a **window**. `loadMessages(chatId, 30)` asks for 30, and `LocalStorageProvider` runs `ORDER BY timestamp DESC LIMIT 30` and then reverses, so it returns *the newest 30*.

Once `loadOlderMessages` has paginated earlier turns into the store — it **prepends** them — those turns sit outside that window, fall into the leftover loop, and get appended **after** the newest message:

> a 50-message store merged against a 30-message window comes back as `[newest 30, oldest 20]`

## Why it shows up constantly

The sync fires on the `isSending` true → false transition, so it runs at the **end of every turn**. Scroll up in a long chat, send one message, and the transcript reorders itself when the turn finishes.

The precondition is near-permanent: **56 chats** in the local database exceed 30 messages, the largest at **517**.

`useAgent`'s stream-recovery path calls the same helper with the same `limit: 30`, so it carried the identical defect and is fixed by the same change.

## The fix

Decide the side by **position, not time**.

Time looked like the obvious discriminator and would have been a silent no-op: server-mapped messages carry **no `timestamp` at all** (`mapHistoryMessages` never sets one), and local ones are inconsistent — `ChatContainer` writes a number where the type declares `string`.

Both lists are chronological, so position is exact: a leftover sitting before the first local message the window claimed is older than the window and belongs in front of it; anything after belongs behind. With nothing consumed there is no window to sit outside of, so the original append-at-the-end behaviour is kept rather than guessed at.

## Tests

`tests/chat-history-merge-order.test.ts` — 6 tests, **written failing first** against the real merge:

- the 50-vs-30 pagination case (the reported bug)
- an optimistic send still landing last
- older and newer strays sorted onto their own sides of the window
- a full history left untouched, and an empty server response left untouched
- the gap-filling the merge already did, surviving the change

```
✓ tests/chat-history-merge-order.test.ts (6 tests)
```

The test stubs the gateway client, which opens a WebSocket in its constructor and schedules reconnect timers on failure — otherwise this unit test would depend on a running gateway.

`agentStreamRecovery.ts` is clean under `tsc --noEmit` and `oxlint`. It was already unformatted before this change, so it is left as-is rather than reformatted into an unreviewable diff.

## Related

- #146 — chat pane stranded after a store wipe: the same reload path, a different failure

Made with [Cursor](https://cursor.com)