### PR TITLE
fix(turso-sync): skip _-prefixed scratch tables; actionable no-PK warning

### DIFF
--- a/src/gateway/services/tursoSyncBridgeCore.ts
+++ b/src/gateway/services/tursoSyncBridgeCore.ts
@@ -169,6 +169,11 @@ export const SQLITE_RECOVERY_TABLE = "lost_and_found";
 
 export function isScratchTable(tableName: string): boolean {
   return (
+    // Leading underscore = local scratch by convention (e.g. `_leads_backup`
+    // from an ad hoc CREATE TABLE … AS SELECT). Never synced, never warned
+    // about. Generalises the explicit `_papr_*` checks below, which stay for
+    // readability and as documentation of what the platform itself owns.
+    tableName.startsWith("_") ||
     JOB_BASELINE_TABLES.has(tableName) ||
     tableName === SYNC_REGISTRY_TABLE ||
     tableName === SYNC_META_TABLE ||

--- a/src/gateway/services/tursoSyncLog.ts
+++ b/src/gateway/services/tursoSyncLog.ts
@@ -109,10 +109,16 @@ function warnCdcDisabledOnce(tableName: string): void {
     return;
   }
   cdcDisabledWarned.add(tableName);
+  const t = quoteIdent(tableName);
+  const tNew = quoteIdent(`${tableName}_new`);
   console.warn(
-    `[TursoSyncLog] "${tableName}" has no PRIMARY KEY — change capture is disabled ` +
-      `for it, so local inserts and deletes will never reach Turso. ` +
-      `Add a PRIMARY KEY (or let schema drift heal restore it) to re-enable sync.`,
+    `[TursoSyncLog] ${t} has no PRIMARY KEY — change capture is disabled, so local ` +
+      `inserts/updates/deletes will never reach Turso. This usually comes from ` +
+      `CREATE TABLE … AS SELECT, which drops constraints. To fix, rebuild with a key:\n` +
+      `  CREATE TABLE ${tNew} (id INTEGER PRIMARY KEY, …);\n` +
+      `  INSERT INTO ${tNew} SELECT * FROM ${t};\n` +
+      `  DROP TABLE ${t}; ALTER TABLE ${tNew} RENAME TO ${t};\n` +
+      `Or rename it with a leading underscore (_${tableName}) to mark it as local scratch.`,
   );
 }
 

--- a/tests/turso-sync-bridge.test.ts
+++ b/tests/turso-sync-bridge.test.ts
@@ -98,6 +98,21 @@ describe("tursoSyncBridgeCore", () => {
     ]);
   });
 
+  it("filterSyncableTables treats any _-prefixed table as local scratch", () => {
+    // Ad hoc backups (CREATE TABLE _x AS SELECT …) never carry a PRIMARY KEY,
+    // so they can't be synced anyway; the underscore is the documented opt-out.
+    expect(
+      filterSyncableTables([
+        "leads",
+        "_test_backup",
+        "_leads_backup",
+        "__tmp",
+        "leads_backup",
+        "a_b_c",
+      ]),
+    ).toEqual(["leads", "leads_backup", "a_b_c"]);
+  });
+
   it("quoteIdent escapes double quotes", () => {
     expect(quoteIdent('foo"bar')).toBe('"foo""bar"');
   });


### PR DESCRIPTION
## Why

`[TursoSyncLog] "_test_backup" has no PRIMARY KEY …` on every boot. The table was an ad hoc `CREATE TABLE … AS SELECT` backup in a job DB — `AS SELECT` never carries constraints, so the sync layer can't attach change capture. The warning's advice ("let schema drift heal restore it") is wrong for this case: drift heal rebuilds *remote* tables to match local and cannot add a PK to a local table that never had one.

## What

- **`_`-prefixed tables are local scratch.** `isScratchTable()` in `tursoSyncBridgeCore.ts` — already the filter behind `filterSyncableTables()` that every enumerator uses (delta push/pull, remote CDC, table prep, drift heal, cutover snapshot, migration ledgers) — now returns true for any leading-underscore name. Agents get a documented, silent way to keep backups local. Generalises the existing explicit `_papr_*` checks, which stay for readability.
- **Warning says what to do.** Prints the `CREATE new → INSERT SELECT → DROP → RENAME` recipe and the underscore escape hatch instead of pointing at a mechanism that can't fix it.

## Not in this PR

Rejecting no-PK `CREATE TABLE` at migration-apply time — needs a real DDL parser (AS SELECT, compound PK, WITHOUT ROWID, quoted idents) and a hard-fail vs warn policy. Follow-up.

Tests: +1 case in `turso-sync-bridge.test.ts`; turso suite 20/20 files, 128 passed; `build:gateway` clean.