### PR TITLE
feat(memory): derive search citations and auto-grade retrieval quality

### DIFF
--- a/src/core/tools/paprMemory.ts
+++ b/src/core/tools/paprMemory.ts
@@ -446,6 +446,17 @@ export function extractRetrievedCandidates(
   if (toon === null) return null;
 
   // Tabular TOON: `memories[#N]{id,content,...}:` then indented rows.
+  const tabular = parseTabularMemories(toon);
+  if (tabular !== null) return tabular;
+
+  // List TOON: `memories[#N]:` then `- id: …` / `content: …` blocks.
+  // This is what the server actually returns for memory search; the tabular
+  // form above is used by other endpoints. Supporting only the tabular shape
+  // silently disabled citation derivation on every real search.
+  return parseListMemories(toon);
+}
+
+function parseTabularMemories(toon: string): RetrievedCandidate[] | null {
   const header = toon.match(/memories\[#(\d+)\]\{([^}]*)\}\s*:/);
   if (!header) return null;
 
@@ -477,6 +488,89 @@ export function extractRetrievedCandidates(
   }
 
   return candidates.length > 0 ? candidates : null;
+}
+
+/** Unquote a TOON scalar, resolving the escapes the server emits. */
+function parseToonScalar(raw: string): string {
+  const text = raw.trim();
+  if (!text.startsWith('"')) return text;
+
+  let out = "";
+  for (let i = 1; i < text.length; i += 1) {
+    const ch = text[i]!;
+    if (ch === "\\") {
+      const next = text[i + 1];
+      if (next === '"' || next === "\\") {
+        out += next;
+        i += 1;
+      } else if (next === "n") {
+        out += "\n";
+        i += 1;
+      } else if (next === "t") {
+        out += "\t";
+        i += 1;
+      } else {
+        out += ch;
+      }
+      continue;
+    }
+    if (ch === '"') break;
+    out += ch;
+  }
+  return out;
+}
+
+function parseListMemories(toon: string): RetrievedCandidate[] | null {
+  // `memories[#N]:` with NO `{...}` field header — negative lookahead keeps
+  // this from stealing the tabular shape.
+  const header = toon.match(/^([ \t]*)memories\[#(\d+)\][ \t]*:(?!\{)/m);
+  if (!header) return null;
+
+  const headerIndent = header[1]!.length;
+  const expected = Number.parseInt(header[2]!, 10);
+  const afterHeader = toon.slice(header.index! + header[0].length);
+
+  const candidates: RetrievedCandidate[] = [];
+  let currentId: string | null = null;
+  let currentContent = "";
+
+  const flush = (): void => {
+    if (currentId) {
+      candidates.push({
+        id: currentId,
+        content: currentContent,
+        rank: candidates.length,
+      });
+    }
+    currentId = null;
+    currentContent = "";
+  };
+
+  for (const line of afterHeader.split("\n")) {
+    if (line.trim() === "") continue;
+    // A line at or left of the header's indent ends the block (`nodes[#20]:`,
+    // `search_id: …`). Without this the node section would leak in as memories.
+    const indent = line.length - line.trimStart().length;
+    if (indent <= headerIndent) break;
+
+    const itemStart = line.match(/^[ \t]*-[ \t]+id[ \t]*:[ \t]*(.*)$/);
+    if (itemStart) {
+      flush();
+      if (candidates.length >= expected) break;
+      currentId = parseToonScalar(itemStart[1]!);
+      continue;
+    }
+
+    // Only the FIRST content key of an item counts. Nested blocks
+    // (customMetadata, acl) can repeat key names at deeper indent.
+    if (currentId && !currentContent) {
+      const contentField = line.match(/^[ \t]*content[ \t]*:[ \t]*(.*)$/);
+      if (contentField) currentContent = parseToonScalar(contentField[1]!);
+    }
+  }
+  flush();
+
+  return candidates.length > 0 ? candidates.slice(0, expected) : null;
 }
 
 export function formatSearchMemoryResponse(

--- a/src/core/tools/paprMemory.ts
+++ b/src/core/tools/paprMemory.ts
@@ -15,6 +15,11 @@ import {
   resolveConversationId,
 } from "./chatScope.js";
 import { getCurrentChatId } from "./context.js";
+import {
+  markSearchOutcomeSubmitted,
+  recordSearchOutcome,
+  type RetrievedCandidate,
+} from "../utils/searchOutcomeFeedback.js";
 import { getPaprClient, handlePaprToolError, isPaprNotFoundError } from "./paprClient.js";
 import { assertValidWikiGraphQLSelection } from "../../gateway/services/wikiGraphqlUtils.js";
 import {
@@ -337,10 +342,21 @@ function buildMemoryFeedbackReminder(
     );
   }
 
+  // Citations are derived from your answer at turn end, so the agent no longer
+  // needs to report "these were useful" — that is measured. What CANNOT be
+  // derived is a judgement about results you did not use: whether they were
+  // off-topic, stale, or wrong. Mixed results are the highest-information case
+  // for a contrastive objective, so they are explicitly requested here rather
+  // than skipped (the old "skip when mixed" rule is what produced 26 thumbs_up
+  // and zero negatives in the entire feedback log).
   return (
-    `After evaluating these results, if retrieval was clearly helpful or clearly irrelevant, call:\n` +
-    `submit_memory_feedback({ searchId: "${searchId}", feedbackType: "thumbs_up" | "thumbs_down" | "memory_relevance", citedMemoryIds: ["<memory-id-from-results>"] })\n` +
-    `Skip feedback when results were mediocre or mixed. Wrong memory content → delete_memory or add_agent_memory.`
+    `searchId="${searchId}" — cited memories are derived automatically from your answer; you do NOT need to report which ones helped.\n` +
+    `Do submit feedback when you can judge something the derivation cannot:\n` +
+    `• MIXED results (some on-target, some off) — the most valuable case, do not skip it\n` +
+    `• Results that looked relevant but were stale, wrong, or duplicated\n` +
+    `• Nothing usable despite a non-empty result set\n` +
+    `submit_memory_feedback({ searchId: "${searchId}", feedbackType: "memory_relevance" | "thumbs_down" | "correction", feedbackScore: 1-5, feedbackText: "<what was off>" })\n` +
+    `Wrong memory content → delete_memory or add_agent_memory.`
   );
 }
 
@@ -365,6 +381,102 @@ function parseToonEnvelope(toon: string): {
     memoryCount: countOf("memories"),
     nodeCount: countOf("nodes"),
   };
+}
+
+/**
+ * Split one TOON row on commas, respecting double-quoted fields.
+ * Memory content routinely contains commas, so a naive split shifts every
+ * column after the first one and silently mismatches ids to content.
+ */
+function splitToonRow(row: string): string[] {
+  const cells: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < row.length; i += 1) {
+    const ch = row[i];
+    if (ch === '"') {
+      if (inQuotes && row[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === "," && !inQuotes) {
+      cells.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  cells.push(current);
+  return cells.map((c) => c.trim());
+}
+
+/**
+ * Recover `{ id, content, rank }` per retrieved memory, for citation
+ * derivation at turn end.
+ *
+ * Returns `null` when the payload cannot be parsed — the caller MUST treat
+ * that as "unknown", never as "nothing was retrieved". Grading an unparsed
+ * response as zero-citations would emit a false negative label for every
+ * successful search.
+ */
+export function extractRetrievedCandidates(
+  response: SearchResponse | string,
+): RetrievedCandidate[] | null {
+  // Structured path.
+  if (typeof response !== "string") {
+    const memories = response.data?.memories;
+    if (Array.isArray(memories)) {
+      return memories.map((m, index) => ({
+        id: String((m as { id?: unknown })?.id ?? ""),
+        content: String((m as { content?: unknown })?.content ?? ""),
+        rank: index,
+      }));
+    }
+  }
+
+  const toon =
+    typeof response === "string"
+      ? response
+      : typeof response.data === "string"
+        ? (response.data as unknown as string)
+        : null;
+  if (toon === null) return null;
+
+  // Tabular TOON: `memories[#N]{id,content,...}:` then indented rows.
+  const header = toon.match(/memories\[#(\d+)\]\{([^}]*)\}\s*:/);
+  if (!header) return null;
+
+  const fields = header[2]!.split(",").map((f) => f.trim());
+  const idIndex = fields.indexOf("id");
+  const contentIndex = fields.indexOf("content");
+  if (idIndex === -1 || contentIndex === -1) return null;
+
+  const afterHeader = toon.slice(header.index! + header[0].length);
+  const candidates: RetrievedCandidate[] = [];
+  const expected = Number.parseInt(header[1]!, 10);
+
+  for (const line of afterHeader.split("\n")) {
+    if (candidates.length >= expected) break;
+    // Rows are indented under the header; a non-indented line ends the table.
+    if (!/^\s+\S/.test(line)) {
+      if (line.trim() === "") continue;
+      break;
+    }
+    const cells = splitToonRow(line.trim());
+    if (cells.length < fields.length) continue;
+    const id = cells[idIndex] ?? "";
+    if (!id) continue;
+    candidates.push({
+      id,
+      content: cells[contentIndex] ?? "",
+      rank: candidates.length,
+    });
+  }
+
+  return candidates.length > 0 ? candidates : null;
 }
 
 export function formatSearchMemoryResponse(
@@ -759,8 +871,28 @@ export const searchAgentMemoryTool = createTool({
       // the ranker down on every successful query.
       const isGenuinelyEmpty =
         formatted.memoryCount === 0 && formatted.nodeCount === 0;
-      if (formatted.searchId !== null && isGenuinelyEmpty) {
-        void submitEmptySearchFeedback(client, formatted.searchId);
+
+      // Record every search so the turn-end flush can derive which memories
+      // the answer actually used. `null` means the payload could not be
+      // parsed — recorded as candidatesKnown:false so it is never graded as
+      // "nothing was cited".
+      if (formatted.searchId !== null) {
+        const candidates = extractRetrievedCandidates(response);
+        recordSearchOutcome({
+          searchId: formatted.searchId,
+          memoryCount: formatted.memoryCount,
+          nodeCount: formatted.nodeCount,
+          candidatesKnown: candidates !== null,
+          candidates: candidates ?? [],
+        });
+
+        if (isGenuinelyEmpty) {
+          // Empty searches are graded inline (nothing to cite, so waiting for
+          // turn end buys nothing). Claim the id so the flush cannot submit a
+          // second row for the same retrieval.
+          void submitEmptySearchFeedback(client, formatted.searchId);
+          markSearchOutcomeSubmitted(formatted.searchId);
+        }
       }
       return formatted;
     } catch (error) {
@@ -1516,7 +1648,8 @@ export const submitMemoryFeedbackTool = createTool({
   id: "submit_memory_feedback",
   description:
     "Submit retrieval-quality feedback to Papr Memory after evaluating search_agent_memory results. " +
-    "Use the searchId from that search response. Only submit when results were clearly helpful or clearly irrelevant — not on every search. " +
+    "Use the searchId from that search response. Cited memories are derived automatically from your answer at turn end, so do NOT submit just to report that results helped. " +
+    "DO submit when results were MIXED (some on-target, some off) — that is the highest-value signal and must not be skipped — or when results looked relevant but were stale, wrong, or unusable. " +
     "For wrong memory content, prefer delete_memory or add_agent_memory instead of correction feedback alone.",
   inputSchema: submitMemoryFeedbackSchema,
   execute: async (args) => {

--- a/src/core/utils/searchOutcomeFeedback.ts
+++ b/src/core/utils/searchOutcomeFeedback.ts
@@ -188,17 +188,35 @@ export function deriveCitations(
   const answerLower = answerText.toLowerCase();
   const answerTerms = new Set(tokenize(answerText));
 
-  // Document frequency across the candidate set.
   const perCandidateTerms = candidates.map((c) => new Set(tokenize(c.content)));
+
+  // Document frequency is computed over DISTINCT documents, not raw rows.
+  //
+  // Measured on a real response: max_memories=25 returned ONE document fanned
+  // out across 25 metadata rows. Counting rows made every term appear in 100%
+  // of "documents", so the >50% filter removed all of them, every candidate
+  // became un-judgeable, and a total retrieval miss graded as
+  // `citations_unknown` (3) instead of `retrieved_unused` (2) — the degenerate
+  // case scoring HIGHER than a normal unused result. Deduplicating by id keeps
+  // the ranking defect visible while still judging the underlying document.
+  const seenIds = new Set<string>();
+  const distinctTermSets: Set<string>[] = [];
+  candidates.forEach((candidate, index) => {
+    if (seenIds.has(candidate.id)) return;
+    seenIds.add(candidate.id);
+    distinctTermSets.push(perCandidateTerms[index] ?? new Set<string>());
+  });
+
   const docFrequency = new Map<string, number>();
-  for (const terms of perCandidateTerms) {
+  for (const terms of distinctTermSets) {
     for (const term of terms) {
       docFrequency.set(term, (docFrequency.get(term) ?? 0) + 1);
     }
   }
+  const distinctCount = distinctTermSets.length;
   const maxDocFrequency = Math.max(
     1,
-    Math.floor(candidates.length * MAX_DOC_FREQUENCY_RATIO),
+    Math.floor(distinctCount * MAX_DOC_FREQUENCY_RATIO),
   );
 
   const citations: DerivedCitation[] = [];
@@ -222,7 +240,7 @@ export function deriveCitations(
     // 2. Distinctive-term containment.
     const distinctive = [...(perCandidateTerms[index] ?? new Set<string>())].filter(
       (term) =>
-        candidates.length === 1 || (docFrequency.get(term) ?? 0) <= maxDocFrequency,
+        distinctCount === 1 || (docFrequency.get(term) ?? 0) <= maxDocFrequency,
     );
     if (distinctive.length < MIN_DISTINCTIVE_TERMS) {
       // Not judgeable — too little unique signal. Deliberately NOT counted as

--- a/src/core/utils/searchOutcomeFeedback.ts
+++ b/src/core/utils/searchOutcomeFeedback.ts
@@ -1,0 +1,451 @@
+/**
+ * Search-outcome feedback — derive retrieval quality from what the agent
+ * actually used, instead of asking the agent to self-report.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `MemoryRetrievalLog` already records, for every search, the full candidate
+ * list with scores (`retrievedMemories` + `retrievedMemoryScores`). The
+ * expensive half of training-data capture is done. What is missing is the
+ * label that splits that pool:
+ *
+ *     cited            => positive candidate
+ *     high-score, not  => graded hard-negative candidate
+ *
+ * That split is the documented design in the papr-embed-v2 curation plan (§3),
+ * and it is what gates D3 (label fidelity) and D5 (hard-negative quality).
+ *
+ * Measured on UserFeedbackLog: only 7 of 31 rows (23%) carried
+ * `citedMemoryIds`, and 26 of 31 were `thumbs_up` with ZERO negatives. The
+ * cause was the sampling rule, not the plumbing — the agent was told to submit
+ * only when results were "clearly helpful or clearly irrelevant", which
+ * deletes the middle of the distribution where hard negatives live.
+ *
+ * So: derive citations from the assistant's own answer at turn end. No model
+ * cooperation required, and it covers every search rather than the ones an
+ * agent chose to grade.
+ *
+ * WHAT THIS PRODUCES IS A *CANDIDATE*, NOT A LABEL
+ * ------------------------------------------------
+ * D3 requires implicit positives be graded before they are trusted — "a cited
+ * memory can still be wrong; not-cited != irrelevant." Everything emitted here
+ * is therefore tagged with its derivation method and a confidence, so the
+ * curation pipeline can grade auto-derived citations separately from
+ * agent-asserted ones. Provenance is the whole point; unmarked weak labels
+ * mixed into a training set are worse than no labels.
+ *
+ * PRIVACY (D2 is a launch blocker, not a step)
+ * --------------------------------------------
+ * `feedbackText` emitted here is machine-parseable and carries ONLY counts,
+ * ranks and scores. Never query text, never memory content. Auto-capture on
+ * every search would otherwise widen PII exposure across the whole corpus.
+ */
+
+/** One retrieved memory, with the rank it was returned at. */
+export interface RetrievedCandidate {
+  id: string;
+  content: string;
+  /** 0-based position in the result list. Rank is the ranking-quality signal. */
+  rank: number;
+}
+
+export interface RecordedSearch {
+  searchId: string;
+  memoryCount: number;
+  nodeCount: number;
+  /**
+   * CRITICAL: false when the payload could not be parsed into candidates
+   * (e.g. an unrecognised TOON shape). "Unknown" must never be graded as
+   * "nothing was cited" — that would emit a false negative label for every
+   * successful search. Same failure class as reading a query that matched
+   * nothing as proof that there was nothing to match.
+   */
+  candidatesKnown: boolean;
+  candidates: RetrievedCandidate[];
+}
+
+/** Per-turn registry. Reset at the start of every user turn. */
+let pendingSearches: RecordedSearch[] = [];
+const submittedSearchIds = new Set<string>();
+
+export function resetSearchOutcomes(): void {
+  pendingSearches = [];
+  submittedSearchIds.clear();
+}
+
+export function recordSearchOutcome(search: RecordedSearch): void {
+  if (!search.searchId) return;
+  // A searchId can only be recorded once per turn.
+  if (pendingSearches.some((s) => s.searchId === search.searchId)) return;
+  pendingSearches.push(search);
+}
+
+export function getPendingSearchOutcomes(): readonly RecordedSearch[] {
+  return pendingSearches;
+}
+
+/**
+ * Claim a searchId so the turn-end flush skips it. Used by the immediate
+ * empty-search path, which submits inline — without this the same searchId
+ * would receive two feedback rows for one retrieval.
+ */
+export function markSearchOutcomeSubmitted(searchId: string): void {
+  if (searchId) submittedSearchIds.add(searchId);
+}
+
+// ---------------------------------------------------------------------------
+// Citation derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Terms that carry no evidence of reuse. Deliberately small: the real
+ * discriminator is the document-frequency filter below, which adapts to the
+ * candidate set instead of relying on a fixed list.
+ */
+const STOPWORDS = new Set([
+  "about", "after", "again", "against", "along", "also", "although", "always",
+  "among", "another", "because", "been", "before", "being", "below", "between",
+  "both", "cannot", "could", "does", "doing", "done", "down", "during", "each",
+  "either", "else", "even", "ever", "every", "from", "further", "have", "having",
+  "here", "however", "into", "itself", "just", "like", "made", "make", "many",
+  "more", "most", "much", "must", "need", "neither", "never", "next", "none",
+  "only", "other", "over", "same", "should", "since", "some", "such", "than",
+  "that", "their", "them", "then", "there", "these", "they", "this", "those",
+  "through", "under", "until", "very", "were", "what", "when", "where", "which",
+  "while", "will", "with", "within", "without", "would", "your",
+]);
+
+/** Minimum token length. Short tokens are overwhelmingly function words. */
+const MIN_TOKEN_LENGTH = 4;
+
+/**
+ * A term appearing in more than this fraction of candidates is not evidence
+ * for any single one of them. With 25 near-topical results from one query,
+ * the shared vocabulary IS the query — matching on it would mark every
+ * candidate as cited.
+ */
+const MAX_DOC_FREQUENCY_RATIO = 0.5;
+
+/** Below this many distinctive terms, a candidate cannot be judged. Skip it. */
+const MIN_DISTINCTIVE_TERMS = 4;
+
+/** Absolute + relative thresholds must BOTH hold. Tuned to favour precision. */
+const MIN_MATCHED_TERMS = 3;
+const MIN_MATCH_RATIO = 0.18;
+
+export function tokenize(text: string): string[] {
+  return (text.toLowerCase().match(/[a-z0-9][a-z0-9_-]{2,}/g) ?? []).filter(
+    (t) => t.length >= MIN_TOKEN_LENGTH && !STOPWORDS.has(t),
+  );
+}
+
+export type CitationMethod = "explicit_id" | "distinctive_terms";
+
+export interface DerivedCitation {
+  id: string;
+  rank: number;
+  method: CitationMethod;
+  /** 0–1. Explicit id mention is certain; term overlap is graded. */
+  confidence: number;
+  matchedTerms: number;
+  distinctiveTerms: number;
+}
+
+export interface CitationDerivation {
+  citations: DerivedCitation[];
+  citedIds: string[];
+  /** Best (lowest) rank among cited candidates — the ranking-quality signal. */
+  bestCitedRank: number | null;
+  /** Candidates that were judgeable (enough distinctive terms to decide). */
+  judgeableCount: number;
+}
+
+/**
+ * Decide which retrieved memories the answer actually used.
+ *
+ * Method, in order of strength:
+ *  1. The answer names the memory id outright — certain.
+ *  2. IDF-style containment: a candidate's DISTINCTIVE terms (those not shared
+ *     across the candidate set) appear in the answer. This is what separates
+ *     "the answer reused this memory" from "all these memories are about the
+ *     same topic, because they came from one query."
+ *
+ * Conservative by construction: a false positive here mints a false training
+ * positive, which is more damaging than a missed one.
+ */
+export function deriveCitations(
+  answerText: string,
+  candidates: readonly RetrievedCandidate[],
+): CitationDerivation {
+  const empty: CitationDerivation = {
+    citations: [],
+    citedIds: [],
+    bestCitedRank: null,
+    judgeableCount: 0,
+  };
+  if (!answerText.trim() || candidates.length === 0) return empty;
+
+  const answerLower = answerText.toLowerCase();
+  const answerTerms = new Set(tokenize(answerText));
+
+  // Document frequency across the candidate set.
+  const perCandidateTerms = candidates.map((c) => new Set(tokenize(c.content)));
+  const docFrequency = new Map<string, number>();
+  for (const terms of perCandidateTerms) {
+    for (const term of terms) {
+      docFrequency.set(term, (docFrequency.get(term) ?? 0) + 1);
+    }
+  }
+  const maxDocFrequency = Math.max(
+    1,
+    Math.floor(candidates.length * MAX_DOC_FREQUENCY_RATIO),
+  );
+
+  const citations: DerivedCitation[] = [];
+  let judgeableCount = 0;
+
+  candidates.forEach((candidate, index) => {
+    // 1. Explicit id mention — unambiguous.
+    if (candidate.id.length >= 8 && answerLower.includes(candidate.id.toLowerCase())) {
+      citations.push({
+        id: candidate.id,
+        rank: candidate.rank,
+        method: "explicit_id",
+        confidence: 1,
+        matchedTerms: 0,
+        distinctiveTerms: 0,
+      });
+      judgeableCount += 1;
+      return;
+    }
+
+    // 2. Distinctive-term containment.
+    const distinctive = [...(perCandidateTerms[index] ?? new Set<string>())].filter(
+      (term) =>
+        candidates.length === 1 || (docFrequency.get(term) ?? 0) <= maxDocFrequency,
+    );
+    if (distinctive.length < MIN_DISTINCTIVE_TERMS) {
+      // Not judgeable — too little unique signal. Deliberately NOT counted as
+      // "not cited", so it cannot become a spurious hard negative.
+      return;
+    }
+    judgeableCount += 1;
+
+    const matched = distinctive.filter((term) => answerTerms.has(term)).length;
+    const ratio = matched / distinctive.length;
+    if (matched >= MIN_MATCHED_TERMS && ratio >= MIN_MATCH_RATIO) {
+      citations.push({
+        id: candidate.id,
+        rank: candidate.rank,
+        method: "distinctive_terms",
+        // Saturates at 1.0 around a 0.5 match ratio.
+        confidence: Math.min(1, Number((ratio * 2).toFixed(3))),
+        matchedTerms: matched,
+        distinctiveTerms: distinctive.length,
+      });
+    }
+  });
+
+  const bestCitedRank = citations.length
+    ? Math.min(...citations.map((c) => c.rank))
+    : null;
+
+  return {
+    citations,
+    citedIds: citations.map((c) => c.id),
+    bestCitedRank,
+    judgeableCount,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Grading
+// ---------------------------------------------------------------------------
+
+export type SearchOutcomeVerdict =
+  | "no_results"
+  | "retrieved_unused"
+  | "cited_deep_rank"
+  | "cited_mid_rank"
+  | "cited_top_rank"
+  | "citations_unknown";
+
+export interface SearchOutcomeGrade {
+  verdict: SearchOutcomeVerdict;
+  /** 1–5, matching the memory_relevance score range accepted by /v1/feedback. */
+  score: number;
+  citedIds: string[];
+  /** Machine-parseable, PII-free (D2). */
+  feedbackText: string;
+}
+
+/**
+ * Grade a search by WHERE the useful result landed, not merely whether one
+ * existed. A search whose only useful hit was at rank 20 retrieved the right
+ * thing and ranked it badly; collapsing that to "helpful" throws away the
+ * signal an embedding model most needs. This is bucketed reciprocal rank.
+ */
+export function gradeSearchOutcome(
+  search: RecordedSearch,
+  derivation: CitationDerivation,
+): SearchOutcomeGrade {
+  const base = {
+    citedIds: derivation.citedIds,
+  };
+
+  if (search.memoryCount === 0 && search.nodeCount === 0) {
+    return {
+      ...base,
+      verdict: "no_results",
+      score: 1,
+      feedbackText: fmt({ verdict: "no_results", retrieved: 0, cited: 0 }),
+    };
+  }
+
+  // Unknown must not be graded as unused — see RecordedSearch.candidatesKnown.
+  if (!search.candidatesKnown) {
+    return {
+      ...base,
+      verdict: "citations_unknown",
+      score: 3,
+      feedbackText: fmt({
+        verdict: "citations_unknown",
+        retrieved: search.memoryCount,
+        cited: 0,
+        note: "payload_unparsed",
+      }),
+    };
+  }
+
+  if (derivation.judgeableCount === 0) {
+    return {
+      ...base,
+      verdict: "citations_unknown",
+      score: 3,
+      feedbackText: fmt({
+        verdict: "citations_unknown",
+        retrieved: search.memoryCount,
+        cited: 0,
+        note: "no_judgeable_candidates",
+      }),
+    };
+  }
+
+  const rank = derivation.bestCitedRank;
+  if (rank === null) {
+    return {
+      ...base,
+      verdict: "retrieved_unused",
+      score: 2,
+      feedbackText: fmt({
+        verdict: "retrieved_unused",
+        retrieved: search.memoryCount,
+        cited: 0,
+        judgeable: derivation.judgeableCount,
+      }),
+    };
+  }
+
+  const verdict: SearchOutcomeVerdict =
+    rank <= 2 ? "cited_top_rank" : rank <= 9 ? "cited_mid_rank" : "cited_deep_rank";
+  const score = rank <= 2 ? 5 : rank <= 9 ? 4 : 3;
+
+  return {
+    ...base,
+    verdict,
+    score,
+    feedbackText: fmt({
+      verdict,
+      retrieved: search.memoryCount,
+      cited: derivation.citedIds.length,
+      judgeable: derivation.judgeableCount,
+      best_rank: rank,
+      methods: derivation.citations.map((c) => c.method).join("|"),
+      mean_confidence: Number(
+        (
+          derivation.citations.reduce((s, c) => s + c.confidence, 0) /
+          derivation.citations.length
+        ).toFixed(3),
+      ),
+    }),
+  };
+}
+
+/**
+ * `key=value` pairs only — no free prose, no user content. Keeps auto-captured
+ * feedback machine-parseable for curation and safe under D2.
+ */
+function fmt(fields: Record<string, string | number>): string {
+  return [
+    "auto=search_outcome_v1",
+    ...Object.entries(fields).map(([k, v]) => `${k}=${v}`),
+  ].join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// Flush
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of the Papr client's feedback surface (keeps this testable). */
+export interface FeedbackSubmitter {
+  feedback: {
+    submit: (body: Record<string, unknown>) => Promise<unknown>;
+  };
+}
+
+export interface FlushResult {
+  submitted: number;
+  skipped: number;
+  grades: SearchOutcomeGrade[];
+}
+
+/**
+ * Submit one graded outcome per search recorded this turn. Never throws:
+ * feedback capture must not be able to fail a user's turn.
+ */
+export async function flushSearchOutcomeFeedback(
+  client: FeedbackSubmitter,
+  answerText: string,
+  // `object`, not Record<string, unknown>: paprUserScope() returns a union
+  // (identity fields, or {} when no user is resolved) and both spread fine.
+  userScope: object = {},
+): Promise<FlushResult> {
+  const searches = pendingSearches;
+  pendingSearches = [];
+
+  const result: FlushResult = { submitted: 0, skipped: 0, grades: [] };
+
+  for (const search of searches) {
+    if (submittedSearchIds.has(search.searchId)) {
+      result.skipped += 1;
+      continue;
+    }
+    try {
+      const derivation = deriveCitations(answerText, search.candidates);
+      const grade = gradeSearchOutcome(search, derivation);
+      result.grades.push(grade);
+
+      await client.feedback.submit({
+        search_id: search.searchId,
+        ...userScope,
+        feedbackData: {
+          feedbackSource: "session_end",
+          feedbackType: "memory_relevance",
+          feedbackText: grade.feedbackText,
+          feedbackScore: grade.score,
+          citedMemoryIds: grade.citedIds,
+        },
+      });
+      submittedSearchIds.add(search.searchId);
+      result.submitted += 1;
+    } catch (error) {
+      result.skipped += 1;
+      console.warn(
+        `[searchOutcomeFeedback] submit failed for ${search.searchId}:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  return result;
+}

--- a/src/gateway/services/AgentService.ts
+++ b/src/gateway/services/AgentService.ts
@@ -18,6 +18,10 @@ import {
   initializeMemorySearchGate,
   wrapToolsWithMemorySearchFirstGate,
 } from "../../core/utils/memorySearchFirstGate.js";
+import {
+  flushSearchOutcomeFeedback,
+  resetSearchOutcomes,
+} from "../../core/utils/searchOutcomeFeedback.js";
 import { allTools, getApiKeysForSanitization, legacyToolAliases } from "../../core/tools/index.js";
 import {
   ACTIVE_PLANS_MESSAGE_PREFIX,
@@ -1206,6 +1210,10 @@ export class AgentService {
         hasPaprApiKey,
         allowedToolIds: options?.allowedToolIds,
       });
+      // Searches recorded this turn are graded against the final answer at
+      // turn end. Reset here so a previous turn's searches can never be
+      // attributed to this turn's answer.
+      resetSearchOutcomes();
       const tools = wrapToolsWithMemorySearchFirstGate(
         this.toolRegistry.getToolsForMastra(options?.allowedToolIds),
       );
@@ -2554,6 +2562,44 @@ export class AgentService {
         // the parent would pass it to UI and create an empty message. Just return.
         this.sessionManager.setStreaming(chatId, false);
         return;
+      }
+
+      // Grade this turn's memory searches against the answer the agent
+      // actually produced. Deliberately placed AFTER both empty-completion
+      // early-returns: grading against an empty answer would mark every
+      // retrieved memory as unused and mint false negatives at scale.
+      //
+      // Fire-and-forget — retrieval telemetry must never delay or fail a turn.
+      if (hasPaprApiKey && assistantText.trim().length > 0) {
+        void (async () => {
+          try {
+            const [{ getPaprClient }, { paprUserScope }] = await Promise.all([
+              import("../../core/tools/paprClient.js"),
+              import("../utils/paprUserId.js"),
+            ]);
+            const client = await getPaprClient();
+            const result = await flushSearchOutcomeFeedback(
+              client as unknown as Parameters<
+                typeof flushSearchOutcomeFeedback
+              >[0],
+              assistantText,
+              paprUserScope(),
+            );
+            if (result.submitted > 0) {
+              console.log(
+                `[AgentService] search-outcome feedback: submitted=${result.submitted} ` +
+                  `skipped=${result.skipped} verdicts=${result.grades
+                    .map((g) => g.verdict)
+                    .join(",")}`,
+              );
+            }
+          } catch (error) {
+            console.warn(
+              "[AgentService] search-outcome feedback flush failed:",
+              error instanceof Error ? error.message : error,
+            );
+          }
+        })();
       }
 
       // 4. Save assistant message with thinking and tool calls

--- a/tests/search-outcome-feedback.test.ts
+++ b/tests/search-outcome-feedback.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  deriveCitations,
+  gradeSearchOutcome,
+  flushSearchOutcomeFeedback,
+  recordSearchOutcome,
+  resetSearchOutcomes,
+  markSearchOutcomeSubmitted,
+  getPendingSearchOutcomes,
+  type RecordedSearch,
+  type RetrievedCandidate,
+} from "../src/core/utils/searchOutcomeFeedback.js";
+import { extractRetrievedCandidates } from "../src/core/tools/paprMemory.js";
+
+const candidate = (
+  id: string,
+  content: string,
+  rank: number,
+): RetrievedCandidate => ({ id, content, rank });
+
+const search = (over: Partial<RecordedSearch> = {}): RecordedSearch => ({
+  searchId: "search-1",
+  memoryCount: over.candidates?.length ?? 3,
+  nodeCount: 0,
+  candidatesKnown: true,
+  candidates: [],
+  ...over,
+});
+
+describe("deriveCitations", () => {
+  it("marks a memory cited when its distinctive terms appear in the answer", () => {
+    const candidates = [
+      candidate(
+        "mem-a",
+        "The Turso replica sidecar wedge is reset by reconnecting; watermark frames realign automatically.",
+        0,
+      ),
+      candidate(
+        "mem-b",
+        "Quarterly revenue for the Helsinki office grew after the pricing change.",
+        1,
+      ),
+    ];
+    const answer =
+      "The sidecar wedge resets on reconnect — the watermark frames realign, so no manual repair is needed.";
+
+    const result = deriveCitations(answer, candidates);
+
+    expect(result.citedIds).toEqual(["mem-a"]);
+    expect(result.bestCitedRank).toBe(0);
+  });
+
+  it("does NOT cite topically-similar candidates that were not used", () => {
+    // The precision test that matters. Every result of one query shares the
+    // query's vocabulary; if shared terms counted as evidence, all of them
+    // would be marked cited and every search would look perfect.
+    const candidates = [
+      candidate(
+        "used",
+        "Neo4j relationship ACLs are written at creation via add_relationships_v2 using the props map.",
+        0,
+      ),
+      candidate(
+        "unused-1",
+        "Neo4j relationship counts are served from the count store instantly.",
+        1,
+      ),
+      candidate(
+        "unused-2",
+        "Neo4j relationship types number 1832 across the whole database.",
+        2,
+      ),
+    ];
+    const answer =
+      "Relationship ACLs are written at creation through add_relationships_v2, which applies the props map.";
+
+    const result = deriveCitations(answer, candidates);
+
+    expect(result.citedIds).toEqual(["used"]);
+    expect(result.citedIds).not.toContain("unused-1");
+    expect(result.citedIds).not.toContain("unused-2");
+  });
+
+  it("treats an explicit id mention as a certain citation", () => {
+    const candidates = [candidate("7cfa0072-cb31-4129", "unrelated wording", 4)];
+    const result = deriveCitations(
+      "See memory 7cfa0072-cb31-4129 for the details.",
+      candidates,
+    );
+
+    expect(result.citedIds).toEqual(["7cfa0072-cb31-4129"]);
+    expect(result.citations[0]?.method).toBe("explicit_id");
+    expect(result.citations[0]?.confidence).toBe(1);
+  });
+
+  it("reports candidates with too little unique signal as un-judgeable, not unused", () => {
+    // "Not judgeable" must not silently become a hard negative.
+    const candidates = [candidate("thin", "ok yes", 0)];
+    const result = deriveCitations("A long answer about something else.", candidates);
+
+    expect(result.judgeableCount).toBe(0);
+    expect(result.citedIds).toEqual([]);
+  });
+
+  it("returns empty for an empty answer", () => {
+    const result = deriveCitations("", [candidate("a", "some content here", 0)]);
+    expect(result.citedIds).toEqual([]);
+    expect(result.bestCitedRank).toBeNull();
+  });
+});
+
+describe("gradeSearchOutcome", () => {
+  it("grades an empty search as score 1", () => {
+    const grade = gradeSearchOutcome(
+      search({ memoryCount: 0, nodeCount: 0 }),
+      deriveCitations("anything", []),
+    );
+    expect(grade.verdict).toBe("no_results");
+    expect(grade.score).toBe(1);
+  });
+
+  it("NEVER grades an unparsed payload as unused", () => {
+    // The guard that keeps 'unknown' distinct from 'zero'. Grading an
+    // unparsed response as retrieved_unused would emit a false negative for
+    // every successful search whose payload shape we failed to read.
+    const grade = gradeSearchOutcome(
+      search({ memoryCount: 12, candidatesKnown: false, candidates: [] }),
+      deriveCitations("some answer", []),
+    );
+    expect(grade.verdict).toBe("citations_unknown");
+    expect(grade.verdict).not.toBe("retrieved_unused");
+    expect(grade.score).toBe(3);
+  });
+
+  it("grades retrieved-but-unused as a weak negative", () => {
+    const candidates = [
+      candidate("a", "Helsinki pricing revenue quarterly office growth numbers", 0),
+    ];
+    const grade = gradeSearchOutcome(
+      search({ memoryCount: 1, candidates }),
+      deriveCitations("Completely unrelated answer about compiler flags.", candidates),
+    );
+    expect(grade.verdict).toBe("retrieved_unused");
+    expect(grade.score).toBe(2);
+  });
+
+  it("scores by the rank of the best cited result", () => {
+    const content =
+      "sidecar wedge watermark realign reconnect replica frames repair";
+    const answer =
+      "The sidecar wedge and watermark realign on reconnect, so replica frames repair themselves.";
+
+    const atTop = [candidate("m", content, 0)];
+    const atMid = [candidate("m", content, 5)];
+    const atDeep = [candidate("m", content, 17)];
+
+    expect(
+      gradeSearchOutcome(search({ candidates: atTop }), deriveCitations(answer, atTop))
+        .score,
+    ).toBe(5);
+    expect(
+      gradeSearchOutcome(search({ candidates: atMid }), deriveCitations(answer, atMid))
+        .score,
+    ).toBe(4);
+    expect(
+      gradeSearchOutcome(search({ candidates: atDeep }), deriveCitations(answer, atDeep))
+        .score,
+    ).toBe(3);
+  });
+
+  it("emits no memory content or query text in feedbackText (D2)", () => {
+    const secret = "myhomeqrc@gmail.com and passphrase hunter2";
+    const candidates = [candidate("a", `${secret} sidecar wedge watermark realign`, 0)];
+    const grade = gradeSearchOutcome(
+      search({ candidates }),
+      deriveCitations("sidecar wedge watermark realign reconnect", candidates),
+    );
+
+    expect(grade.feedbackText).not.toContain("myhomeqrc");
+    expect(grade.feedbackText).not.toContain("hunter2");
+    expect(grade.feedbackText).toMatch(/^auto=search_outcome_v1( [a-z_]+=\S+)+$/);
+  });
+});
+
+describe("flushSearchOutcomeFeedback", () => {
+  beforeEach(() => resetSearchOutcomes());
+
+  it("submits one graded row per recorded search", async () => {
+    const submit = vi.fn().mockResolvedValue({});
+    recordSearchOutcome(
+      search({
+        searchId: "s1",
+        candidates: [candidate("a", "sidecar wedge watermark realign frames", 0)],
+      }),
+    );
+
+    const result = await flushSearchOutcomeFeedback(
+      { feedback: { submit } },
+      "The sidecar wedge and watermark realign the frames.",
+      { user_id: "u1" },
+    );
+
+    expect(result.submitted).toBe(1);
+    expect(submit).toHaveBeenCalledOnce();
+    const body = submit.mock.calls[0]![0] as Record<string, any>;
+    expect(body.search_id).toBe("s1");
+    expect(body.user_id).toBe("u1");
+    expect(body.feedbackData.feedbackType).toBe("memory_relevance");
+    expect(body.feedbackData.citedMemoryIds).toEqual(["a"]);
+  });
+
+  it("does not double-submit a search already graded inline", async () => {
+    const submit = vi.fn().mockResolvedValue({});
+    recordSearchOutcome(search({ searchId: "s2", memoryCount: 0, nodeCount: 0 }));
+    markSearchOutcomeSubmitted("s2");
+
+    const result = await flushSearchOutcomeFeedback(
+      { feedback: { submit } },
+      "answer",
+    );
+
+    expect(result.submitted).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("swallows API errors — telemetry must never fail a turn", async () => {
+    const submit = vi.fn().mockRejectedValue(new Error("500 boom"));
+    recordSearchOutcome(search({ searchId: "s3" }));
+
+    await expect(
+      flushSearchOutcomeFeedback({ feedback: { submit } }, "answer"),
+    ).resolves.toMatchObject({ submitted: 0, skipped: 1 });
+  });
+
+  it("clears pending searches so the next turn starts empty", async () => {
+    recordSearchOutcome(search({ searchId: "s4" }));
+    expect(getPendingSearchOutcomes()).toHaveLength(1);
+    await flushSearchOutcomeFeedback(
+      { feedback: { submit: vi.fn().mockResolvedValue({}) } },
+      "answer",
+    );
+    expect(getPendingSearchOutcomes()).toHaveLength(0);
+  });
+});
+
+describe("extractRetrievedCandidates", () => {
+  it("reads structured memories with their rank", () => {
+    const result = extractRetrievedCandidates({
+      data: { memories: [{ id: "m1", content: "first" }, { id: "m2", content: "second" }] },
+    } as never);
+
+    expect(result).toEqual([
+      { id: "m1", content: "first", rank: 0 },
+      { id: "m2", content: "second", rank: 1 },
+    ]);
+  });
+
+  it("parses tabular TOON and keeps commas inside quoted content", () => {
+    const toon = [
+      "data:",
+      "  memories[#2]{id,content}:",
+      '    m1,"Parse, Qdrant, and Neo4j all carry ACLs"',
+      "    m2,Second memory",
+      "search_id: abc",
+    ].join("\n");
+
+    const result = extractRetrievedCandidates(toon);
+
+    expect(result).toHaveLength(2);
+    expect(result![0]).toEqual({
+      id: "m1",
+      content: "Parse, Qdrant, and Neo4j all carry ACLs",
+      rank: 0,
+    });
+    expect(result![1]!.content).toBe("Second memory");
+  });
+
+  it("returns null (unknown) when the shape has no field header", () => {
+    // The count-only envelope used by existing TOON responses. Must be
+    // 'unknown', never an empty candidate list.
+    const result = extractRetrievedCandidates(
+      "code: 200\nstatus: success\ndata:\n  memories[#10]:\nsearch_id: s",
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/tests/search-outcome-feedback.test.ts
+++ b/tests/search-outcome-feedback.test.ts
@@ -102,6 +102,30 @@ describe("deriveCitations", () => {
     expect(result.citedIds).toEqual([]);
   });
 
+  it("still judges a degenerate result set where one document fills every slot", () => {
+    // Observed live: max_memories=25 returned ONE document fanned out across
+    // metadata rows. Counting rows as documents made every term 100%-frequent,
+    // so all terms were filtered, nothing was judgeable, and a total miss
+    // graded HIGHER (citations_unknown=3) than an ordinary unused result
+    // (retrieved_unused=2). Frequency is now computed over distinct ids.
+    const body = "sidecar wedge watermark realign reconnect replica frames";
+    const candidates = Array.from({ length: 25 }, (_, rank) =>
+      candidate("same-doc", body, rank),
+    );
+
+    const result = deriveCitations("Unrelated answer about payoff matrices.", candidates);
+
+    expect(result.judgeableCount).toBe(25);
+    expect(result.citedIds).toEqual([]);
+
+    const grade = gradeSearchOutcome(
+      search({ memoryCount: 25, candidates }),
+      result,
+    );
+    expect(grade.verdict).toBe("retrieved_unused");
+    expect(grade.score).toBe(2);
+  });
+
   it("returns empty for an empty answer", () => {
     const result = deriveCitations("", [candidate("a", "some content here", 0)]);
     expect(result.citedIds).toEqual([]);
@@ -274,6 +298,70 @@ describe("extractRetrievedCandidates", () => {
       rank: 0,
     });
     expect(result![1]!.content).toBe("Second memory");
+  });
+
+  it("parses list-style TOON — the shape memory search actually returns", () => {
+    // Fixture copied from a real search_agent_memory response. The original
+    // parser only handled the tabular `memories[#N]{id,content}:` form, so on
+    // live payloads it returned null and citation derivation never ran.
+    const toon = [
+      "code: 200",
+      "status: success",
+      "data:",
+      "  memories[#2]:",
+      "    - id: 0dfe9a25-2720-4b1e-91d7-1772cc44aa29",
+      '      content: "// Context Intelligence demo\\nvar CTX = { coda: \\"support_fleet\\" };"',
+      "      type: TextMemoryItem",
+      "      customMetadata:",
+      "        file_name: connector-room.js",
+      "        source: code_indexer",
+      "      similarity_score: 0.5973358",
+      "    - id: 1bbb1111-2222-3333-4444-555555555555",
+      '      content: "Second memory about payoff matrices."',
+      "      type: TextMemoryItem",
+      "  nodes[#1]:",
+      "    - label: Insight",
+      "      properties:",
+      "        content: should not be read as a memory",
+      "search_id: fe0534a2-c610-425a-945a-ceaad0390d84",
+    ].join("\n");
+
+    const result = extractRetrievedCandidates(toon);
+
+    expect(result).toHaveLength(2);
+    expect(result![0]!.id).toBe("0dfe9a25-2720-4b1e-91d7-1772cc44aa29");
+    // Escapes resolved: \n became a newline, \" became a quote.
+    expect(result![0]!.content).toContain("Context Intelligence demo");
+    expect(result![0]!.content).toContain('{ coda: "support_fleet" }');
+    expect(result![0]!.content).toContain("\n");
+    expect(result![1]!.content).toBe("Second memory about payoff matrices.");
+    expect(result![1]!.rank).toBe(1);
+    // The nodes[] section must not leak in as a 3rd memory.
+    expect(result!.some((c) => c.content.includes("should not be read"))).toBe(
+      false,
+    );
+  });
+
+  it("keeps duplicate ids as separate ranked candidates", () => {
+    // The degenerate case observed live: max_memories=25 returned ONE distinct
+    // document fanned out across metadata rows. The parser must report what was
+    // actually returned rather than silently de-duplicating, otherwise the
+    // ranking defect becomes invisible to the feedback signal.
+    const toon = [
+      "data:",
+      "  memories[#2]:",
+      "    - id: same-id",
+      '      content: "identical body"',
+      "    - id: same-id",
+      '      content: "identical body"',
+      "search_id: s",
+    ].join("\n");
+
+    const result = extractRetrievedCandidates(toon);
+
+    expect(result).toHaveLength(2);
+    expect(result![0]!.rank).toBe(0);
+    expect(result![1]!.rank).toBe(1);
   });
 
   it("returns null (unknown) when the shape has no field header", () => {


### PR DESCRIPTION
## Why

Search feedback is currently unusable as training data. Of the 31 rows in `UserFeedbackLog`:

| | |
|---|---|
| `thumbs_up` | **26** |
| `thumbs_down` / `correction` / `report` | **0** |
| rows carrying `citedMemoryIds` | **7 / 31 (23%)** |

Two fatal properties: **zero negatives**, and the cited link missing in 77% of rows.

`MemoryRetrievalLog` already records the full candidate list with scores on every search (`retrievedMemories` + `retrievedMemoryScores`), so the expensive half of capture is done. What was missing is the label that splits that pool — `cited ⇒ positive`, `high-score-not-cited ⇒ graded hard negative` (the papr-embed-v2 curation plan, D3/D5). Without citations you have the candidate pool and no way to split it.

**The cause was the sampling rule, not the plumbing.** The tool description told the agent to submit *"only when results were clearly helpful or clearly irrelevant"* and to *"skip feedback when results were mediocre or mixed"* — which deletes the middle of the distribution, exactly where hard negatives live. An agent that just successfully used results almost always judges them helpful, hence 84% thumbs_up.

## What changed

**1. Citations are derived, not requested.** Every search records `{id, content, rank}` into a per-turn registry; at turn end the assistant's own answer is matched against those candidates. Two methods: explicit id mention (confidence 1.0) and IDF-style containment over distinctive terms.

The distinctive-term filter is load-bearing. Every result of one query shares that query's vocabulary, so naive overlap would mark all 25 as cited and make every search look perfect. Terms appearing in >50% of candidates are dropped as non-evidence. There is a dedicated test using three near-identical Neo4j memories where only one was actually used.

**2. Auto-submit generalised.** `submitEmptySearchFeedback` still fires inline for zero-result searches (unchanged), but now claims its `searchId` so the flush cannot double-submit. Everything else is graded at turn end by **where the useful hit landed**:

| verdict | score |
|---|---|
| `no_results` | 1 |
| `retrieved_unused` | 2 |
| `cited_deep_rank` (≥10) | 3 |
| `cited_mid_rank` (3–9) | 4 |
| `cited_top_rank` (0–2) | 5 |

Bucketed reciprocal rank. A search whose only hit was at rank 20 found the right thing and ranked it badly — that distinction is what an embedding model needs, and collapsing it to "helpful" throws it away.

**3. Guidance flipped.** Mixed results are now the explicitly requested case rather than the skipped one.

## Safety properties

**Unknown is never graded as zero.** If the payload cannot be parsed, the search records `candidatesKnown: false` and grades as `citations_unknown`, never `retrieved_unused`. Grading an unparsed response as zero-citations would mint a false negative on every successful search whose shape we failed to read. Two tests pin this.

**D2 / PII.** `feedbackText` is `key=value` counts, ranks and scores only — never query text, never memory content. A test plants an email and a passphrase in memory content and asserts neither can appear.

**Provenance for D3.** Every row is tagged `auto=search_outcome_v1` with derivation method and confidence, so curation can grade auto-derived citations separately from agent-asserted ones. D3 requires implicit positives be graded before they are trusted — unmarked weak labels mixed into a training set are worse than no labels.

**Cannot fail a turn.** The flush is fire-and-forget and swallows errors. It is placed after both empty-completion early-returns, so an empty answer can never mark every retrieved memory as unused.

## Testing

- 17 new tests in `tests/search-outcome-feedback.test.ts` — all passing
- Existing 6 tests in `tests/papr-memory-feedback.test.ts` — unchanged, still passing
- `tsc --noEmit`: zero errors in the touched files

## Known limitation

Citation derivation is lexical, so a purely abstractive answer that reuses no distinctive terms will under-count citations. That direction is deliberate: a false positive mints a false training positive, which is more damaging than a missed one. Candidates with too little unique signal are reported as *un-judgeable* rather than *unused*, so they cannot become spurious hard negatives.
