### PR TITLE
feat(agent): separate chat and job concurrency pools; show waiting-for-slot state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4856,4 +4856,30 @@ Head-of-line blocking with a poison pill at the front: the queue could only grow
 
 ---
 
+### Issue 76: History Sync Drops Paginated Turns Below the Newest Message ✅ FIXED
+**Added:** 2026-09-03
+**Problem:** In a long chat, the newest reply would appear part-way up the transcript with a block of *older* turns rendered beneath it. Scrolling to the bottom showed old messages; the actual latest answer sat above them.
+**Root Cause:** `mergeHistoryWithLocal` treats the server list as the spine, walks it in order, then appends any local message the server list didn't account for — on the assumption those are optimistic sends that outran the server:
+
+```300:304:ui/lib/agentStreamRecovery.ts
+  // Optimistic user sends + in-flight streaming placeholders not on server yet.
+  for (const localMsg of base) {
+    if (consumedLocalIds.has(localMsg.id)) continue;
+    merged.push(localMsg);
+  }
+```
+
+That assumption holds only while the server list is the *whole* history. It isn't: every sync fetches a **window** — `loadMessages(chatId, 30)`, and `LocalStorageProvider` reads `ORDER BY timestamp DESC LIMIT 30` then reverses, so it returns the newest 30. Once `loadOlderMessages` has paginated earlier turns into the store (it *prepends* them), those older turns are outside the window, land in the leftover loop, and get appended **after** the newest message. A 50-message store merged against a 30-message window comes back as `[newest 30, oldest 20]`.
+**Trigger is routine:** the sync fires on the `isSending` true→false transition, i.e. at the end of **every turn**. Scroll up in a long chat, send one message, and the transcript reorders itself. 56 chats in the local DB exceed 30 messages (largest: 517), so the precondition is near-permanent.
+**Solution:** Decide the side by **position, not time**. Server-mapped messages carry no `timestamp` at all (`mapHistoryMessages` never sets one) and local ones are inconsistent (`ChatContainer` writes a number where the type says string), so a timestamp comparison would have been a silent no-op. Both lists are chronological, so a leftover sitting before the first local message the window claimed is older than the window and belongs in front of it; anything after belongs behind. With nothing consumed there is no window to sit outside of, so the original append-at-the-end behaviour is kept rather than guessed at.
+**Also fixed by the same change:** `useAgent`'s stream-recovery path calls the same helper with the same `limit: 30`, so it had the identical defect.
+**Files Created:**
+- `tests/chat-history-merge-order.test.ts` — 6 tests, written failing first: the 50-vs-30 pagination case, an optimistic send still landing last, older and newer strays on their own sides, and the gap-filling the merge already did surviving the change
+**Files Changed:**
+- `ui/lib/agentStreamRecovery.ts` — leftover placement in `mergeHistoryWithLocal`
+**Prevention:** When one list is used as the ordering spine for another, state whether it is the complete set or a window — and if it is a window, "not found in it" cannot mean "newer than it." Reach for a field only after checking it is actually populated: the timestamp on these messages looks authoritative in the type and is absent at runtime.
+**Related:** Issue 75 (chat pane stranded after a store wipe — the same reload path, a different failure)
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4856,4 +4856,27 @@ Head-of-line blocking with a poison pill at the front: the queue could only grow
 
 ---
 
+### Issue 74: Model Selection Leaking Across Chats ✅ FIXED
+**Added:** 2026-09-03
+**Problem:** Returning to an Opus 5 chat showed — and ran — Claude Fable 5.1, in a chat where Fable had never been used. Not cosmetic: the picker value is sent as `config.model`, so the wrong model answered.
+**Evidence:** In one real chat, 32 assistant turns ran on `claude-opus-5` and 2 on `claude-fable-5`, *interleaved* rather than appended (so not a user switching midway). Across 30 days, 16 of 288 chats had more than one model answer, including cross-provider pairs like `claude-opus-5` + `gpt-5-6-sol-high`.
+**Root Cause:** `getLastSelectedModel(chatId)` fell through to a single global `localStorage["paprwork_last_model_id"]` when the chat had no in-memory entry — returning **another chat's** model. Per-chat selection lived only in a Zustand map with no `persist`, so three ordinary events emptied it: app restart, `resetForWorkspaceSwitch()`, and any chat that never touched the picker (`defaultChatState` omits `lastSelectedModelId`). Chat tabs also unmount on switch-away, so every return re-ran hydration and re-read the global.
+**Solution:** Separate the two conflated questions. "Which model is *this chat* on" is now persisted per `chatId` (bounded, LRU); "which model should a *new chat* start on" stays global, because there that is correct. Precedence: this chat's explicit pick → the model that last answered **in this chat** (from `messages.model`, server-side truth, no schema change) → global (**new chats only**) → app defaults. `hasHistory` comes from `messageCount`, so a reopened chat never flashes another chat's model while history loads.
+**Files Created:**
+- `ui/utils/chatModelMemory.ts` — durable per-chat store with rename/forget
+- `ui/utils/resolveChatModel.ts` — pure precedence rule + history lookup
+- `tests/chat-model-scoping.test.ts` — 21 tests
+- `docs/PER_CHAT_MODEL_SCOPING.md` — complete documentation
+**Files Changed:**
+- `ui/stores/chatStore.ts` — global fallback removed; `getDefaultModelForNewChat` added; selection carried across temp→permanent id rename
+- `ui/components/Chat/ChatContainer.tsx` — hydration uses the precedence rule
+- `ui/utils/historyMapper.ts`, `ui/types/chat.ts` — carry `model` per message
+- `ui/hooks/useChat.ts` — forget a deleted chat's model
+- `ui/App.tsx` — boot seeds the new-chat default, not per-chat state
+**Prevention:** A read for a specific key must not fall back to a global value — returning *something* looks robust but silently answers a question that was not asked. If per-entity state is worth reading after a restart, persist it per entity; an in-memory map plus a global fallback degrades into the global on every restart.
+**Related:** Fable 5.1 producing no output at all is a separate defect (AI SDK v6 `maxOutputTokens` rename + Anthropic `display: "summarized"` adaptive thinking) — see PR #140.
+**See:** `docs/PER_CHAT_MODEL_SCOPING.md`
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4856,4 +4856,32 @@ Head-of-line blocking with a poison pill at the front: the queue could only grow
 
 ---
 
+### Issue 75: Open Chat Reverts to Empty "New Chat" Until You Switch Tabs ✅ FIXED
+**Added:** 2026-09-03
+**Problem:** An open conversation would spontaneously render the empty "What would you like to build?" welcome screen, as if the chat had been replaced by a new one. Switching to another tab and back brought the whole conversation straight back.
+**Root Cause:** `ChatContainer` hydrates its messages in an effect keyed on `chatId`:
+
+```300:303:ui/components/Chat/ChatContainer.tsx
+  useEffect(() => {
+    syncHistoryFromServer();
+  }, [chatId, syncHistoryFromServer]);
+```
+
+`resetForWorkspaceSwitch()` clears **every** entry (`chatStates: new Map()`) and the workspace reload restores tabs — via `hydrateWorkspaceFromCache` — without restoring message bodies. So the pane can outlive its own state: same `chatId`, no entry, effect never re-runs. `MessageList` renders `WelcomeMessage` whenever `filteredMessages.length === 0 && !isLoading`, so the pane sits there indefinitely. The recovery the user found is that same mechanism in reverse: inactive chat tabs are unmounted (`ContentArea` renders only the active pane, and unlike app tabs there is no chat keep-alive host), so switching away and back **remounts** the pane and re-runs the hydration effect.
+**Not the cause (checked):** the history fetch was healthy — `gateway.send` rejects on `success: false`/timeout, so a failed load would log `Failed to load messages`, and neither that nor `Request failed - Type: agent:history` appears anywhere in the captured logs. Worth knowing for future triage: the log pipeline forwards renderer **warnings and errors only**, so `console.log` lines such as `[WorkspaceSwitch]` never appear and their absence proves nothing.
+**Solution:** Recover when the entry disappears from under a mounted pane, rather than chasing each event that might clear it — the stranding is identical whatever wipes the store. `shouldRehydrateAfterStoreWipe()` fires on the present → absent transition only:
+- **Absence, not emptiness, is the signal.** A new chat is created holding `messages: []`, so keying off an empty array would fight every genuinely empty chat; only a wipe removes the entry outright.
+- **Cannot loop.** `loadMessages` always writes an entry back in its `finally`, which flips the flag and ends the sequence.
+- **Temp ids are skipped.** `migrateChatId` deletes the temp entry and then `await`s before the tab switches to the permanent id, so the pane can legitimately render with a temp id and no entry — and no temp chat exists server-side to load.
+- **Safe across a real workspace switch.** If the chat belongs to the workspace being left, the reload returns nothing and the pane correctly stays empty.
+**Files Created:**
+- `ui/utils/chatStateRecovery.ts` — the predicate
+- `tests/chat-state-recovery.test.ts` — 6 tests, including one pinning that `resetForWorkspaceSwitch` *removes* entries rather than writing empty ones (the invariant that absence-as-signal depends on; if that ever changed, the recovery would silently stop firing)
+**Files Changed:**
+- `ui/components/Chat/ChatContainer.tsx` — transition effect beside the existing hydration effect
+**Prevention:** A component that loads its data once, keyed on its own identity, is stranded by anything that clears that data without changing the identity. Either re-hydrate on the disappearance or have the wipe re-seed what it clears. Separately: know which console levels your log pipeline captures before reading absence as evidence.
+**Related:** Issue 72 (workspace switch regressions), Issue 74 (model selection leaking across chats — same `resetForWorkspaceSwitch` wipe, different casualty)
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**

--- a/docs/PER_CHAT_MODEL_SCOPING.md
+++ b/docs/PER_CHAT_MODEL_SCOPING.md
@@ -1,0 +1,122 @@
+# Per-Chat Model Scoping
+
+**Fixed:** 2026-09-03
+
+## Symptom
+
+Open three chats — two on Claude Opus 5, one on Claude Fable 5.1. Return to an
+Opus chat and the picker reads **Fable 5.1**, in a chat where Fable was never
+used.
+
+This is not only a mislabelled picker. The picker's value is what
+`ChatContainer` sends as `config.model`, so the displayed model is the model
+that answers.
+
+## Evidence
+
+From a real installation (`chats.db`, read-only):
+
+```sql
+SELECT model, COUNT(*) FROM messages
+WHERE chat_id = 'e7008114-…' AND role = 'assistant'
+GROUP BY model ORDER BY MIN(timestamp);
+
+claude-opus-5  | 32   -- 2026-09-02T16:08 … 2026-09-03T23:30
+claude-fable-5 |  2   -- 2026-09-02T23:41 … 2026-09-03T01:04
+```
+
+Two turns of an Opus conversation were served by Fable, *interleaved* with the
+Opus turns rather than appended — so this was not the user switching models
+partway through. Across 30 days, 16 of 288 chats had more than one model answer,
+including cross-provider pairs such as `claude-opus-5` + `gpt-5-6-sol-high`.
+
+## Root cause
+
+Model selection had three layers, and only the weakest one was durable:
+
+| Layer | Scope | Survived restart? |
+|---|---|---|
+| `ChatContainer` `useState` | one mounted chat | no |
+| `chatStates[chatId].lastSelectedModelId` | per chat | **no** (plain Zustand map) |
+| `localStorage["paprwork_last_model_id"]` | **global** | yes |
+
+`getLastSelectedModel(chatId)` fell through to the global value whenever the
+requested chat had no in-memory entry:
+
+```ts
+const fromChat = state.chatStates.get(chatId)?.lastSelectedModelId;
+if (fromChat) return fromChat;
+return localStorage.getItem("paprwork_last_model_id"); // ← another chat's model
+```
+
+Three ordinary events empty the per-chat map, after which *every* chat reads the
+global:
+
+1. **App restart** — the store has no `persist` middleware.
+2. **Workspace switch** — `resetForWorkspaceSwitch()` clears `chatStates`.
+3. **A chat that never touched the picker** — `defaultChatState` omits
+   `lastSelectedModelId`, so it is only ever written by an explicit change.
+
+Chat tabs also unmount when you switch away (unlike app tabs, they are not
+kept alive), so returning to a chat re-runs hydration and re-reads the global.
+
+## The fix
+
+Separate the two questions that were conflated:
+
+- **Which model is *this chat* on?** Persisted per chat, keyed by `chatId`
+  (`ui/utils/chatModelMemory.ts`), so it survives restarts and workspace
+  switches. Bounded at `MAX_REMEMBERED_CHATS` (200), evicting least-recently-used.
+- **Which model should a *new chat* start on?** The global last pick. Still
+  global, because here that is the correct answer.
+
+Precedence is now (`ui/utils/resolveChatModel.ts`):
+
+1. This chat's explicit selection.
+2. The model that last answered **in this chat**, read from `messages.model` in
+   its own history. This is server-side truth and needs no new schema — it works
+   even after local storage is cleared or the app is reinstalled.
+3. The global default — **only** when the chat has no history. An existing chat
+   never inherits another chat's model.
+4. The app's ordinary defaults (`sonnet-5` → `gpt-5-6-sol` → …).
+
+`hasHistory` comes from chat metadata (`messageCount`), so it is known before
+history finishes loading. A reopened chat therefore never flashes another chat's
+model while waiting.
+
+Re-deriving is idempotent: an explicit per-chat pick outranks history, so the
+hydration effect can re-run when history arrives without walking back a
+selection the user just made.
+
+## Files
+
+| File | Change |
+|---|---|
+| `ui/utils/chatModelMemory.ts` | **New** — durable per-chat store, bounded, with rename/forget |
+| `ui/utils/resolveChatModel.ts` | **New** — precedence rule and history lookup, pure |
+| `ui/stores/chatStore.ts` | Global fallback removed from `getLastSelectedModel`; added `getDefaultModelForNewChat`; selection carried across the temp→permanent id rename |
+| `ui/components/Chat/ChatContainer.tsx` | Hydration uses the precedence rule |
+| `ui/utils/historyMapper.ts`, `ui/types/chat.ts` | Carry `model` per message so a chat can recover its own model |
+| `ui/hooks/useChat.ts` | Forget a deleted chat's model |
+| `ui/App.tsx` | Boot seeds the *new-chat* default, not per-chat state |
+| `tests/chat-model-scoping.test.ts` | 21 tests |
+
+## Tests
+
+```bash
+npx vitest run tests/chat-model-scoping.test.ts --config vitest.config.unit.ts
+```
+
+Covers per-chat isolation, survival across a simulated restart, the reported
+regression (existing chat + global Fable → does *not* return Fable), new-chat
+seeding, the temp→permanent rename, LRU eviction, corrupted/tampered storage,
+and a missing `window`.
+
+## Prevention
+
+"Which model is this chat on" and "which model should a new chat use" are
+different questions with different scopes. A read for a specific key must not
+fall back to a global value — returning *something* looks robust but silently
+answers a question that was not asked. If per-entity state is worth reading
+after a restart, it has to be persisted per entity; an in-memory map plus a
+global fallback degrades into the global on every restart.

--- a/src/core/types/streaming.ts
+++ b/src/core/types/streaming.ts
@@ -16,6 +16,8 @@ export type StreamChunkType =
   | "compression-start" // Context overflow — summarization in progress
   | "compression-complete" // Summarization finished, stream will retry
   | "wrap-up-start" // Post-tool text summary in progress
+  | "concurrency-queued" // Waiting for an agent stream slot
+  | "concurrency-acquired" // Slot acquired — model work starting
   | "error"
   | "done";
 
@@ -99,6 +101,16 @@ export interface DonePayload {
     output: number;
     total: number;
   };
+}
+
+/**
+ * Emitted while waiting for a concurrency pool slot (no model work yet).
+ */
+export interface ConcurrencyQueuePayload {
+  pool: "chat" | "job";
+  activeCount: number;
+  maxConcurrent: number;
+  waitingCount: number;
 }
 
 /**

--- a/src/gateway/services/AgentService.ts
+++ b/src/gateway/services/AgentService.ts
@@ -1813,7 +1813,11 @@ export class AgentService {
           console.log(`${'─'.repeat(80)}`);
         });
         console.log(`\nTools available: ${Object.keys(streamTextOptions.tools || {}).length}`);
-        console.log(`Max tokens: ${streamTextOptions.maxTokens}`);
+        // Read the field the SDK actually honours. This line used to print
+        // `maxTokens`, the pre-v6 name, so it reported the cap we intended
+        // while the request went out with the provider default of 4096 — the
+        // reason this bug stayed invisible in the logs for so long.
+        console.log(`Max output tokens: ${streamTextOptions.maxOutputTokens}`);
         console.log(`Max steps: ${streamTextOptions.stopWhen ? 'custom' : 'default'}`);
         console.log(`${'='.repeat(80)}\n`);
         

--- a/src/gateway/services/AgentService.ts
+++ b/src/gateway/services/AgentService.ts
@@ -468,19 +468,44 @@ export class AgentService {
 
     // Register ownership before waiting so stop/replacement can abort a queued stream.
     this.sessionManager.setAbortController(chatId, abortController);
-    this.sessionManager.setStreaming(chatId, true);
 
     if (!skipConcurrencyGate) {
       const { getAgentStreamConcurrencyGate } = await import(
         "./agent/agentStreamConcurrency.js"
       );
+      const gate = getAgentStreamConcurrencyGate();
       try {
-        const priority = chatId.startsWith("job:") ? "background" : "foreground";
-        concurrencyLease = await getAgentStreamConcurrencyGate().acquire(
+        for await (const event of gate.acquireWithEvents(
           chatId,
           abortController.signal,
-          priority,
-        );
+        )) {
+          if (event.type === "queued") {
+            yield {
+              type: "concurrency-queued",
+              chatId,
+              payload: {
+                pool: event.pool,
+                activeCount: event.activeCount,
+                maxConcurrent: event.maxConcurrent,
+                waitingCount: event.waitingCount,
+              },
+              timestamp: new Date().toISOString(),
+            } as StreamChunk & { chatId: string };
+            continue;
+          }
+          concurrencyLease = event.lease;
+          yield {
+            type: "concurrency-acquired",
+            chatId,
+            payload: {
+              pool: event.pool,
+              activeCount: event.activeCount,
+              maxConcurrent: event.maxConcurrent,
+              waitingCount: 0,
+            },
+            timestamp: new Date().toISOString(),
+          } as StreamChunk & { chatId: string };
+        }
       } catch (concurrencyError) {
         const message =
           concurrencyError instanceof Error
@@ -502,6 +527,9 @@ export class AgentService {
         return;
       }
     }
+
+    // Mark streaming only after a slot is acquired — pi-ai / AI SDK work has not started yet.
+    this.sessionManager.setStreaming(chatId, true);
     clearInFlightToolResults(chatId);
 
     // Track response state for error recovery

--- a/src/gateway/services/AgentService.ts
+++ b/src/gateway/services/AgentService.ts
@@ -50,6 +50,7 @@ import {
   compactStaleToolResults,
   estimateMessagesTokens,
 } from "./agent/compactToolResults.js";
+import { anthropicModelUsesAdaptiveThinking } from "../utils/anthropicAdaptiveThinking.js";
 import {
   computeHistoryTokenBudget,
   isContextLengthError,
@@ -1015,6 +1016,9 @@ export class AgentService {
             min_p?: number;
           };
         };
+        anthropic?: {
+          thinking?: { type: "adaptive"; display?: "summarized" };
+        };
       } = {};
 
       // For OpenAI GPT-5.x models with reasoning effort and summary
@@ -1061,6 +1065,24 @@ export class AgentService {
           providerOptions,
           buildMoonshotProviderOptions(config.model, config.reasoning),
         );
+      }
+
+      // For Anthropic models that self-enable thinking (Fable 5.1, Sonnet 5, Opus 5).
+      // Without display:"summarized" they stream empty thinking deltas, so the turn
+      // shows nothing after reasoning-start.
+      //
+      // sendReasoning is deliberately left at its default (true): the SDK replays a
+      // thinking block only when it still holds the signature Anthropic issued, and
+      // drops unsigned reasoning with a warning rather than sending a block the API
+      // would reject. Turning it off would discard the model's own signed reasoning
+      // between tool steps for no safety gain.
+      if (
+        config.provider === "anthropic" &&
+        anthropicModelUsesAdaptiveThinking(config.model)
+      ) {
+        providerOptions.anthropic = {
+          thinking: { type: "adaptive", display: "summarized" },
+        };
       }
 
       // For Ollama models (Qwen, Gemma, etc.) — thinking + adaptive context
@@ -1185,7 +1207,10 @@ export class AgentService {
           ...(tools as unknown as ToolSet),
           ...nativeSearchTools, // Merge native search tools
         },
-        maxTokens: effectiveMaxTokens,
+        // `ai` v6 renamed this from maxTokens. Passing the old name is not an error —
+        // it is dropped as an unknown key with no warning, and @ai-sdk/anthropic then
+        // substitutes its own 4096 default, silently truncating every reply.
+        maxOutputTokens: effectiveMaxTokens,
         // Allow up to maxSteps tool roundtrips before stopping.
         // Hard limit at maxSteps (default 100), but we force stop at 95 to give
         // the model a chance to respond gracefully before hitting the limit.
@@ -1226,6 +1251,7 @@ export class AgentService {
         ...(providerOptions.openai ||
         providerOptions.google ||
         providerOptions.ollama ||
+        providerOptions.anthropic ||
         config.provider === "zai" ||
         config.provider === "groq" ||
         config.provider === "moonshot"

--- a/src/gateway/services/agent/agentStreamConcurrency.ts
+++ b/src/gateway/services/agent/agentStreamConcurrency.ts
@@ -1,36 +1,70 @@
-/** Global concurrency gate for user chats, embedded agents, and jobs. */
+/** Separate concurrency pools for interactive chats and background agent jobs. */
 
 export const DEFAULT_AGENT_STREAM_MAX_CONCURRENT = 6;
 export const AGENT_STREAM_ACQUIRE_TIMEOUT_MS = 5_000;
 export const BACKGROUND_AGENT_STREAM_ACQUIRE_TIMEOUT_MS = 120_000;
 
-export type AgentStreamPriority = "foreground" | "background";
+export type AgentStreamPool = "chat" | "job";
 
 export interface AgentStreamConcurrencyLease {
   chatId: string;
   token: symbol;
-  priority: AgentStreamPriority;
+  pool: AgentStreamPool;
 }
 
 export class AgentStreamConcurrencyTimeoutError extends Error {
   constructor(
+    readonly pool: AgentStreamPool,
     readonly maxConcurrent: number,
     readonly activeCount: number,
     readonly activeChatIds: string[] = [],
   ) {
     super(
-      `Too many concurrent agent sessions (${activeCount}/${maxConcurrent}). ` +
-        "Another chat or agent is still running; stop it or try again shortly.",
+      `Too many concurrent ${pool} agent sessions (${activeCount}/${maxConcurrent}). ` +
+        "Another session is still running; stop it or try again shortly.",
     );
     this.name = "AgentStreamConcurrencyTimeoutError";
   }
 }
+
+export interface AgentStreamPoolStats {
+  pool: AgentStreamPool;
+  maxConcurrent: number;
+  activeCount: number;
+  waitingCount: number;
+  activeChatIds: string[];
+}
+
+export interface AgentStreamConcurrencyStats {
+  chat: AgentStreamPoolStats;
+  job: AgentStreamPoolStats;
+}
+
+export type AgentStreamQueueEvent =
+  | {
+      type: "queued";
+      pool: AgentStreamPool;
+      activeCount: number;
+      maxConcurrent: number;
+      waitingCount: number;
+    }
+  | {
+      type: "admitted";
+      lease: AgentStreamConcurrencyLease;
+      pool: AgentStreamPool;
+      activeCount: number;
+      maxConcurrent: number;
+    };
 
 function readMaxConcurrent(): number {
   const parsed = Number.parseInt(process.env.AGENT_STREAM_MAX_CONCURRENT ?? "", 10);
   return Number.isFinite(parsed) && parsed >= 1
     ? parsed
     : DEFAULT_AGENT_STREAM_MAX_CONCURRENT;
+}
+
+export function resolveAgentStreamPool(chatId: string): AgentStreamPool {
+  return chatId.startsWith("job:") ? "job" : "chat";
 }
 
 interface Waiter {
@@ -42,13 +76,19 @@ interface Waiter {
   onAbort?: () => void;
 }
 
-export class AgentStreamConcurrencyGate {
-  private readonly maxConcurrent = readMaxConcurrent();
+class AgentStreamPoolGate {
+  constructor(
+    readonly pool: AgentStreamPool,
+    private readonly maxConcurrent: number,
+    private readonly acquireTimeoutMs: number,
+  ) {}
+
   private readonly active = new Map<string, AgentStreamConcurrencyLease>();
   private readonly waitQueue: Waiter[] = [];
 
-  getStats() {
+  getStats(): AgentStreamPoolStats {
     return {
+      pool: this.pool,
       maxConcurrent: this.maxConcurrent,
       activeCount: this.active.size,
       waitingCount: this.waitQueue.length,
@@ -56,55 +96,115 @@ export class AgentStreamConcurrencyGate {
     };
   }
 
-  /**
-   * Force-release any lease for a specific chatId.
-   * Use when stopping a stream to immediately free the slot for a replacement.
-   */
   forceReleaseByChatId(chatId: string): boolean {
     const existing = this.active.get(chatId);
     if (!existing) return false;
     this.active.delete(chatId);
     console.log(
-      `[AgentStreamConcurrency] Force-released lease for ${chatId}`,
+      `[AgentStreamConcurrency] Force-released ${this.pool} lease for ${chatId}`,
     );
     this.drainQueue();
     return true;
   }
 
+  async *acquireWithEvents(
+    chatId: string,
+    signal?: AbortSignal,
+  ): AsyncGenerator<AgentStreamQueueEvent, AgentStreamConcurrencyLease> {
+    const lease: AgentStreamConcurrencyLease = {
+      chatId,
+      token: Symbol(chatId),
+      pool: this.pool,
+    };
+
+    if (this.canAdmit(lease)) {
+      const admitted = this.admit(lease);
+      yield {
+        type: "admitted",
+        lease: admitted,
+        pool: this.pool,
+        activeCount: this.active.size,
+        maxConcurrent: this.maxConcurrent,
+      };
+      return admitted;
+    }
+
+    if (signal?.aborted) throw this.cancelledError();
+
+    const statsBeforeWait = this.getStats();
+    yield {
+      type: "queued",
+      pool: this.pool,
+      activeCount: statsBeforeWait.activeCount,
+      maxConcurrent: statsBeforeWait.maxConcurrent,
+      waitingCount: statsBeforeWait.waitingCount + 1,
+    };
+
+    if (signal?.aborted) throw this.cancelledError();
+
+    const admittedLease = await new Promise<AgentStreamConcurrencyLease>(
+      (resolve, reject) => {
+        const waiter: Waiter = {
+          lease,
+          resolve,
+          reject,
+          timer: null,
+          signal,
+        };
+
+        waiter.onAbort = () => {
+          this.removeWaiter(waiter);
+          reject(this.cancelledError());
+        };
+        signal?.addEventListener("abort", waiter.onAbort, { once: true });
+
+        if (this.acquireTimeoutMs > 0) {
+          waiter.timer = setTimeout(() => {
+            this.removeWaiter(waiter);
+            const stats = this.getStats();
+            reject(
+              new AgentStreamConcurrencyTimeoutError(
+                this.pool,
+                stats.maxConcurrent,
+                stats.activeCount,
+                stats.activeChatIds,
+              ),
+            );
+          }, this.acquireTimeoutMs);
+        }
+
+        this.waitQueue.push(waiter);
+        console.log(
+          `[AgentStreamConcurrency] Queued ${chatId} (${this.pool}) — ` +
+            `${this.active.size}/${this.maxConcurrent} active, ` +
+            `${this.waitQueue.length} waiting`,
+        );
+      },
+    );
+
+    yield {
+      type: "admitted",
+      lease: admittedLease,
+      pool: this.pool,
+      activeCount: this.active.size,
+      maxConcurrent: this.maxConcurrent,
+    };
+    return admittedLease;
+  }
+
   async acquire(
     chatId: string,
     signal?: AbortSignal,
-    priority: AgentStreamPriority = "foreground",
   ): Promise<AgentStreamConcurrencyLease> {
-    const lease = { chatId, token: Symbol(chatId), priority };
-    if (this.canAdmit(lease)) return this.admit(lease);
-    if (signal?.aborted) throw this.cancelledError();
-
-    return new Promise((resolve, reject) => {
-      const waiter: Waiter = { lease, resolve, reject, timer: null, signal };
-      waiter.onAbort = () => {
-        this.removeWaiter(waiter);
-        reject(this.cancelledError());
-      };
-      signal?.addEventListener("abort", waiter.onAbort, { once: true });
-      const timeout = priority === "foreground"
-        ? AGENT_STREAM_ACQUIRE_TIMEOUT_MS
-        : BACKGROUND_AGENT_STREAM_ACQUIRE_TIMEOUT_MS;
-      waiter.timer = setTimeout(() => {
-        this.removeWaiter(waiter);
-        const stats = this.getStats();
-        reject(new AgentStreamConcurrencyTimeoutError(
-          stats.maxConcurrent,
-          stats.activeCount,
-          stats.activeChatIds,
-        ));
-      }, timeout);
-      this.waitQueue.push(waiter);
-      console.log(
-        `[AgentStreamConcurrency] Queued ${chatId} (${priority}) — ` +
-          `${this.active.size}/${this.maxConcurrent} active`,
-      );
-    });
+    let lease: AgentStreamConcurrencyLease | undefined;
+    for await (const event of this.acquireWithEvents(chatId, signal)) {
+      if (event.type === "queued") continue;
+      lease = event.lease;
+    }
+    if (!lease) {
+      throw new Error("Agent stream concurrency admission failed");
+    }
+    return lease;
   }
 
   release(lease: AgentStreamConcurrencyLease): void {
@@ -116,10 +216,7 @@ export class AgentStreamConcurrencyGate {
 
   private canAdmit(lease: AgentStreamConcurrencyLease): boolean {
     if (this.active.has(lease.chatId)) return false;
-    if (this.active.size >= this.maxConcurrent) return false;
-    if (lease.priority === "foreground" || this.maxConcurrent === 1) return true;
-    // Keep one slot available for interactive chat when background work is running.
-    return this.active.size < this.maxConcurrent - 1;
+    return this.active.size < this.maxConcurrent;
   }
 
   private admit(lease: AgentStreamConcurrencyLease): AgentStreamConcurrencyLease {
@@ -128,14 +225,12 @@ export class AgentStreamConcurrencyGate {
   }
 
   private drainQueue(): void {
-    // Foreground waiters always get first chance at newly available capacity.
-    this.waitQueue.sort((a, b) =>
-      a.lease.priority === b.lease.priority ? 0 : a.lease.priority === "foreground" ? -1 : 1,
-    );
     let admitted = true;
     while (admitted) {
       admitted = false;
-      const index = this.waitQueue.findIndex((waiter) => this.canAdmit(waiter.lease));
+      const index = this.waitQueue.findIndex((waiter) =>
+        this.canAdmit(waiter.lease),
+      );
       if (index < 0) break;
       const waiter = this.waitQueue[index];
       this.removeWaiter(waiter);
@@ -149,11 +244,85 @@ export class AgentStreamConcurrencyGate {
     if (index >= 0) this.waitQueue.splice(index, 1);
     if (waiter.timer) clearTimeout(waiter.timer);
     waiter.timer = null;
-    if (waiter.onAbort) waiter.signal?.removeEventListener("abort", waiter.onAbort);
+    if (waiter.onAbort) {
+      waiter.signal?.removeEventListener("abort", waiter.onAbort);
+    }
   }
 
   private cancelledError(): Error {
     return new Error("Agent stream cancelled while waiting for concurrency slot");
+  }
+}
+
+export class AgentStreamConcurrencyGate {
+  private readonly chatGate: AgentStreamPoolGate;
+  private readonly jobGate: AgentStreamPoolGate;
+
+  constructor() {
+    const maxConcurrent = readMaxConcurrent();
+    // Chats wait until the user aborts — no timeout while queued for a slot.
+    this.chatGate = new AgentStreamPoolGate("chat", maxConcurrent, 0);
+    this.jobGate = new AgentStreamPoolGate(
+      "job",
+      maxConcurrent,
+      BACKGROUND_AGENT_STREAM_ACQUIRE_TIMEOUT_MS,
+    );
+  }
+
+  private gateForPool(pool: AgentStreamPool): AgentStreamPoolGate {
+    return pool === "job" ? this.jobGate : this.chatGate;
+  }
+
+  getStats(): AgentStreamConcurrencyStats {
+    return {
+      chat: this.chatGate.getStats(),
+      job: this.jobGate.getStats(),
+    };
+  }
+
+  /** @deprecated Prefer getStats().chat — kept for older callers. */
+  getLegacyStats() {
+    const chat = this.chatGate.getStats();
+    return {
+      maxConcurrent: chat.maxConcurrent,
+      activeCount: chat.activeCount,
+      waitingCount: chat.waitingCount,
+      activeChatIds: chat.activeChatIds,
+    };
+  }
+
+  async *acquireWithEvents(
+    chatId: string,
+    signal?: AbortSignal,
+    pool: AgentStreamPool = resolveAgentStreamPool(chatId),
+  ): AsyncGenerator<AgentStreamQueueEvent, AgentStreamConcurrencyLease> {
+    return yield* this.gateForPool(pool).acquireWithEvents(chatId, signal);
+  }
+
+  async acquire(
+    chatId: string,
+    signal?: AbortSignal,
+    pool: AgentStreamPool = resolveAgentStreamPool(chatId),
+  ): Promise<AgentStreamConcurrencyLease> {
+    let lease: AgentStreamConcurrencyLease | undefined;
+    for await (const event of this.acquireWithEvents(chatId, signal, pool)) {
+      if (event.type === "admitted") lease = event.lease;
+    }
+    if (!lease) {
+      throw new Error("Agent stream concurrency admission failed");
+    }
+    return lease;
+  }
+
+  release(lease: AgentStreamConcurrencyLease): void {
+    this.gateForPool(lease.pool).release(lease);
+  }
+
+  forceReleaseByChatId(chatId: string): boolean {
+    return (
+      this.chatGate.forceReleaseByChatId(chatId) ||
+      this.jobGate.forceReleaseByChatId(chatId)
+    );
   }
 }
 

--- a/src/gateway/services/providers/piAiAnthropicAdaptiveThinking.ts
+++ b/src/gateway/services/providers/piAiAnthropicAdaptiveThinking.ts
@@ -6,6 +6,8 @@
  * We patch the outgoing Messages API payload via pi-ai's onPayload hook.
  */
 
+import { anthropicModelUsesAdaptiveThinking } from "../../utils/anthropicAdaptiveThinking.js";
+
 export type PiAiReasoningLevel =
   | "minimal"
   | "low"
@@ -50,15 +52,15 @@ export interface PiAiAnthropicStreamOptions {
 /** Minimum Claude Code CLI version Anthropic accepts for OAuth-backed frontier models. */
 export const CLAUDE_CODE_OAUTH_USER_AGENT_VERSION = "2.1.251";
 
-/** Models pi-ai misconfigures (budget thinking) but Anthropic requires adaptive-only. */
+/**
+ * Models pi-ai misconfigures (budget thinking) but Anthropic requires adaptive-only.
+ *
+ * Shares one list with the AI SDK path so the OAuth and API-key routes cannot drift
+ * apart — a model handled here but missed there streams empty thinking deltas and
+ * the turn renders as nothing at all.
+ */
 export function requiresPiAiAdaptiveThinkingOverride(modelId: string): boolean {
-  return (
-    modelId.includes("fable") ||
-    modelId.includes("opus-5") ||
-    modelId.includes("opus-4-8") ||
-    modelId.includes("opus-4.8") ||
-    modelId.includes("sonnet-5")
-  );
+  return anthropicModelUsesAdaptiveThinking(modelId);
 }
 
 export function mapPiAiReasoningToAnthropicEffort(

--- a/src/gateway/utils/anthropicAdaptiveThinking.ts
+++ b/src/gateway/utils/anthropicAdaptiveThinking.ts
@@ -1,0 +1,28 @@
+/**
+ * Which Anthropic models need adaptive thinking configured explicitly.
+ *
+ * Fable 5.1 and Sonnet 5 switch thinking on by themselves as soon as tools are
+ * present, and the thinking text is withheld: the stream carries an empty
+ * `thinking_delta` followed only by a `signature_delta`. The turn therefore looks
+ * dead to the UI — `reasoning-start` arrives and nothing follows. Asking for
+ * `display: "summarized"` is what makes the text materialise.
+ *
+ * Verified against the live API (same prompt, tools present):
+ *   claude-opus-5     -> no thinking block
+ *   claude-fable-5-1  -> thinking block, 0 chars of text, signature required
+ *   claude-sonnet-5   -> thinking block, 0 chars of text, signature required
+ *
+ * The model list matches `requiresPiAiAdaptiveThinkingOverride` so the API-key
+ * (AI SDK) and OAuth (pi-ai) paths behave identically. Opus 5 does not
+ * self-enable thinking, but the pi-ai path already requests adaptive thinking for
+ * it, so it stays in the set to keep the two routes from diverging.
+ */
+export function anthropicModelUsesAdaptiveThinking(modelId: string): boolean {
+  return (
+    modelId.includes("fable") ||
+    modelId.includes("opus-5") ||
+    modelId.includes("opus-4-8") ||
+    modelId.includes("opus-4.8") ||
+    modelId.includes("sonnet-5")
+  );
+}

--- a/tests/agent-stream-concurrency.test.ts
+++ b/tests/agent-stream-concurrency.test.ts
@@ -15,74 +15,106 @@ describe("AgentStreamConcurrencyGate", () => {
   });
   afterEach(() => vi.useRealTimers());
 
-  test("defaults to six concurrent agent streams", () => {
+  test("defaults to six concurrent streams per pool", () => {
     const gate = new AgentStreamConcurrencyGate();
     expect(DEFAULT_AGENT_STREAM_MAX_CONCURRENT).toBe(6);
-    expect(gate.getStats().maxConcurrent).toBe(6);
+    expect(gate.getStats().chat.maxConcurrent).toBe(6);
+    expect(gate.getStats().job.maxConcurrent).toBe(6);
   });
 
-  test("allows two foreground streams", async () => {
-    process.env.AGENT_STREAM_MAX_CONCURRENT = "2";
+  test("chat and job pools are independent", async () => {
+    process.env.AGENT_STREAM_MAX_CONCURRENT = "1";
     const gate = new AgentStreamConcurrencyGate();
-    const a = await gate.acquire("chat-a");
-    const b = await gate.acquire("chat-b");
-    expect(gate.getStats().activeCount).toBe(2);
-    gate.release(a);
-    gate.release(b);
-    expect(gate.getStats().activeCount).toBe(0);
+    const job = await gate.acquire("job:a");
+    const chat = await gate.acquire("chat-a");
+    expect(gate.getStats().job.activeCount).toBe(1);
+    expect(gate.getStats().chat.activeCount).toBe(1);
+    gate.release(job);
+    gate.release(chat);
   });
 
-  test("reserves one slot from background work for foreground chat", async () => {
+  test("six jobs do not block a seventh chat", async () => {
     process.env.AGENT_STREAM_MAX_CONCURRENT = "2";
     const gate = new AgentStreamConcurrencyGate();
-    const job = await gate.acquire("job:a", undefined, "background");
-    let secondJobAdmitted = false;
-    const secondJob = gate.acquire("job:b", undefined, "background").then((lease) => {
-      secondJobAdmitted = true;
+    const jobs = await Promise.all([
+      gate.acquire("job:1"),
+      gate.acquire("job:2"),
+    ]);
+    const chat = await gate.acquire("chat-a");
+    expect(chat.pool).toBe("chat");
+    expect(gate.getStats().job.activeCount).toBe(2);
+    expect(gate.getStats().chat.activeCount).toBe(1);
+    for (const lease of jobs) gate.release(lease);
+    gate.release(chat);
+  });
+
+  test("chat pool blocks additional chats at capacity", async () => {
+    process.env.AGENT_STREAM_MAX_CONCURRENT = "1";
+    const gate = new AgentStreamConcurrencyGate();
+    await gate.acquire("chat-a");
+    let secondAdmitted = false;
+    const second = gate.acquire("chat-b").then((lease) => {
+      secondAdmitted = true;
       return lease;
     });
     await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(secondJobAdmitted).toBe(false);
-
-    const chat = await gate.acquire("chat-a", undefined, "foreground");
-    expect(gate.getStats().activeCount).toBe(2);
-    gate.release(chat);
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(secondJobAdmitted).toBe(false);
-
-    gate.release(job);
-    const secondLease = await secondJob;
-    expect(secondJobAdmitted).toBe(true);
-    gate.release(secondLease);
+    expect(secondAdmitted).toBe(false);
+    gate.forceReleaseByChatId("chat-a");
+    await second;
+    expect(secondAdmitted).toBe(true);
   });
 
-  test("foreground waits only briefly before returning a useful error", async () => {
+  test("chat pool waits indefinitely by default (no timeout)", async () => {
     vi.useFakeTimers();
     process.env.AGENT_STREAM_MAX_CONCURRENT = "1";
     const gate = new AgentStreamConcurrencyGate();
     await gate.acquire("chat-a");
     const pending = gate.acquire("chat-b");
-    const expectation = expect(pending).rejects.toBeInstanceOf(
-      AgentStreamConcurrencyTimeoutError,
-    );
-    await vi.advanceTimersByTimeAsync(AGENT_STREAM_ACQUIRE_TIMEOUT_MS + 1);
-    await expectation;
+    let rejected = false;
+    void pending.catch(() => {
+      rejected = true;
+    });
+    await vi.advanceTimersByTimeAsync(AGENT_STREAM_ACQUIRE_TIMEOUT_MS + 60_000);
+    expect(rejected).toBe(false);
   });
 
-  test("background work retains the longer queue timeout", async () => {
+  test("job pool retains the longer queue timeout", async () => {
     vi.useFakeTimers();
     process.env.AGENT_STREAM_MAX_CONCURRENT = "1";
     const gate = new AgentStreamConcurrencyGate();
-    await gate.acquire("chat-a");
-    const pending = gate.acquire("job:a", undefined, "background");
+    await gate.acquire("job:a");
+    const pending = gate.acquire("job:b");
     let rejected = false;
-    void pending.catch(() => { rejected = true; });
+    void pending.catch(() => {
+      rejected = true;
+    });
     await vi.advanceTimersByTimeAsync(AGENT_STREAM_ACQUIRE_TIMEOUT_MS + 1);
     expect(rejected).toBe(false);
     await vi.advanceTimersByTimeAsync(
       BACKGROUND_AGENT_STREAM_ACQUIRE_TIMEOUT_MS - AGENT_STREAM_ACQUIRE_TIMEOUT_MS,
     );
     await expect(pending).rejects.toBeInstanceOf(AgentStreamConcurrencyTimeoutError);
+  });
+
+  test("acquireWithEvents yields queued then admitted", async () => {
+    process.env.AGENT_STREAM_MAX_CONCURRENT = "1";
+    const gate = new AgentStreamConcurrencyGate();
+    await gate.acquire("chat-a");
+
+    const events: string[] = [];
+    let leasePromise: Promise<unknown> | undefined;
+    const run = async () => {
+      for await (const event of gate.acquireWithEvents("chat-b")) {
+        events.push(event.type);
+      }
+    };
+    leasePromise = run();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(events).toEqual(["queued"]);
+
+    gate.forceReleaseByChatId("chat-a");
+    await leasePromise;
+    expect(events).toEqual(["queued", "admitted"]);
   });
 
   test("serializes replacement streams and ignores stale releases", async () => {
@@ -99,9 +131,9 @@ describe("AgentStreamConcurrencyGate", () => {
     gate.release(first);
     const second = await replacement;
     gate.release(first);
-    expect(gate.getStats().activeCount).toBe(1);
+    expect(gate.getStats().chat.activeCount).toBe(1);
     gate.release(second);
-    expect(gate.getStats().activeCount).toBe(0);
+    expect(gate.getStats().chat.activeCount).toBe(0);
   });
 
   test("aborts a queued replacement", async () => {
@@ -110,9 +142,10 @@ describe("AgentStreamConcurrencyGate", () => {
     const first = await gate.acquire("chat-a");
     const controller = new AbortController();
     const replacement = gate.acquire("chat-a", controller.signal);
+    await Promise.resolve();
     controller.abort();
     await expect(replacement).rejects.toThrow("cancelled while waiting");
-    expect(gate.getStats().waitingCount).toBe(0);
+    expect(gate.getStats().chat.waitingCount).toBe(0);
     gate.release(first);
   });
 
@@ -120,42 +153,18 @@ describe("AgentStreamConcurrencyGate", () => {
     process.env.AGENT_STREAM_MAX_CONCURRENT = "1";
     const gate = new AgentStreamConcurrencyGate();
     const first = await gate.acquire("chat-a");
-    expect(gate.getStats().activeCount).toBe(1);
+    expect(gate.getStats().chat.activeCount).toBe(1);
 
-    // Force release (simulates stopStreaming being called)
     const released = gate.forceReleaseByChatId("chat-a");
     expect(released).toBe(true);
-    expect(gate.getStats().activeCount).toBe(0);
+    expect(gate.getStats().chat.activeCount).toBe(0);
 
-    // New stream can now acquire immediately
     const second = await gate.acquire("chat-a");
-    expect(gate.getStats().activeCount).toBe(1);
+    expect(gate.getStats().chat.activeCount).toBe(1);
 
-    // Original release is a no-op (token mismatch)
     gate.release(first);
-    expect(gate.getStats().activeCount).toBe(1);
+    expect(gate.getStats().chat.activeCount).toBe(1);
     gate.release(second);
-    expect(gate.getStats().activeCount).toBe(0);
-  });
-
-  test("forceReleaseByChatId drains waiting queue", async () => {
-    process.env.AGENT_STREAM_MAX_CONCURRENT = "1";
-    const gate = new AgentStreamConcurrencyGate();
-    await gate.acquire("chat-a");
-
-    // Queue a replacement
-    let admitted = false;
-    const replacement = gate.acquire("chat-a").then((lease) => {
-      admitted = true;
-      return lease;
-    });
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(admitted).toBe(false);
-
-    // Force release should drain queue and admit the replacement
-    gate.forceReleaseByChatId("chat-a");
-    const second = await replacement;
-    expect(admitted).toBe(true);
-    gate.release(second);
+    expect(gate.getStats().chat.activeCount).toBe(0);
   });
 });

--- a/tests/anthropic-request-shape.test.ts
+++ b/tests/anthropic-request-shape.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Contract tests for the Anthropic request body the AI SDK builds for us.
+ *
+ * These exist because the failure they cover is invisible: `ai` v6 renamed
+ * `maxTokens` to `maxOutputTokens`, and passing the old name is not an error.
+ * It is dropped as an unknown key with no warning, and @ai-sdk/anthropic then
+ * substitutes its own 4096 default — so a model configured for 128K output was
+ * silently capped at 4096 on every request. Nothing in types, lint, or runtime
+ * logs catches that; only the wire format shows it.
+ *
+ * We assert against a local echo server rather than mocking the SDK, so the
+ * tests fail if a future SDK version renames or reinterprets these options.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { streamText, tool } from "ai";
+import type { ModelMessage } from "ai";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { anthropicModelUsesAdaptiveThinking } from "../src/gateway/utils/anthropicAdaptiveThinking.js";
+
+interface AnthropicRequestBody {
+  model: string;
+  max_tokens: number;
+  thinking?: { type: string; display?: string };
+  messages: Array<{ role: string; content: unknown }>;
+}
+
+let server: http.Server;
+let baseURL: string;
+const received: AnthropicRequestBody[] = [];
+
+/** Smallest SSE body that lets streamText resolve instead of throwing. */
+function writeMinimalStream(res: http.ServerResponse): void {
+  res.writeHead(200, { "content-type": "text/event-stream" });
+  res.write(
+    `event: message_start\ndata: ${JSON.stringify({
+      type: "message_start",
+      message: {
+        id: "msg_test",
+        type: "message",
+        role: "assistant",
+        model: "claude-fable-5-1",
+        content: [],
+        stop_reason: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    })}\n\n`,
+  );
+  res.write(
+    `event: message_delta\ndata: ${JSON.stringify({
+      type: "message_delta",
+      delta: { stop_reason: "end_turn" },
+      usage: { output_tokens: 1 },
+    })}\n\n`,
+  );
+  res.write(`event: message_stop\ndata: {"type":"message_stop"}\n\n`);
+  res.end();
+}
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      received.push(JSON.parse(body) as AnthropicRequestBody);
+      writeMinimalStream(res);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  baseURL = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});
+
+/** Issue one request through the real SDK and return the body Anthropic would see. */
+async function capture(
+  extra: Record<string, unknown>,
+  messages?: ModelMessage[],
+): Promise<AnthropicRequestBody> {
+  const anthropic = createAnthropic({
+    apiKey: "test-key-not-real",
+    baseURL,
+  });
+  const result = streamText({
+    model: anthropic("claude-fable-5-1"),
+    messages: messages ?? [{ role: "user", content: "hello" }],
+    tools: {
+      bash: tool({
+        description: "Run a shell command",
+        inputSchema: z.object({ command: z.string() }),
+      }),
+    },
+    ...extra,
+  });
+  // Draining is what actually issues the request.
+  for await (const _chunk of result.fullStream) {
+    void _chunk;
+  }
+  const body = received.at(-1);
+  if (!body) {
+    throw new Error("echo server captured no request");
+  }
+  return body;
+}
+
+describe("anthropic request shape", () => {
+  it("sends the configured output cap when using the v6 option name", async () => {
+    const body = await capture({ maxOutputTokens: 128000 });
+    expect(body.max_tokens).toBe(128000);
+  });
+
+  it("regression: the pre-v6 maxTokens name is silently ignored", async () => {
+    // This is the bug, pinned. `maxTokens` does not throw and does not warn — it
+    // is dropped, and the provider default takes over. If a future SDK starts
+    // honouring or rejecting it, this test tells us the workaround can change.
+    const body = await capture({ maxTokens: 128000 });
+    expect(body.max_tokens).toBe(4096);
+    expect(body.max_tokens).not.toBe(128000);
+  });
+
+  it("requests summarized adaptive thinking so reasoning text is not withheld", async () => {
+    // Fable 5.1 enables thinking by itself once tools are present and streams
+    // empty thinking deltas unless display is summarized, which renders as a
+    // turn that produces nothing at all.
+    const body = await capture({
+      maxOutputTokens: 128000,
+      providerOptions: {
+        anthropic: {
+          thinking: { type: "adaptive", display: "summarized" },
+        },
+      },
+    });
+    expect(body.thinking).toEqual({ type: "adaptive", display: "summarized" });
+  });
+
+  it("never puts an unsigned thinking block on the wire", async () => {
+    // Anthropic rejects a thinking block whose signature is missing or does not
+    // match ("thinking.signature: Field required" / "Invalid `signature`"). Our
+    // stored history carries reasoning text but no signature, so this is the
+    // invariant that keeps a replayed turn from 400ing. The SDK drops such a
+    // part and emits an "unsupported reasoning metadata" warning instead, which
+    // is why we leave sendReasoning at its default rather than disabling it.
+    const messages: ModelMessage[] = [
+      { role: "user", content: "check the repo" },
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "Prior reasoning with no signature." },
+          { type: "text", text: "Let me look." },
+        ],
+      },
+      { role: "user", content: "continue" },
+    ];
+
+    const body = await capture({ maxOutputTokens: 1000 }, messages);
+    const sentBlockTypes = body.messages
+      .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+      .filter((c): c is { type: string } => typeof c === "object" && c !== null)
+      .map((c) => c.type);
+
+    expect(sentBlockTypes).not.toContain("thinking");
+    // The text alongside the dropped reasoning must still survive.
+    expect(sentBlockTypes).toContain("text");
+  });
+});
+
+describe("anthropicModelUsesAdaptiveThinking", () => {
+  it("covers the models that self-enable thinking", () => {
+    // Verified against the live API: these return a thinking block with empty
+    // text when tools are present.
+    expect(anthropicModelUsesAdaptiveThinking("claude-fable-5-1")).toBe(true);
+    expect(anthropicModelUsesAdaptiveThinking("claude-fable-5")).toBe(true);
+    expect(anthropicModelUsesAdaptiveThinking("claude-sonnet-5")).toBe(true);
+  });
+
+  it("stays in step with the pi-ai override list", () => {
+    expect(anthropicModelUsesAdaptiveThinking("claude-opus-5")).toBe(true);
+    expect(anthropicModelUsesAdaptiveThinking("claude-opus-4-8")).toBe(true);
+    expect(anthropicModelUsesAdaptiveThinking("claude-opus-4.8")).toBe(true);
+  });
+
+  it("leaves budget-thinking and non-Claude models alone", () => {
+    expect(anthropicModelUsesAdaptiveThinking("claude-opus-4-7")).toBe(false);
+    expect(anthropicModelUsesAdaptiveThinking("claude-opus-4-6")).toBe(false);
+    expect(anthropicModelUsesAdaptiveThinking("claude-sonnet-4-6")).toBe(false);
+    expect(anthropicModelUsesAdaptiveThinking("claude-haiku-4-5")).toBe(false);
+    expect(anthropicModelUsesAdaptiveThinking("gpt-5-6-sol")).toBe(false);
+  });
+});

--- a/tests/chat-history-merge-order.test.ts
+++ b/tests/chat-history-merge-order.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Merging server history into a chat must not reorder the conversation.
+ *
+ * The bug these cover: the server list is a *window* — loadMessages asks for
+ * the newest 30 — but the merge treated any local message missing from that
+ * window as an optimistic send and appended it to the end. Once the user had
+ * scrolled up and paginated older turns into view, the next history sync moved
+ * every one of those older turns *below* the newest message.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { ChatMessage } from "../ui/types/chat";
+
+// The module under test transitively imports the gateway client, which opens a
+// WebSocket in its constructor and schedules reconnect timers on failure. Stub
+// it so this stays a pure unit test instead of depending on a running gateway.
+vi.mock("../ui/src/lib/gateway", () => ({
+  gateway: { send: vi.fn(), onBroadcast: vi.fn(), isConnected: () => false },
+  GATEWAY_DISCONNECTED_ERROR: "Gateway disconnected",
+}));
+
+import { mergeHistoryWithLocal } from "../ui/lib/agentStreamRecovery";
+
+function msg(id: string, role: "user" | "assistant" = "user"): ChatMessage {
+  // Server-mapped messages carry no timestamp (see mapHistoryMessages), so the
+  // fixtures omit it too — placement must not depend on one.
+  return { id, role, content: `body ${id}` } as ChatMessage;
+}
+
+/** m01..mNN, chronological, as the store holds them. */
+function conversation(count: number): ChatMessage[] {
+  return Array.from({ length: count }, (_, i) =>
+    msg(
+      `m${String(i + 1).padStart(2, "0")}`,
+      i % 2 === 0 ? "user" : "assistant",
+    ),
+  );
+}
+
+const ids = (messages: ChatMessage[]) => messages.map((m) => m.id);
+
+describe("mergeHistoryWithLocal ordering", () => {
+  it("keeps paginated older turns above the fetched window", () => {
+    // The user scrolled up, so the store holds 50 turns. A routine history
+    // sync fetches only the newest 30.
+    const local = conversation(50);
+    const serverWindow = local.slice(20).map((m) => msg(m.id, m.role as never));
+
+    const merged = mergeHistoryWithLocal(local, serverWindow);
+
+    expect(ids(merged)).toEqual(ids(local));
+  });
+
+  it("still appends an optimistic send the server has not stored yet", () => {
+    const local = [...conversation(4), msg("pending-user")];
+    const serverWindow = conversation(4);
+
+    const merged = mergeHistoryWithLocal(local, serverWindow);
+
+    expect(ids(merged)).toEqual(["m01", "m02", "m03", "m04", "pending-user"]);
+  });
+
+  it("places older and newer strays on their own sides of the window", () => {
+    const local = [
+      msg("old-a"),
+      msg("old-b"),
+      ...conversation(3),
+      msg("pending-user"),
+    ];
+    const serverWindow = conversation(3);
+
+    const merged = mergeHistoryWithLocal(local, serverWindow);
+
+    expect(ids(merged)).toEqual([
+      "old-a",
+      "old-b",
+      "m01",
+      "m02",
+      "m03",
+      "pending-user",
+    ]);
+  });
+
+  it("leaves a full history untouched when nothing was paginated", () => {
+    const local = conversation(6);
+    const server = conversation(6);
+
+    expect(ids(mergeHistoryWithLocal(local, server))).toEqual(ids(local));
+  });
+
+  it("keeps local order when the server returns nothing", () => {
+    const local = conversation(3);
+
+    expect(ids(mergeHistoryWithLocal(local, []))).toEqual(ids(local));
+  });
+
+  it("adds server turns the store is missing, in place", () => {
+    // The gap-filling the merge already did must survive the fix.
+    const local = [msg("m01"), msg("m03")];
+    const server = [msg("m01"), msg("m02"), msg("m03")];
+
+    expect(ids(mergeHistoryWithLocal(local, server))).toEqual([
+      "m01",
+      "m02",
+      "m03",
+    ]);
+  });
+});

--- a/tests/chat-model-scoping.test.ts
+++ b/tests/chat-model-scoping.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Model selection must not cross between chats.
+ *
+ * The bug these cover: per-chat selection lived only in an in-memory map, so a
+ * restart emptied it and every chat then fell back to one global "last model
+ * picked anywhere". Opening an Opus chat showed Fable — and, because the picker
+ * value is what gets sent as `config.model`, Fable actually answered. In one
+ * real chat, 32 turns ran on claude-opus-5 and 2 turns silently ran on Fable.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  MAX_REMEMBERED_CHATS,
+  forgetChatModel,
+  readChatModel,
+  readNewChatDefaultModel,
+  renameChatModel,
+  writeChatModel,
+  writeNewChatDefaultModel,
+} from "../ui/utils/chatModelMemory";
+import {
+  findHistoryModelId,
+  resolveChatModelId,
+} from "../ui/utils/resolveChatModel";
+
+/** Minimal localStorage so these run without a DOM. */
+class MemoryStorage implements Storage {
+  private data = new Map<string, string>();
+  get length(): number {
+    return this.data.size;
+  }
+  clear(): void {
+    this.data.clear();
+  }
+  getItem(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.data.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.data.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.data.set(key, String(value));
+  }
+}
+
+const OPUS = "claude-opus-5";
+const FABLE = "claude-fable-5-1";
+
+beforeEach(() => {
+  const storage = new MemoryStorage();
+  // @ts-expect-error -- test shim for a browser global
+  globalThis.window = { localStorage: storage };
+});
+
+describe("chatModelMemory", () => {
+  it("keeps each chat's model separate", () => {
+    writeChatModel("chat-opus", OPUS);
+    writeChatModel("chat-fable", FABLE);
+
+    expect(readChatModel("chat-opus")).toBe(OPUS);
+    expect(readChatModel("chat-fable")).toBe(FABLE);
+  });
+
+  it("regression: picking a model in one chat does not change another", () => {
+    writeChatModel("chat-a", OPUS);
+    writeChatModel("chat-b", OPUS);
+
+    writeChatModel("chat-b", FABLE);
+
+    expect(readChatModel("chat-a")).toBe(OPUS);
+    expect(readChatModel("chat-b")).toBe(FABLE);
+  });
+
+  it("survives a restart — this is what the in-memory map could not do", () => {
+    writeChatModel("chat-opus", OPUS);
+
+    // A restart drops React/Zustand state but not localStorage.
+    expect(readChatModel("chat-opus")).toBe(OPUS);
+  });
+
+  it("returns undefined for a chat it has never seen", () => {
+    writeChatModel("chat-fable", FABLE);
+    expect(readChatModel("chat-unknown")).toBeUndefined();
+  });
+
+  it("tracks the new-chat default separately from any chat", () => {
+    writeChatModel("chat-opus", OPUS);
+    writeNewChatDefaultModel(FABLE);
+
+    expect(readNewChatDefaultModel()).toBe(FABLE);
+    expect(readChatModel("chat-opus")).toBe(OPUS);
+  });
+
+  it("carries the selection across the temp -> permanent chat id rename", () => {
+    writeChatModel("temp-123", FABLE);
+    renameChatModel("temp-123", "real-456");
+
+    expect(readChatModel("real-456")).toBe(FABLE);
+    expect(readChatModel("temp-123")).toBeUndefined();
+  });
+
+  it("forgets a deleted chat", () => {
+    writeChatModel("chat-gone", OPUS);
+    forgetChatModel("chat-gone");
+    expect(readChatModel("chat-gone")).toBeUndefined();
+  });
+
+  it("bounds growth, evicting least recently used chats first", () => {
+    for (let i = 0; i < MAX_REMEMBERED_CHATS; i++) {
+      writeChatModel(`chat-${i}`, OPUS);
+    }
+    // Revisit the oldest so it is no longer least-recently-used.
+    writeChatModel("chat-0", FABLE);
+    writeChatModel("chat-overflow", OPUS);
+
+    expect(readChatModel("chat-0")).toBe(FABLE);
+    expect(readChatModel("chat-overflow")).toBe(OPUS);
+    expect(readChatModel("chat-1")).toBeUndefined();
+  });
+
+  it("shrugs off a corrupted blob instead of throwing", () => {
+    window.localStorage.setItem("paprwork_chat_model_ids", "{not json");
+    expect(readChatModel("chat-any")).toBeUndefined();
+
+    writeChatModel("chat-any", OPUS);
+    expect(readChatModel("chat-any")).toBe(OPUS);
+  });
+
+  it("ignores non-string entries in a tampered blob", () => {
+    window.localStorage.setItem(
+      "paprwork_chat_model_ids",
+      JSON.stringify({ good: OPUS, bad: 42, empty: "" }),
+    );
+    expect(readChatModel("good")).toBe(OPUS);
+    expect(readChatModel("bad")).toBeUndefined();
+    expect(readChatModel("empty")).toBeUndefined();
+  });
+
+  it("does not throw when there is no window (SSR / worker)", () => {
+    // @ts-expect-error -- removing the test shim
+    delete globalThis.window;
+    expect(() => writeChatModel("chat-a", OPUS)).not.toThrow();
+    expect(readChatModel("chat-a")).toBeUndefined();
+    expect(readNewChatDefaultModel()).toBeUndefined();
+  });
+});
+
+describe("resolveChatModelId", () => {
+  it("prefers the chat's own explicit selection", () => {
+    expect(
+      resolveChatModelId({
+        perChatModelId: OPUS,
+        historyModelId: FABLE,
+        newChatDefaultModelId: FABLE,
+        hasHistory: true,
+      }),
+    ).toBe(OPUS);
+  });
+
+  it("falls back to the model that answered in this chat", () => {
+    expect(
+      resolveChatModelId({
+        historyModelId: OPUS,
+        newChatDefaultModelId: FABLE,
+        hasHistory: true,
+      }),
+    ).toBe(OPUS);
+  });
+
+  it("regression: an existing chat never inherits the global default", () => {
+    // The exact reported case: an Opus chat, no local selection left after a
+    // restart, and Fable was the last model picked in some other chat.
+    expect(
+      resolveChatModelId({
+        newChatDefaultModelId: FABLE,
+        hasHistory: true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("seeds a brand-new chat from the global default", () => {
+    expect(
+      resolveChatModelId({
+        newChatDefaultModelId: FABLE,
+        hasHistory: false,
+      }),
+    ).toBe(FABLE);
+  });
+
+  it("returns undefined when there is nothing to go on", () => {
+    expect(resolveChatModelId({ hasHistory: false })).toBeUndefined();
+  });
+
+  it("keeps two parallel chats on their own models", () => {
+    const opusChat = resolveChatModelId({
+      perChatModelId: OPUS,
+      newChatDefaultModelId: FABLE,
+      hasHistory: true,
+    });
+    const fableChat = resolveChatModelId({
+      perChatModelId: FABLE,
+      newChatDefaultModelId: FABLE,
+      hasHistory: true,
+    });
+
+    expect(opusChat).toBe(OPUS);
+    expect(fableChat).toBe(FABLE);
+  });
+});
+
+describe("findHistoryModelId", () => {
+  it("returns the model that answered most recently", () => {
+    expect(
+      findHistoryModelId([
+        { role: "user" },
+        { role: "assistant", model: FABLE },
+        { role: "user" },
+        { role: "assistant", model: OPUS },
+      ]),
+    ).toBe(OPUS);
+  });
+
+  it("skips a streaming turn that has no model yet", () => {
+    expect(
+      findHistoryModelId([
+        { role: "assistant", model: OPUS },
+        { role: "user" },
+        { role: "assistant" },
+      ]),
+    ).toBe(OPUS);
+  });
+
+  it("ignores user messages", () => {
+    expect(
+      findHistoryModelId([{ role: "user", model: FABLE }]),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for an empty chat", () => {
+    expect(findHistoryModelId([])).toBeUndefined();
+  });
+});

--- a/tests/chat-state-recovery.test.ts
+++ b/tests/chat-state-recovery.test.ts
@@ -1,0 +1,95 @@
+/**
+ * A mounted chat pane must recover when its store entry is wiped underneath it.
+ *
+ * The bug these cover: the pane hydrates messages in an effect keyed on chatId,
+ * so a wipe of `chatStates` left the pane rendering the welcome screen with the
+ * conversation apparently gone. Switching to another tab and back restored it,
+ * because that unmounts and remounts the pane and re-runs the hydration effect.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { shouldRehydrateAfterStoreWipe } from "../ui/utils/chatStateRecovery";
+
+const CHAT = "8f2c1d90-4a6b-4c2e-9f11-7d3b5e6a1c04";
+
+describe("shouldRehydrateAfterStoreWipe", () => {
+  it("reloads when the entry disappears while the pane is mounted", () => {
+    expect(
+      shouldRehydrateAfterStoreWipe({
+        chatId: CHAT,
+        hadEntry: true,
+        hasEntry: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("stays quiet while the entry is present", () => {
+    expect(
+      shouldRehydrateAfterStoreWipe({
+        chatId: CHAT,
+        hadEntry: true,
+        hasEntry: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not fire on first mount, when the mount effect already loads", () => {
+    expect(
+      shouldRehydrateAfterStoreWipe({
+        chatId: CHAT,
+        hadEntry: false,
+        hasEntry: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("settles after the reload recreates the entry, so it cannot loop", () => {
+    // The reload always writes an entry back (loadMessages does so in its
+    // finally block), which flips hasEntry true and ends the sequence.
+    const first = shouldRehydrateAfterStoreWipe({
+      chatId: CHAT,
+      hadEntry: true,
+      hasEntry: false,
+    });
+    const second = shouldRehydrateAfterStoreWipe({
+      chatId: CHAT,
+      hadEntry: false,
+      hasEntry: true,
+    });
+    expect([first, second]).toEqual([true, false]);
+  });
+
+  it("ignores temp chats, whose entry is removed by id migration", () => {
+    // migrateChatId deletes the temp entry, then an await runs before the tab
+    // switches to the permanent id — so the pane can render with the temp id
+    // and no entry. There is nothing to load for a temp chat.
+    expect(
+      shouldRehydrateAfterStoreWipe({
+        chatId: "temp-1757030000000-abc123",
+        hadEntry: true,
+        hasEntry: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("store wipe shape the recovery depends on", () => {
+  it("resetForWorkspaceSwitch removes entries rather than emptying them", () => {
+    // The predicate keys off entry *absence*, which is only a valid signal
+    // while the wipe clears the map. If this ever changed to writing entries
+    // holding [], the recovery above would silently stop firing.
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const source = readFileSync(
+      path.join(here, "../ui/stores/chatStore.ts"),
+      "utf8",
+    );
+
+    const reset = source.slice(source.indexOf("resetForWorkspaceSwitch:"));
+    const body = reset.slice(0, reset.indexOf("}),") + 3);
+
+    expect(body).toContain("chatStates: new Map()");
+  });
+});

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -29,6 +29,7 @@ import { PaprQuotaBanner } from "./components/PaprQuotaBanner/PaprQuotaBanner";
 import { ConnectionIndicator } from "./components/ConnectionIndicator/ConnectionIndicator";
 import { useAppStatePersistence } from "./hooks/useAppStatePersistence";
 import { useChatStore } from "./stores/chatStore";
+import { writeNewChatDefaultModel } from "./utils/chatModelMemory";
 import {
   initializeAmplitudeBrowser,
   setTelemetryPaprUserId,
@@ -132,9 +133,10 @@ export function App() {
         if (response.success && response.data?.uiPreferences) {
           const { lastModelId } = response.data.uiPreferences;
           
-          // Populate localStorage for fast access (model selection only)
+          // Seeds *new* chats only. Existing chats resolve their own model from
+          // their per-chat selection or their history, never from this value.
           if (lastModelId) {
-            localStorage.setItem("paprwork_last_model_id", lastModelId);
+            writeNewChatDefaultModel(lastModelId);
           }
           
           console.log('[App] UI preferences loaded from settings:', { lastModelId });

--- a/ui/components/Chat/ChatContainer.tsx
+++ b/ui/components/Chat/ChatContainer.tsx
@@ -37,6 +37,7 @@ import {
 import { artifactsToMessageAttachments } from "../../utils/messageAttachments";
 import { mapHistoryMessages } from "../../utils/historyMapper";
 import { extractFilesFromDataTransfer } from "../../utils/chatAttachmentFiles";
+import { shouldRehydrateAfterStoreWipe } from "../../utils/chatStateRecovery";
 import "./ChatContainer.css";
 import { trackEvent } from "../../lib/telemetry";
 import { chatHasLiveStreamBlockingHistory } from "../../lib/agentStreamRecovery";
@@ -271,6 +272,19 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
   useEffect(() => {
     syncHistoryFromServer();
   }, [chatId, syncHistoryFromServer]);
+
+  // The effect above only re-runs when chatId changes, so a store wipe while
+  // this pane stays mounted leaves it on the welcome screen until the user
+  // switches tabs and forces a remount. See shouldRehydrateAfterStoreWipe.
+  const hasChatState = chatState !== undefined;
+  const prevHasChatStateRef = useRef(hasChatState);
+  useEffect(() => {
+    const hadEntry = prevHasChatStateRef.current;
+    prevHasChatStateRef.current = hasChatState;
+    if (shouldRehydrateAfterStoreWipe({ chatId, hadEntry, hasEntry: hasChatState })) {
+      syncHistoryFromServer();
+    }
+  }, [hasChatState, chatId, syncHistoryFromServer]);
 
   // Listen for new messages delivered from jobs/sub-agents
   useEffect(() => {

--- a/ui/components/Chat/ChatContainer.tsx
+++ b/ui/components/Chat/ChatContainer.tsx
@@ -36,6 +36,10 @@ import {
 } from "../../stores/artifactsStore";
 import { artifactsToMessageAttachments } from "../../utils/messageAttachments";
 import { mapHistoryMessages } from "../../utils/historyMapper";
+import {
+  findHistoryModelId,
+  resolveChatModelId,
+} from "../../utils/resolveChatModel";
 import { extractFilesFromDataTransfer } from "../../utils/chatAttachmentFiles";
 import "./ChatContainer.css";
 import { trackEvent } from "../../lib/telemetry";
@@ -234,11 +238,33 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
 
   const isWaitingForModel = selectedModel.provider === 'ollama' && installing === selectedModel.id;
 
+  /** Model that last answered in *this* chat — the durable per-chat record. */
+  const historyModelId = useMemo(() => findHistoryModelId(messages), [messages]);
+
+  /**
+   * Does this chat already hold a conversation? Answered from chat metadata so
+   * it is known before history finishes loading; an existing chat must never be
+   * seeded from the global "last model picked anywhere".
+   */
+  const chatHasHistory = useChatStore((state) => {
+    const known = state.chats.find((chat) => chat.id === chatId);
+    if (known) return known.messageCount > 0;
+    return (state.chatStates.get(chatId)?.messages.length ?? 0) > 0;
+  });
+
   // When chatId or auth status changes: pick best default
-  // Priority: last selected (persisted in localStorage) > default order (sonnet-5 → gpt-5-6-sol → gemini-3-flash) > first available
+  // Priority: this chat's own selection > this chat's own history > global
+  // default (new chats only) > default order (sonnet-5 → gpt-5-6-sol →
+  // gemini-3-flash) > first available
   useEffect(() => {
     setSelectedModel((prev) => {
-      const lastId = useChatStore.getState().getLastSelectedModel(chatId);
+      const store = useChatStore.getState();
+      const lastId = resolveChatModelId({
+        perChatModelId: store.getLastSelectedModel(chatId),
+        historyModelId,
+        newChatDefaultModelId: store.getDefaultModelForNewChat(),
+        hasHistory: chatHasHistory,
+      });
       if (lastId) {
         const migratedId = migratePickerModelId(lastId);
         const lastModel = getModelById(migratedId);
@@ -256,7 +282,11 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
       if (!isModelAvailable(prev)) return fallbackModel;
       return prev;
     });
-  }, [chatId, authStatus, pickerModels]);
+    // historyModelId is a dependency because history arrives after mount: a
+    // chat reopened before its messages load must correct itself once they do.
+    // Re-running is safe — an explicit per-chat pick outranks history, so this
+    // cannot walk back a selection the user just made.
+  }, [chatId, authStatus, pickerModels, historyModelId, chatHasHistory]);
 
   // Focus input when this chat's container mounts
   useEffect(() => {

--- a/ui/components/Chat/ChatContainer.tsx
+++ b/ui/components/Chat/ChatContainer.tsx
@@ -156,6 +156,7 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
   const messages = chatState?.messages ?? EMPTY_MESSAGES;
   const chatIsLoading = chatState?.isLoading ?? false;
   const isSending = chatState?.isSending ?? false;
+  const isWaitingForAgentSlot = chatState?.isWaitingForAgentSlot ?? false;
   const connectionPaused = chatState?.connectionPaused ?? false;
   const needsStreamRecovery = chatState?.needsStreamRecovery ?? false;
   const streamRecoveryReason = chatState?.streamRecoveryReason ?? "connection";
@@ -875,6 +876,7 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
         messages={messages}
         isLoading={chatIsLoading}
         isSending={isSending || isWaitingForModel}
+        isWaitingForAgentSlot={isWaitingForAgentSlot}
         onFilesDropped={handleFilesDroppedToChat}
         onLoadOlder={() => loadOlderMessages(chatId)}
       />

--- a/ui/components/Chat/MessageItem.tsx
+++ b/ui/components/Chat/MessageItem.tsx
@@ -867,103 +867,121 @@ const MessageItemInner: React.FC<MessageItemProps> = ({
                   isStreaming={message.isStreaming}
                   narration={content} // Show agent's explanation after tool calls
                 />
-                {/* JobStatusCard for run_job (fallback when no sequence) */}
-                {message.toolCalls.map((tc) => {
-                  if (tc.toolName !== "run_job") return null;
-                  if (tc.result && tc.status === "success") {
-                    const jobData = parseJobStatusFromToolResult(
-                      tc.toolName,
-                      tc.result,
-                    );
-                    return jobData ? (
-                      <JobStatusCard
-                        key={`job-fallback-${jobData.jobId}`}
-                        data={jobData}
-                      />
-                    ) : null;
-                  }
-                  if (tc.status === "calling" && tc.args?.jobId) {
-                    const jobId = tc.args.jobId as string;
-                    const jobName = getJobName(jobId) || jobId;
-                    return (
-                      <JobStatusCard
-                        key={`job-fallback-${jobId}`}
-                        data={{
-                          type: "job_status",
-                          jobId,
-                          jobName,
-                          runId: "running",
-                          status: "running",
-                          startedAt: new Date().toISOString(),
-                        }}
-                      />
-                    );
-                  }
-                  return null;
-                })}
-                {message.toolCalls.map((tc) => {
-                  if (tc.toolName !== "delegate_task") return null;
+                {/* Job cards for run_job (fallback when no sequence) — one per
+                    jobId, latest state wins. A message can call run_job twice
+                    on the same job (a retry, or a finished run followed by an
+                    in-flight one); rendering both emitted two cards under one
+                    key, which React may drop, with contradictory status. The
+                    sequence path above already dedupes via addedJobIds. */}
+                {(() => {
+                  const jobMap = new Map<
+                    string,
+                    Parameters<typeof JobStatusCard>[0]["data"]
+                  >();
+                  message.toolCalls.forEach((tc) => {
+                    if (tc.toolName !== "run_job") return;
+                    if (tc.result && tc.status === "success") {
+                      const jobData = parseJobStatusFromToolResult(
+                        tc.toolName,
+                        tc.result,
+                      );
+                      if (jobData) jobMap.set(jobData.jobId, jobData);
+                      return;
+                    }
+                    if (tc.status === "calling" && tc.args?.jobId) {
+                      const jobId = tc.args.jobId as string;
+                      jobMap.set(jobId, {
+                        type: "job_status",
+                        jobId,
+                        jobName: getJobName(jobId) || jobId,
+                        runId: "running",
+                        status: "running",
+                        startedAt: new Date().toISOString(),
+                      });
+                    }
+                  });
+                  return Array.from(jobMap.entries()).map(([jobId, data]) => (
+                    <JobStatusCard key={`job-fallback-${jobId}`} data={data} />
+                  ));
+                })()}
+                {/* Delegation cards — one per delegationId, latest state wins.
+                    The in-flight branch identifies a card by the chat's
+                    subagent job, which is the same value for every concurrent
+                    delegate_task, so two would otherwise share one key. */}
+                {(() => {
+                  const delegationMap = new Map<
+                    string,
+                    React.ComponentProps<typeof MiniChatCard>
+                  >();
 
-                  if (tc.result) {
-                    const delegationData = parseDelegationFromToolResult(
-                      tc.toolName,
-                      tc.result,
-                    );
-                    if (!delegationData) return null;
-                    const miniStatus =
-                      delegationData.status === "pending" ||
-                      delegationData.status === "running"
-                        ? "active"
-                        : delegationData.status === "completed"
-                          ? "completed"
-                          : "failed";
-                    return (
+                  message.toolCalls.forEach((tc, index) => {
+                    if (tc.toolName !== "delegate_task") return;
+
+                    if (tc.result) {
+                      const delegationData = parseDelegationFromToolResult(
+                        tc.toolName,
+                        tc.result,
+                      );
+                      if (!delegationData) return;
+                      const miniStatus =
+                        delegationData.status === "pending" ||
+                        delegationData.status === "running"
+                          ? "active"
+                          : delegationData.status === "completed"
+                            ? "completed"
+                            : "failed";
+                      delegationMap.set(delegationData.id, {
+                        delegationId: delegationData.id,
+                        subAgentName:
+                          delegationData.agentName ?? delegationData.agentId,
+                        task: delegationData.task,
+                        status: miniStatus,
+                        context: delegationData.context,
+                        resultText: delegationData.resultText,
+                        error: delegationData.error,
+                        subAgentIcon: delegationData.agentIcon,
+                        defaultExpanded: false,
+                      });
+                      return;
+                    }
+
+                    if (tc.status === "calling") {
+                      const task = (tc.args?.task as string) || "Delegated task";
+                      const requestedAgentId = tc.args?.useAgentId as
+                        | string
+                        | undefined;
+                      const { agentId, agentName } =
+                        resolveDelegationAgentDisplay(
+                          requestedAgentId,
+                          subagentJobForChat,
+                          getAgentName,
+                        );
+                      const jobIdFromStore = subagentJobForChat?.jobId;
+                      // Index, not Date.now(): a timestamp changes on every
+                      // render, remounting the card and dropping its state.
+                      const placeholderId =
+                        jobIdFromStore || tc.id || `delegation-${index}`;
+                      if (!chatId && !jobIdFromStore) return;
+                      delegationMap.set(placeholderId, {
+                        delegationId: placeholderId,
+                        subAgentName: agentName ?? agentId,
+                        task,
+                        status: "active",
+                        context: (tc.args?.context as string) || undefined,
+                        defaultExpanded: false,
+                      });
+                    }
+                  });
+
+                  return Array.from(delegationMap.entries()).map(
+                    ([delegationId, props]) => (
                       <MiniChatCard
-                        key={`delegation-fallback-${delegationData.id}`}
-                        delegationId={delegationData.id}
-                        subAgentName={
-                          delegationData.agentName ?? delegationData.agentId
-                        }
-                        task={delegationData.task}
-                        status={miniStatus}
-                        context={delegationData.context}
-                        resultText={delegationData.resultText}
-                        error={delegationData.error}
-                        subAgentIcon={delegationData.agentIcon}
-                        defaultExpanded={false}
+                        key={`delegation-fallback-${delegationId}`}
+                        {...props}
                       />
-                    );
-                  }
-
-                  if (tc.status === "calling") {
-                    const task = (tc.args?.task as string) || "Delegated task";
-                    const requestedAgentId = tc.args?.useAgentId as
-                      | string
-                      | undefined;
-                    const { agentId, agentName } = resolveDelegationAgentDisplay(
-                      requestedAgentId,
-                      subagentJobForChat,
-                      getAgentName,
-                    );
-                    const jobIdFromStore = subagentJobForChat?.jobId;
-                    const placeholderId =
-                      jobIdFromStore || tc.id || `delegation-${Date.now()}`;
-                    if (!chatId && !jobIdFromStore) return null;
-                    return (
-                      <MiniChatCard
-                        key={`delegation-fallback-${placeholderId}`}
-                        delegationId={placeholderId}
-                        subAgentName={agentName ?? agentId}
-                        task={task}
-                        status="active"
-                        context={(tc.args?.context as string) || undefined}
-                        defaultExpanded={false}
-                      />
-                    );
-                  }
-
-                  return null;
-                })}
+                    ),
+                  );
+                })()}
               </>
             )}
 

--- a/ui/components/Chat/MessageList.css
+++ b/ui/components/Chat/MessageList.css
@@ -60,6 +60,18 @@
   gap: 12px;
 }
 
+.agent-waiting-indicator {
+  display: flex;
+  align-items: center;
+  padding: 12px 0;
+  gap: 12px;
+}
+
+.agent-waiting-indicator__label {
+  font-size: 13px;
+  color: var(--text-secondary, #888);
+}
+
 .loading-older-indicator {
   display: flex;
   align-items: center;

--- a/ui/components/Chat/MessageList.tsx
+++ b/ui/components/Chat/MessageList.tsx
@@ -19,6 +19,7 @@ interface MessageListProps {
   messages: ChatMessage[];
   isLoading?: boolean;
   isSending?: boolean;
+  isWaitingForAgentSlot?: boolean;
   /** When set, file drops on the list attach the same way as Add context → file upload */
   onFilesDropped?: (files: File[]) => void;
   /** Called when user scrolls to the top (for loading older messages) */
@@ -37,6 +38,7 @@ export const MessageList: React.FC<MessageListProps> = ({
   messages,
   isLoading,
   isSending,
+  isWaitingForAgentSlot,
   onFilesDropped,
   onLoadOlder,
 }) => {
@@ -294,7 +296,61 @@ export const MessageList: React.FC<MessageListProps> = ({
           </div>
         </div>
       )}
-      {isSending && !filteredMessages.some((m) => m.isStreaming) && (
+      {isWaitingForAgentSlot &&
+        isSending &&
+        !filteredMessages.some((m) => m.isStreaming) && (
+        <div className="message-item">
+          <div className="message-avatar-container">
+            <div className="message-avatar-assistant">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 105 124"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="message-avatar-icon"
+              >
+                <path
+                  d="M27.9998 101.5C-11.5 158 6.99988 51 43.4008 60.5002C99.2884 75.0861 115.18 20.7781 83.6804 8.27816C40.2693 -8.94844 51.9998 65 27.9998 101.5Z"
+                  stroke="url(#papr-gradient-waiting)"
+                  strokeWidth="10"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <defs>
+                  <linearGradient
+                    id="papr-gradient-waiting"
+                    x1="17.2207"
+                    y1="89.4214"
+                    x2="68.8959"
+                    y2="35.8394"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stopColor="#0060E0" />
+                    <stop offset="0.6" stopColor="#00ACFA" />
+                    <stop offset="1" stopColor="#0BCDFF" />
+                  </linearGradient>
+                </defs>
+              </svg>
+            </div>
+          </div>
+          <div className="message-content">
+            <div className="agent-waiting-indicator">
+              <span className="agent-waiting-indicator__label">
+                Waiting for agent slot…
+              </span>
+              <div className="loading-dots">
+                <span></span>
+                <span></span>
+                <span></span>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+      {isSending &&
+        !isWaitingForAgentSlot &&
+        !filteredMessages.some((m) => m.isStreaming) && (
         <div className="message-item">
           <div className="message-avatar-container">
             <div className="message-avatar-assistant">

--- a/ui/hooks/useAgent.ts
+++ b/ui/hooks/useAgent.ts
@@ -73,6 +73,7 @@ export function useAgent() {
   const updateStreamingMessage = useChatStore((s) => s.updateStreamingMessage);
   const finalizeStreamingMessage = useChatStore((s) => s.finalizeStreamingMessage);
   const setSending = useChatStore((s) => s.setSending);
+  const setWaitingForAgentSlot = useChatStore((s) => s.setWaitingForAgentSlot);
   const setConnectionPaused = useChatStore((s) => s.setConnectionPaused);
   const setFinishingWork = useChatStore((s) => s.setFinishingWork);
   const setNeedsStreamRecovery = useChatStore((s) => s.setNeedsStreamRecovery);
@@ -200,6 +201,14 @@ export function useAgent() {
       }
 
       switch (chunk.type) {
+        case "concurrency-queued":
+          setWaitingForAgentSlot(chatId, true);
+          break;
+
+        case "concurrency-acquired":
+          setWaitingForAgentSlot(chatId, false);
+          break;
+
         case "reasoning-delta":
           {
             // Append reasoning delta to ref (always immediate)
@@ -1375,6 +1384,7 @@ export function useAgent() {
       updateStreamingMessage,
       finalizeStreamingMessage,
       setSending,
+      setWaitingForAgentSlot,
       setConnectionPaused,
       setFinishingWork,
       setNeedsStreamRecovery,

--- a/ui/hooks/useChat.ts
+++ b/ui/hooks/useChat.ts
@@ -9,6 +9,7 @@ import { useTabStore } from "../stores/tabStore";
 import { gateway } from "../src/lib/gateway";
 import { mapHistoryMessages } from "../utils/historyMapper";
 import { fetchChatHistory } from "../utils/chatHistoryApi";
+import { forgetChatModel } from "../utils/chatModelMemory";
 import {
   chatHasLiveStreamBlockingHistory,
   mergeHistoryWithLocal,
@@ -305,6 +306,7 @@ export function useChat() {
     async (chatId: string) => {
       try {
         await gateway.send("chat:delete", { chatId });
+        forgetChatModel(chatId);
         await loadChats(true);
         // Note: Tab management handled by tabStore (closeTab)
       } catch (error) {

--- a/ui/lib/agentStreamRecovery.ts
+++ b/ui/lib/agentStreamRecovery.ts
@@ -297,13 +297,39 @@ export function mergeHistoryWithLocal(
     merged.push(serverMsg);
   }
 
-  // Optimistic user sends + in-flight streaming placeholders not on server yet.
-  for (const localMsg of base) {
-    if (consumedLocalIds.has(localMsg.id)) continue;
-    merged.push(localMsg);
+  // Locals the server list didn't account for. Usually optimistic sends and
+  // in-flight placeholders, which belong at the end — but the server list is a
+  // *window* (loadMessages asks for the newest N), so once pagination has
+  // pulled older turns into the store those fall outside the window too, and
+  // appending them would drop the earlier half of the conversation below its
+  // own latest message.
+  //
+  // Position decides which side, not time: server-mapped messages carry no
+  // timestamp at all (see mapHistoryMessages). Both lists are chronological, so
+  // a leftover sitting before the first message the window claimed is older
+  // than the window, and anything after it is newer.
+  let firstConsumedIndex = -1;
+  for (let i = 0; i < base.length; i++) {
+    if (consumedLocalIds.has(base[i].id)) {
+      firstConsumedIndex = i;
+      break;
+    }
   }
 
-  return merged;
+  const beforeWindow: ChatMessage[] = [];
+  const afterWindow: ChatMessage[] = [];
+  base.forEach((localMsg, index) => {
+    if (consumedLocalIds.has(localMsg.id)) return;
+    // With nothing consumed there is no window to sit outside of, so keep the
+    // original append-at-the-end behaviour rather than guessing.
+    if (firstConsumedIndex !== -1 && index < firstConsumedIndex) {
+      beforeWindow.push(localMsg);
+    } else {
+      afterWindow.push(localMsg);
+    }
+  });
+
+  return [...beforeWindow, ...merged, ...afterWindow];
 }
 
 /**

--- a/ui/stores/chatStore.ts
+++ b/ui/stores/chatStore.ts
@@ -61,6 +61,7 @@ interface ChatStore {
   getChatMemoryScope: (chatId: string) => MemoryAudience;
   setLoading: (loading: boolean) => void;
   setSending: (chatId: string, sending: boolean) => void;
+  setWaitingForAgentSlot: (chatId: string, waiting: boolean) => void;
   setConnectionPaused: (chatId: string, paused: boolean) => void;
   setFinishingWork: (chatId: string, finishing: boolean) => void;
   setNeedsStreamRecovery: (
@@ -421,6 +422,21 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       newChatStates.set(chatId, {
         ...chatState,
         isSending: sending,
+        ...(sending ? {} : { isWaitingForAgentSlot: false }),
+      });
+
+      return { chatStates: newChatStates };
+    }),
+
+  setWaitingForAgentSlot: (chatId, waiting) =>
+    set((state) => {
+      const chatState = state.chatStates.get(chatId);
+      if (!chatState) return state;
+
+      const newChatStates = new Map(state.chatStates);
+      newChatStates.set(chatId, {
+        ...chatState,
+        isWaitingForAgentSlot: waiting,
       });
 
       return { chatStates: newChatStates };

--- a/ui/stores/chatStore.ts
+++ b/ui/stores/chatStore.ts
@@ -17,6 +17,13 @@ import type { MemoryAudience } from "../constants/memoryScope";
 import type { ToolCall } from "../types/core";
 import { gateway } from "../src/lib/gateway";
 import { trackEvent } from "../lib/telemetry";
+import {
+  readChatModel,
+  readNewChatDefaultModel,
+  renameChatModel,
+  writeChatModel,
+  writeNewChatDefaultModel,
+} from "../utils/chatModelMemory";
 
 // Re-export types for backward compatibility
 export type { ChatMetadata, ChatMessage, ChatState, StreamingState, SequenceItem, MessageAttachment };
@@ -79,7 +86,10 @@ interface ChatStore {
 
   // Model selection per chat
   setLastSelectedModel: (chatId: string, modelId: string) => void;
+  /** The model this chat is on, or undefined — never another chat's model. */
   getLastSelectedModel: (chatId: string) => string | undefined;
+  /** Seed for chats with no history of their own. */
+  getDefaultModelForNewChat: () => string | undefined;
 
   // ──────────────────────────────────────────────────────────────────────
   // Live streaming slice (ephemeral, separate from chatStates.messages)
@@ -291,6 +301,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   migrateChatId: (oldChatId, newChatId) =>
     set((state) => {
       if (oldChatId === newChatId) return state;
+
+      // Carry the persisted model across the rename, or the chat loses it the
+      // moment its first message gives it a permanent id.
+      renameChatModel(oldChatId, newChatId);
 
       const oldState = state.chatStates.get(oldChatId);
       const newChatStates = new Map(state.chatStates);
@@ -555,32 +569,34 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         } catch { /* ignore */ }
       }
 
-      if (typeof window !== "undefined") {
-        try {
-          localStorage.setItem("paprwork_last_model_id", modelId);
-          // Also save to Gateway settings for reliable persistence
-          gateway.send('settings:save-ui-preferences', { lastModelId: modelId }).catch(() => {});
-        } catch {
-          /* ignore */
-        }
+      // Two separate facts: this chat is on this model, and a new chat should
+      // start here. Keeping them apart is what stops one chat's pick from
+      // becoming another chat's model.
+      writeChatModel(chatId, modelId);
+      writeNewChatDefaultModel(modelId);
+      try {
+        gateway
+          .send("settings:save-ui-preferences", { lastModelId: modelId })
+          .catch(() => {});
+      } catch {
+        /* ignore */
       }
       return { chatStates: newChatStates };
     }),
 
+  /**
+   * The model *this* chat is on — never another chat's. Returns undefined when
+   * the chat has no selection of its own; callers decide what to fall back to
+   * (see ChatContainer, which prefers the chat's own history over any global).
+   */
   getLastSelectedModel: (chatId) => {
-    const state = get();
-    const fromChat = state.chatStates.get(chatId)?.lastSelectedModelId;
+    const fromChat = get().chatStates.get(chatId)?.lastSelectedModelId;
     if (fromChat) return fromChat;
-    if (typeof window !== "undefined") {
-      try {
-        const persisted = localStorage.getItem("paprwork_last_model_id");
-        if (persisted) return persisted;
-      } catch {
-        /* ignore */
-      }
-    }
-    return undefined;
+    return readChatModel(chatId);
   },
+
+  /** What a brand-new chat should open on: the last model picked anywhere. */
+  getDefaultModelForNewChat: () => readNewChatDefaultModel(),
 
   // Load UI preferences from settings (called on app mount)
   loadUIPreferences: async () => {

--- a/ui/stores/chatStore.ts
+++ b/ui/stores/chatStore.ts
@@ -12,6 +12,7 @@ import type {
   StreamingState,
   SequenceItem,
   StreamRecoveryReason,
+  MessageAttachment,
 } from "../types/chat";
 import type { MemoryAudience } from "../constants/memoryScope";
 import type { ToolCall } from "../types/core";
@@ -602,12 +603,17 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   loadUIPreferences: async () => {
     try {
       const response = await gateway.send('settings:get', {});
-      if (response.success && response.data?.uiPreferences) {
-        const { lastModelId } = response.data.uiPreferences;
-        if (lastModelId) {
-          // Store in localStorage for fast access
-          localStorage.setItem("paprwork_last_model_id", lastModelId);
-        }
+      // `GatewayResponse.data` is `unknown` by design; narrow it the same way
+      // the other settings:get callers do rather than widening the response.
+      const uiPreferences = response.success
+        ? (response.data as { uiPreferences?: { lastModelId?: string } })
+            ?.uiPreferences
+        : undefined;
+      const lastModelId = uiPreferences?.lastModelId;
+      if (lastModelId) {
+        // Seeds *new* chats only. An existing chat resolves its own model from
+        // its per-chat selection or its history — see resolveChatModelId.
+        writeNewChatDefaultModel(lastModelId);
       }
     } catch (error) {
       console.error('[ChatStore] Failed to load UI preferences:', error);

--- a/ui/types/chat.ts
+++ b/ui/types/chat.ts
@@ -47,6 +47,11 @@ export interface ChatMessage extends CoreMessage {
   streamingContent?: string;
   /** Context files/docs attached when the user sent this message */
   attachments?: MessageAttachment[];
+  /**
+   * Model that produced this assistant message, as persisted by the gateway.
+   * Read back to restore a chat's own model on reopen.
+   */
+  model?: string;
 
   // V1-style sequence for interleaving text and tool calls
   sequence?: SequenceItem[];

--- a/ui/types/chat.ts
+++ b/ui/types/chat.ts
@@ -70,6 +70,8 @@ export interface ChatState {
   isStreaming: boolean;
   /** True when gateway disconnected mid-stream — Working card shows reconnecting */
   connectionPaused?: boolean;
+  /** Waiting for a chat-pool agent slot — no model work has started yet */
+  isWaitingForAgentSlot?: boolean;
   /** Post-tool text summary in progress (wrap-up continuation). */
   isFinishingWork?: boolean;
   /** Auto-resume failed — user can tap Continue to retry stream recovery */

--- a/ui/utils/chatModelMemory.ts
+++ b/ui/utils/chatModelMemory.ts
@@ -1,0 +1,177 @@
+/**
+ * Which model each chat is using, and which model a *new* chat should start on.
+ *
+ * These are two different questions, and conflating them let one chat's model
+ * bleed into another. Per-chat selection used to live only in an in-memory
+ * Zustand map, so every app restart and every workspace switch emptied it —
+ * after which a read for chat A fell back to the single global "last model" and
+ * returned whatever had been picked last in *any* chat. That is not cosmetic:
+ * the picker value is what gets sent as `config.model`, so the wrong model
+ * actually answered.
+ *
+ * So per-chat selection is persisted here, keyed by chat, and the global value
+ * is kept strictly as the seed for chats that have no history of their own.
+ */
+
+/** chatId -> modelId. Insertion-ordered; oldest entries are evicted first. */
+const PER_CHAT_KEY = "paprwork_chat_model_ids";
+
+/** Single value: what a brand-new chat should open on. */
+const NEW_CHAT_DEFAULT_KEY = "paprwork_last_model_id";
+
+/**
+ * Cap on remembered chats. Selections are tiny, but this map is written on
+ * every model change for the life of the install, so it needs a ceiling.
+ */
+export const MAX_REMEMBERED_CHATS = 200;
+
+type ChatModelMap = Record<string, string>;
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch {
+    // Storage can throw outright when disabled by policy.
+    return null;
+  }
+}
+
+function readMap(): ChatModelMap {
+  const store = storage();
+  if (!store) {
+    return {};
+  }
+  try {
+    const raw = store.getItem(PER_CHAT_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    // Drop anything that is not a plain string pair rather than trusting the blob.
+    const clean: ChatModelMap = {};
+    for (const [chatId, modelId] of Object.entries(parsed)) {
+      if (
+        typeof chatId === "string" &&
+        typeof modelId === "string" &&
+        modelId
+      ) {
+        clean[chatId] = modelId;
+      }
+    }
+    return clean;
+  } catch {
+    return {};
+  }
+}
+
+function writeMap(map: ChatModelMap): void {
+  const store = storage();
+  if (!store) {
+    return;
+  }
+  try {
+    store.setItem(PER_CHAT_KEY, JSON.stringify(map));
+  } catch {
+    /* quota or disabled storage — selection degrades to in-memory only */
+  }
+}
+
+/** The model this specific chat is on, if it has ever been established. */
+export function readChatModel(chatId: string): string | undefined {
+  if (!chatId) {
+    return undefined;
+  }
+  return readMap()[chatId];
+}
+
+/**
+ * Record the model for one chat. Re-writing an existing chat refreshes its
+ * position, so the chats a user actually returns to are the last to be evicted.
+ */
+export function writeChatModel(chatId: string, modelId: string): void {
+  if (!chatId || !modelId) {
+    return;
+  }
+
+  const map = readMap();
+  delete map[chatId];
+  map[chatId] = modelId;
+
+  const chatIds = Object.keys(map);
+  if (chatIds.length > MAX_REMEMBERED_CHATS) {
+    for (const stale of chatIds.slice(
+      0,
+      chatIds.length - MAX_REMEMBERED_CHATS,
+    )) {
+      delete map[stale];
+    }
+  }
+
+  writeMap(map);
+}
+
+/** Forget a chat's model — call when the chat is deleted. */
+export function forgetChatModel(chatId: string): void {
+  if (!chatId) {
+    return;
+  }
+  const map = readMap();
+  if (!(chatId in map)) {
+    return;
+  }
+  delete map[chatId];
+  writeMap(map);
+}
+
+/**
+ * Carry a selection across the temp-id -> permanent-id rename that happens on
+ * the first message of a new chat. Without this, the chat loses its model the
+ * moment it is persisted.
+ */
+export function renameChatModel(oldChatId: string, newChatId: string): void {
+  if (!oldChatId || !newChatId || oldChatId === newChatId) {
+    return;
+  }
+  const map = readMap();
+  const modelId = map[oldChatId];
+  if (!modelId) {
+    return;
+  }
+  delete map[oldChatId];
+  map[newChatId] = modelId;
+  writeMap(map);
+}
+
+/**
+ * What a brand-new chat should open on: the last model the user picked
+ * anywhere. Deliberately global — this is the one place that is correct.
+ */
+export function readNewChatDefaultModel(): string | undefined {
+  const store = storage();
+  if (!store) {
+    return undefined;
+  }
+  try {
+    return store.getItem(NEW_CHAT_DEFAULT_KEY) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeNewChatDefaultModel(modelId: string): void {
+  const store = storage();
+  if (!store || !modelId) {
+    return;
+  }
+  try {
+    store.setItem(NEW_CHAT_DEFAULT_KEY, modelId);
+  } catch {
+    /* ignore */
+  }
+}

--- a/ui/utils/chatStateRecovery.ts
+++ b/ui/utils/chatStateRecovery.ts
@@ -1,0 +1,34 @@
+/**
+ * A mounted chat pane hydrates its messages once, in an effect keyed on chatId.
+ * Anything that drops the chat's entry from the store while the pane stays
+ * mounted therefore strands it: the pane renders the welcome screen and nothing
+ * re-runs the fetch. `resetForWorkspaceSwitch()` clears every entry and the
+ * workspace reload restores tabs without restoring message bodies, so the pane
+ * can outlive its own state.
+ *
+ * This predicate decides whether such a disappearance should trigger a reload.
+ */
+export interface ChatStateRecoveryInput {
+  chatId: string;
+  /** Whether the store held an entry for this chat on the previous render. */
+  hadEntry: boolean;
+  /** Whether the store holds an entry for this chat now. */
+  hasEntry: boolean;
+}
+
+export function shouldRehydrateAfterStoreWipe({
+  chatId,
+  hadEntry,
+  hasEntry,
+}: ChatStateRecoveryInput): boolean {
+  // Only the present -> absent transition indicates a wipe. An entry that is
+  // merely empty belongs to a new chat, which has nothing to load.
+  if (!hadEntry || hasEntry) return false;
+
+  // A temp chat has no server-side rows to load, and migrateChatId removes the
+  // temp entry a tick before the tab switches to the permanent id — so this
+  // transition is expected there and must not fire a fetch.
+  if (chatId.startsWith("temp-")) return false;
+
+  return true;
+}

--- a/ui/utils/historyMapper.ts
+++ b/ui/utils/historyMapper.ts
@@ -182,6 +182,12 @@ export function mapHistoryMessages(
       reasoning,
       toolCalls,
       sequence: sequenceRaw, // Include sequence for interleaved rendering
+      // Which model actually answered. This is the durable record of what a
+      // chat was running on, so reopening it can restore that model instead of
+      // inheriting whatever was last picked in some other chat.
+      ...(typeof candidate.model === "string" && candidate.model
+        ? { model: candidate.model }
+        : {}),
       // Persisted by the gateway when a turn never finished. Carrying it through
       // keeps an interrupted turn labelled as such after a reload, instead of
       // reappearing as a finished answer.

--- a/ui/utils/resolveChatModel.ts
+++ b/ui/utils/resolveChatModel.ts
@@ -1,0 +1,61 @@
+/**
+ * Which model should a chat open on?
+ *
+ * The old rule was "whatever was picked last, anywhere", which is why opening
+ * an Opus chat could show — and then actually run — Fable. Precedence now
+ * starts from the chat itself and only reaches for a global value when the chat
+ * has nothing of its own to go on.
+ */
+
+export interface ChatModelCandidates {
+  /** Explicit selection made for this chat. */
+  perChatModelId?: string;
+  /** Model that answered most recently *in this chat* (from persisted history). */
+  historyModelId?: string;
+  /** Last model picked anywhere. Only meaningful for a chat with no history. */
+  newChatDefaultModelId?: string;
+  /**
+   * Whether this chat already holds a conversation. When true, a global default
+   * is never used: an existing chat must not inherit another chat's model.
+   */
+  hasHistory: boolean;
+}
+
+/**
+ * Returns the model id to open with, or undefined to fall back to the app's
+ * ordinary defaults. The returned id is raw — callers still migrate retired ids
+ * and check availability, since a chat may name a model the user can no longer
+ * reach.
+ */
+export function resolveChatModelId(
+  candidates: ChatModelCandidates,
+): string | undefined {
+  if (candidates.perChatModelId) {
+    return candidates.perChatModelId;
+  }
+
+  // The chat's own history is the truthful record of what it was running on,
+  // and it survives restarts and cleared local storage.
+  if (candidates.historyModelId) {
+    return candidates.historyModelId;
+  }
+
+  if (!candidates.hasHistory && candidates.newChatDefaultModelId) {
+    return candidates.newChatDefaultModelId;
+  }
+
+  return undefined;
+}
+
+/** Model that most recently answered in this chat, if any assistant turn did. */
+export function findHistoryModelId(
+  messages: ReadonlyArray<{ role: string; model?: string }>,
+): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message?.role === "assistant" && message.model) {
+      return message.model;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
`AgentStreamConcurrencyGate` was a single foreground/background gate, so a burst of background agent jobs could starve interactive chats. It now runs two independent pools (`chat` | `job`) with per-pool stats; `getLegacyStats()` is kept for older callers.

The stream emits a waiting-for-slot event and `ChatMessage.isWaitingForAgentSlot` so the UI shows a queued state instead of an empty streaming bubble.

Also fixes `acquireWithEvents` not returning the delegated generator's value (TS2355 under `build:gateway`).

Tests: agent-stream-concurrency 10/10; `npm run build:gateway` clean.