### PR TITLE
fix(memory): stop scoring duplicate floods as perfect retrievals

### DIFF
--- a/src/core/tools/paprMemory.ts
+++ b/src/core/tools/paprMemory.ts
@@ -20,6 +20,10 @@ import {
   recordSearchOutcome,
   type RetrievedCandidate,
 } from "../utils/searchOutcomeFeedback.js";
+import {
+  analyzeResultSetShape,
+  describeResultSetShape,
+} from "../utils/resultSetShape.js";
 import { getPaprClient, handlePaprToolError, isPaprNotFoundError } from "./paprClient.js";
 import { assertValidWikiGraphQLSelection } from "../../gateway/services/wikiGraphqlUtils.js";
 import {
@@ -325,6 +329,13 @@ export interface SearchAgentMemoryToolResult {
   data: SearchResponse | string;
   /** Agent-visible reminder — include literal searchId for submit_memory_feedback */
   _memoryFeedbackReminder: string;
+  /**
+   * Present ONLY when the result set is degenerate (mostly near-duplicates, or
+   * a repeated memory id). Omitted on healthy searches so the field itself is
+   * the signal — an agent that sees it should narrow filters or fall back to
+   * grep rather than reading ranks that carry no new information.
+   */
+  _retrievalQuality?: string;
 }
 
 function buildMemoryFeedbackReminder(
@@ -966,12 +977,22 @@ export const searchAgentMemoryTool = createTool({
       const isGenuinelyEmpty =
         formatted.memoryCount === 0 && formatted.nodeCount === 0;
 
-      // Record every search so the turn-end flush can derive which memories
-      // the answer actually used. `null` means the payload could not be
-      // parsed — recorded as candidatesKnown:false so it is never graded as
-      // "nothing was cited".
+      // Extracted once: the same candidate list feeds turn-end citation
+      // derivation AND the degeneracy check surfaced to the agent below.
+      // `null` means the payload could not be parsed — recorded as
+      // candidatesKnown:false so it is never graded as "nothing was cited".
+      const candidates = extractRetrievedCandidates(response);
+
+      // Warn on duplicate floods / id fan-out regardless of whether a searchId
+      // came back — the agent needs this even when feedback cannot be filed.
+      if (candidates && candidates.length > 0) {
+        const warning = describeResultSetShape(
+          analyzeResultSetShape(candidates),
+        );
+        if (warning) formatted._retrievalQuality = warning;
+      }
+
       if (formatted.searchId !== null) {
-        const candidates = extractRetrievedCandidates(response);
         recordSearchOutcome({
           searchId: formatted.searchId,
           memoryCount: formatted.memoryCount,

--- a/src/core/utils/resultSetShape.ts
+++ b/src/core/utils/resultSetShape.ts
@@ -1,0 +1,150 @@
+/**
+ * Result-set shape analysis — detect degenerate retrievals.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `gradeSearchOutcome` scores a search by WHERE the cited result landed. That
+ * is the right axis for ranking quality, but it is blind to a failure mode we
+ * measured in production:
+ *
+ *   query: "mini-app DB query pattern"  ->  10 results
+ *   ranks 1,2,3 = byte-identical generated `db.ts` scaffolding, differing only
+ *   in the `APP_ID` constant. similarity 0.7042999 vs 0.7041931 (equal to 4dp).
+ *
+ * Cite rank 1 and that search grades `cited_top_rank` = 5/5. A perfect score
+ * for a result set whose effective k was 1. Feeding that back as a positive
+ * label teaches the ranker that the flood was good.
+ *
+ * On disk: 98 of 110 `db.ts` files across 147 mini-apps are byte-identical
+ * once the APP_ID line is removed. Generated scaffolding is the MAJORITY of
+ * the code corpus, so this is structural, not incidental.
+ *
+ * A second, distinct signature is server-side hydration fan-out: N rows that
+ * share one `id` and one `content` while carrying DIFFERENT metadata. Observed
+ * with 20 rows collapsing to a single memory id, every `similarity_score`
+ * equal to 0.5973358 at 7dp. That is a correctness bug, not a ranking miss,
+ * and must be reported separately so it is not "fixed" by tuning the ranker.
+ *
+ * WHAT THIS IS NOT
+ * ----------------
+ * This does not delete or reorder results. Retrieval sees what the server
+ * returned. We only measure the shape so grading can stop rewarding it and the
+ * agent can be told to narrow its filters.
+ */
+
+/** Above this share of repeats, the result set carries less than half the information its length implies. */
+const DEGENERATE_DUPLICATE_RATIO = 0.5;
+
+/**
+ * Collapse incidental identifiers so generated scaffolding compares equal.
+ *
+ * Exact hashing does NOT catch the dominant case: the `db.ts` copies differ by
+ * one UUID. Normalising UUIDs, long hex, and bare integers turns those into a
+ * single group while leaving genuinely different code distinct.
+ */
+export function normalizeForDedupe(content: string): string {
+  return content
+    .replace(
+      /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+      "\u0000UUID",
+    )
+    .replace(/\b[0-9a-f]{16,}\b/gi, "\u0000HEX")
+    .replace(/\b\d+\b/g, "\u0000N")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export interface ShapeInput {
+  id: string;
+  content: string;
+}
+
+export interface ResultSetShape {
+  total: number;
+  /** Distinct memory ids. Fewer than `total` means the server repeated a row. */
+  distinctIds: number;
+  /** Distinct contents after identifier normalisation. */
+  distinctContents: number;
+  /** 1 - distinctContents/total. 0.8 => only a fifth of the set is new information. */
+  duplicateRatio: number;
+  /** Size of the largest near-identical group. */
+  maxRepeat: number;
+  /**
+   * The same memory id returned more than once. Signature of server-side
+   * hydration fan-out — a correctness bug, reported separately from ranking.
+   */
+  idFanOut: boolean;
+  degenerate: boolean;
+}
+
+export function analyzeResultSetShape(
+  candidates: readonly ShapeInput[],
+): ResultSetShape {
+  const total = candidates.length;
+  if (total === 0) {
+    return {
+      total: 0,
+      distinctIds: 0,
+      distinctContents: 0,
+      duplicateRatio: 0,
+      maxRepeat: 0,
+      idFanOut: false,
+      degenerate: false,
+    };
+  }
+
+  const ids = new Set<string>();
+  const groups = new Map<string, number>();
+
+  for (const candidate of candidates) {
+    ids.add(candidate.id);
+    const key = normalizeForDedupe(candidate.content);
+    groups.set(key, (groups.get(key) ?? 0) + 1);
+  }
+
+  const distinctContents = groups.size;
+  const maxRepeat = Math.max(...groups.values());
+  const duplicateRatio = 1 - distinctContents / total;
+  const idFanOut = ids.size < total;
+
+  return {
+    total,
+    distinctIds: ids.size,
+    distinctContents,
+    duplicateRatio: Number(duplicateRatio.toFixed(3)),
+    maxRepeat,
+    idFanOut,
+    // A single result cannot be "mostly duplicates" — guard against total=1
+    // scoring degenerate on a ratio of 0.
+    degenerate:
+      total > 1 && (idFanOut || duplicateRatio >= DEGENERATE_DUPLICATE_RATIO),
+  };
+}
+
+/**
+ * Operator-facing warning. Returns null when the set is healthy so callers can
+ * omit the field entirely rather than emit reassuring noise on every search.
+ *
+ * Carries counts only — no query text, no memory content (D2).
+ */
+export function describeResultSetShape(shape: ResultSetShape): string | null {
+  if (!shape.degenerate) return null;
+
+  const parts: string[] = [
+    `${shape.total} results collapse to ${shape.distinctContents} distinct item(s)`,
+    `largest repeat ${shape.maxRepeat}x`,
+  ];
+
+  if (shape.idFanOut) {
+    parts.push(
+      `SERVER BUG: ${shape.total - shape.distinctIds} row(s) repeat an existing memory id ` +
+        `(hydration fan-out — metadata and content may not correspond)`,
+    );
+  }
+
+  return (
+    `Degenerate result set — ${parts.join("; ")}. ` +
+    `Ranks beyond the first of each group add no information. ` +
+    `Narrow with projectId/projectType/fileName filters, or use grep/read_file for exact lookups.`
+  );
+}

--- a/src/core/utils/searchOutcomeFeedback.ts
+++ b/src/core/utils/searchOutcomeFeedback.ts
@@ -41,6 +41,11 @@
  * every search would otherwise widen PII exposure across the whole corpus.
  */
 
+import {
+  analyzeResultSetShape,
+  type ResultSetShape,
+} from "./resultSetShape.js";
+
 /** One retrieved memory, with the rank it was returned at. */
 export interface RetrievedCandidate {
   id: string;
@@ -283,6 +288,7 @@ export function deriveCitations(
 export type SearchOutcomeVerdict =
   | "no_results"
   | "retrieved_unused"
+  | "retrieved_degenerate"
   | "cited_deep_rank"
   | "cited_mid_rank"
   | "cited_top_rank"
@@ -295,7 +301,17 @@ export interface SearchOutcomeGrade {
   citedIds: string[];
   /** Machine-parseable, PII-free (D2). */
   feedbackText: string;
+  /** Duplicate/fan-out shape of the candidate set. Null when unparseable. */
+  shape: ResultSetShape | null;
 }
+
+/**
+ * Ceiling applied to a cited search whose candidate set was mostly repeats.
+ * Retrieval DID surface something usable, so this is not a failure — but it is
+ * not a 5 either, because effective k was far below requested k. Capping at 3
+ * keeps the row out of the positive tail without flipping it to a negative.
+ */
+const DEGENERATE_CITED_SCORE_CAP = 3;
 
 /**
  * Grade a search by WHERE the useful result landed, not merely whether one
@@ -307,9 +323,28 @@ export function gradeSearchOutcome(
   search: RecordedSearch,
   derivation: CitationDerivation,
 ): SearchOutcomeGrade {
+  // Shape is only meaningful when the payload parsed. An unparsed payload has
+  // no candidates, and an empty candidate list must never be read as "no
+  // duplicates" — same failure class as candidatesKnown.
+  const shape = search.candidatesKnown
+    ? analyzeResultSetShape(search.candidates)
+    : null;
+
   const base = {
     citedIds: derivation.citedIds,
+    shape,
   };
+
+  /** Duplicate/fan-out counters appended to every graded row that has a shape. */
+  const shapeFields = (): Record<string, string | number> =>
+    shape
+      ? {
+          dup_ratio: shape.duplicateRatio,
+          distinct: shape.distinctContents,
+          max_repeat: shape.maxRepeat,
+          ...(shape.idFanOut ? { id_fanout: shape.total - shape.distinctIds } : {}),
+        }
+      : {};
 
   if (search.memoryCount === 0 && search.nodeCount === 0) {
     return {
@@ -335,6 +370,30 @@ export function gradeSearchOutcome(
     };
   }
 
+  const rank = derivation.bestCitedRank;
+
+  // Degeneracy is checked BEFORE `judgeableCount === 0`, and deliberately so.
+  // In a pure duplicate flood every term appears in every candidate, so the
+  // document-frequency filter strips them all and judgeableCount falls to 0 —
+  // which would otherwise be graded `citations_unknown` (a neutral 3). But this
+  // is not unknown: we know precisely what happened. The server returned one
+  // item N times. Emitting "unknown" for the single most diagnosable failure
+  // mode would bury it in the same bucket as unparseable payloads.
+  if (rank === null && shape?.degenerate) {
+    return {
+      ...base,
+      verdict: "retrieved_degenerate",
+      score: 1,
+      feedbackText: fmt({
+        verdict: "retrieved_degenerate",
+        retrieved: search.memoryCount,
+        cited: 0,
+        judgeable: derivation.judgeableCount,
+        ...shapeFields(),
+      }),
+    };
+  }
+
   if (derivation.judgeableCount === 0) {
     return {
       ...base,
@@ -345,11 +404,11 @@ export function gradeSearchOutcome(
         retrieved: search.memoryCount,
         cited: 0,
         note: "no_judgeable_candidates",
+        ...shapeFields(),
       }),
     };
   }
 
-  const rank = derivation.bestCitedRank;
   if (rank === null) {
     return {
       ...base,
@@ -360,13 +419,23 @@ export function gradeSearchOutcome(
         retrieved: search.memoryCount,
         cited: 0,
         judgeable: derivation.judgeableCount,
+        ...shapeFields(),
       }),
     };
   }
 
   const verdict: SearchOutcomeVerdict =
     rank <= 2 ? "cited_top_rank" : rank <= 9 ? "cited_mid_rank" : "cited_deep_rank";
-  const score = rank <= 2 ? 5 : rank <= 9 ? 4 : 3;
+  const rankScore = rank <= 2 ? 5 : rank <= 9 ? 4 : 3;
+
+  // A citation at rank 1 of ten near-identical rows is not a 5. Effective k was
+  // one; the remaining ranks carried no information the answer could have used.
+  // Without this cap a duplicate flood produces the SAME positive label as a
+  // genuinely well-ranked, diverse result set — which is how the ranker learns
+  // to keep flooding.
+  const score = shape?.degenerate
+    ? Math.min(rankScore, DEGENERATE_CITED_SCORE_CAP)
+    : rankScore;
 
   return {
     ...base,
@@ -378,6 +447,8 @@ export function gradeSearchOutcome(
       cited: derivation.citedIds.length,
       judgeable: derivation.judgeableCount,
       best_rank: rank,
+      ...(score !== rankScore ? { rank_score: rankScore, capped: "degenerate" } : {}),
+      ...shapeFields(),
       methods: derivation.citations.map((c) => c.method).join("|"),
       mean_confidence: Number(
         (

--- a/src/gateway/services/storage/CodeIndexTracker.ts
+++ b/src/gateway/services/storage/CodeIndexTracker.ts
@@ -512,6 +512,36 @@ export class CodeIndexTracker {
     };
   }
 
+  /**
+   * Papr memory id for a RAW indexed code file (not its summary).
+   *
+   * `indexed_files.memory_id` has existed since the table was created but was
+   * never written: SmartCodeIndexManager calls recordIndexedFile() without a
+   * memory_id, so every re-index had no id to update against and issued a
+   * fresh `memory.add()` instead. These two accessors close that gap.
+   */
+  getIndexedFileMemoryId(filePath: string): string | undefined {
+    if (this.closed) return undefined;
+    const row = this.db.prepare(
+      'SELECT memory_id FROM indexed_files WHERE file_path = ?'
+    ).get(filePath) as { memory_id?: string } | undefined;
+    return row?.memory_id ?? undefined;
+  }
+
+  /**
+   * Persist the memory id for an indexed file.
+   *
+   * UPDATE (not INSERT OR REPLACE) on purpose: recordIndexedFile() owns row
+   * creation and would clobber memory_id back to NULL if used here, which is
+   * the exact hazard that kept the column empty.
+   */
+  setIndexedFileMemoryId(filePath: string, memoryId: string): void {
+    if (this.closed) return;
+    this.db.prepare(
+      'UPDATE indexed_files SET memory_id = ? WHERE file_path = ?'
+    ).run(memoryId, filePath);
+  }
+
   getFileSummaryMemoryId(filePath: string): string | undefined {
     if (this.closed) return undefined;
     const row = this.db.prepare(

--- a/src/gateway/services/storage/CodeIndexerService.ts
+++ b/src/gateway/services/storage/CodeIndexerService.ts
@@ -7,6 +7,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { createHash } from 'crypto';
+import { normalizeForDedupe } from '../../../core/utils/resultSetShape.js';
 import { getPaprRoot } from '../../../core/utils/paprRoot.js';
 import { Papr } from '@papr/memory';
 import { buildCodeIndexAddPolicy } from '../../utils/paprMemoryPolicy.js';
@@ -14,6 +16,11 @@ import { paprMemoryScopeSpread } from '../../utils/memoryScopeResolver.js';
 import { getProjectPathInfo } from './codeIndexPaths.js';
 import { resolveMiniAppDisplayName } from './codeIndexMetadata.js';
 import { parseJsonTolerant } from '../../../core/utils/atomicJsonWrite.js';
+
+/** Short content digest for duplicate detection. Not security-sensitive. */
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
+}
 
 interface JobJsonMetadata {
   id?: string;
@@ -538,7 +545,15 @@ export class CodeIndexerService {
       project_type: projectMetadata.type,
       source: 'code_indexer',
       indexed_at: new Date().toISOString(),
-      entity_type: 'code_file'
+      entity_type: 'code_file',
+      // Exact hash identifies re-indexes of unchanged files. `boilerplate_hash`
+      // ignores UUIDs/hex/integers so generated scaffolding shares one value:
+      // 98 of 110 `db.ts` files in this workspace are identical apart from
+      // their APP_ID constant, which is why exact hashing alone cannot see the
+      // duplication. Recorded (not filtered) so search can collapse groups
+      // without the indexer having to decide which project "owns" a copy.
+      content_hash: sha256(content),
+      boilerplate_hash: sha256(normalizeForDedupe(content)),
     };
     
     if (fileMetadata.data_source_path) {

--- a/src/gateway/services/storage/CodeIndexerService.ts
+++ b/src/gateway/services/storage/CodeIndexerService.ts
@@ -14,6 +14,8 @@ import { Papr } from '@papr/memory';
 import { buildCodeIndexAddPolicy } from '../../utils/paprMemoryPolicy.js';
 import { paprMemoryScopeSpread } from '../../utils/memoryScopeResolver.js';
 import { getProjectPathInfo } from './codeIndexPaths.js';
+import type { CodeIndexTracker } from './CodeIndexTracker.js';
+import { isMemoryNotFound } from './CodeSummaryMemoryStore.js';
 import { resolveMiniAppDisplayName } from './codeIndexMetadata.js';
 import { parseJsonTolerant } from '../../../core/utils/atomicJsonWrite.js';
 
@@ -100,7 +102,13 @@ export class CodeIndexerService {
   constructor(
     private client: Papr,
     schemaId: string,
-    paprDir?: string
+    paprDir?: string,
+    /**
+     * Optional so existing call sites keep working. When supplied, raw code
+     * files are UPDATED in place on re-index instead of re-added — without it
+     * every re-index inserts another Memory document sharing one memoryId.
+     */
+    private tracker?: CodeIndexTracker,
   ) {
     this.paprDir = paprDir || getPaprRoot();
     this.schemaId = schemaId;
@@ -560,19 +568,13 @@ export class CodeIndexerService {
       paprMetadata.data_source_path = fileMetadata.data_source_path;
     }
     
-    const fileMemoryScope = await paprMemoryScopeSpread({
-      addPolicy: buildCodeIndexAddPolicy(this.schemaId),
-    });
+    const fileMetadataForPapr = {
+      role: 'assistant' as const,
+      category: 'learning' as const,
+      customMetadata: paprMetadata,
+    };
 
-    await this.client.memory.add({
-      content: truncatedContent,
-      ...fileMemoryScope,
-      metadata: {
-        role: 'assistant',
-        category: 'learning',
-        customMetadata: paprMetadata
-      },
-    }).catch((error: unknown) => {
+    const rethrow = (error: unknown): never => {
       const err = error as {
         statusCode?: number;
         code?: number;
@@ -582,6 +584,73 @@ export class CodeIndexerService {
       throw new Error(
         `${err.statusCode ?? err.code ?? 'Unknown'} ${JSON.stringify(err.body ?? err.message ?? error)}`,
       );
+    };
+
+    // UPDATE IN PLACE on re-index.
+    //
+    // This path was an unconditional `memory.add()`, so every re-index of a
+    // file inserted ANOTHER Memory document. Because the server derives
+    // memoryId from content, those documents all share one memoryId, and the
+    // search pipeline dedups ids rather than documents — so a single logical
+    // memory expands to fill every result slot. Measured live: one memoryId
+    // returned 25/25 times across 16 distinct file_paths, with 25 distinct
+    // created_at values proving 25 separate inserts.
+    const knownMemoryId = this.tracker?.getIndexedFileMemoryId(fileMetadata.file_path);
+    if (knownMemoryId) {
+      try {
+        await this.client.memory.update(knownMemoryId, {
+          content: truncatedContent,
+          metadata: fileMetadataForPapr,
+        });
+        return;
+      } catch (error) {
+        // Only a genuine 404 may fall through to `add`. Retrying any other
+        // failure as an insert is precisely what produced the duplicates.
+        if (!isMemoryNotFound(error)) {
+          rethrow(error);
+        }
+        console.warn(
+          `[CodeIndexer] memory ${knownMemoryId} for ${fileMetadata.file_name} ` +
+            `not found (404) — recreating.`,
+        );
+      }
+    }
+
+    const fileMemoryScope = await paprMemoryScopeSpread({
+      addPolicy: buildCodeIndexAddPolicy(this.schemaId),
     });
+
+    const response = await this.client.memory.add({
+      content: truncatedContent,
+      ...fileMemoryScope,
+      metadata: fileMetadataForPapr,
+    }).catch(rethrow);
+
+    // Persist the id so the NEXT run updates instead of inserting. Without
+    // this the column stays NULL and the duplication repeats indefinitely.
+    const newMemoryId = extractAddedMemoryId(response);
+    if (newMemoryId && this.tracker) {
+      this.tracker.setIndexedFileMemoryId(fileMetadata.file_path, newMemoryId);
+    }
   }
+}
+
+/** Read the memory id out of an `add` response across known payload shapes. */
+function extractAddedMemoryId(response: unknown): string | undefined {
+  if (!response || typeof response !== 'object') return undefined;
+  const record = response as Record<string, unknown>;
+  if (typeof record.id === 'string') return record.id;
+
+  const data = record.data;
+  if (Array.isArray(data)) {
+    const first = data[0] as Record<string, unknown> | undefined;
+    const id = first?.memoryId ?? first?.memory_id ?? first?.id;
+    return typeof id === 'string' ? id : undefined;
+  }
+  if (data && typeof data === 'object') {
+    const inner = data as Record<string, unknown>;
+    const id = inner.id ?? inner.memory_id ?? inner.memoryId;
+    return typeof id === 'string' ? id : undefined;
+  }
+  return undefined;
 }

--- a/src/gateway/services/storage/CodeSummaryMemoryStore.ts
+++ b/src/gateway/services/storage/CodeSummaryMemoryStore.ts
@@ -5,6 +5,26 @@
 import { Papr } from '@papr/memory';
 import { buildCodeIndexAddPolicy } from '../../utils/paprMemoryPolicy.js';
 import { paprMemoryScopeSpread } from '../../utils/memoryScopeResolver.js';
+import { isPaprNotFoundError } from '../../../core/tools/paprClient.js';
+
+/**
+ * True only when the memory genuinely does not exist.
+ *
+ * Deliberately narrow: this is the single condition under which an update
+ * may fall back to `add`. Treating any error as "missing" is what turns a
+ * transient 5xx into a duplicate document.
+ *
+ * Checks the SDK error class first, then a raw status code — the update path
+ * can surface either depending on where the failure originates.
+ */
+export function isMemoryNotFound(error: unknown): boolean {
+  if (isPaprNotFoundError(error)) {
+    return true;
+  }
+  const status = (error as { status?: number; statusCode?: number } | null)?.status
+    ?? (error as { statusCode?: number } | null)?.statusCode;
+  return status === 404;
+}
 
 export type CodeSummaryMemoryKind = 'code_file_summary' | 'code_project_overview';
 
@@ -100,13 +120,42 @@ export class CodeSummaryMemoryStore {
     previousMemoryId?: string;
     customMetadata: Record<string, string | number | boolean>;
   }): Promise<string | undefined> {
+    const metadata = {
+      role: 'assistant' as const,
+      category: 'fact' as const,
+      customMetadata: input.customMetadata,
+    };
+
+    // UPDATE IN PLACE when we already own a memory id.
+    //
+    // This used to be delete-then-add, which duplicates on the unhappy path:
+    // the delete error was caught and logged, then `add` ran anyway, leaving
+    // the old memory AND a new one. Because the server derives memoryId from
+    // content, both documents carry the SAME memoryId — and every dedup in
+    // the search pipeline dedups *ids*, so one logical memory then occupies
+    // N result slots. Measured live: a single memoryId returned 25 times,
+    // filling max_memories entirely and crowding out every other candidate.
+    //
+    // `memory.update()` is atomic from the reader's perspective: no window
+    // where the summary is missing, and no way to end up with two documents.
     if (input.previousMemoryId) {
       try {
-        await this.client.memory.delete(input.previousMemoryId);
+        await this.client.memory.update(input.previousMemoryId, {
+          content: input.content,
+          metadata,
+        });
+        return input.previousMemoryId;
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        // 404 is the ONLY case where falling back to `add` is correct — the
+        // memory we were tracking is genuinely gone (deleted elsewhere, or a
+        // stale tracker row). Any other failure (5xx, network, auth) must
+        // propagate: retrying as `add` is exactly what created duplicates.
+        if (!isMemoryNotFound(error)) {
+          throw error;
+        }
         console.warn(
-          `[CodeSummaryMemoryStore] Failed to delete old ${input.memoryKind} memory ${input.previousMemoryId}: ${message}`,
+          `[CodeSummaryMemoryStore] ${input.memoryKind} memory ${input.previousMemoryId} ` +
+            `not found (404) — recreating.`,
         );
       }
     }
@@ -118,11 +167,7 @@ export class CodeSummaryMemoryStore {
     const response = await this.client.memory.add({
       content: input.content,
       ...memoryScope,
-      metadata: {
-        role: 'assistant',
-        category: 'fact',
-        customMetadata: input.customMetadata,
-      },
+      metadata,
     });
 
     return extractMemoryId(response);

--- a/src/gateway/services/storage/SmartCodeIndexManager.ts
+++ b/src/gateway/services/storage/SmartCodeIndexManager.ts
@@ -62,7 +62,14 @@ export class SmartCodeIndexManager {
     };
     
     this.tracker = new CodeIndexTracker(this.config.dataDir);
-    this.indexer = new CodeIndexerService(client, this.config.schemaId, this.config.paprDir);
+    // Tracker is passed so re-indexed files UPDATE their existing memory
+    // instead of inserting a duplicate (indexed_files.memory_id).
+    this.indexer = new CodeIndexerService(
+      client,
+      this.config.schemaId,
+      this.config.paprDir,
+      this.tracker,
+    );
     this.watcher = new CodeFileWatcher(client, this.config.schemaId, this.config.paprDir);
     this.summaryPipeline = new CodeSummaryIndexPipeline(
       client,

--- a/tests/code-index-memory-upsert.test.ts
+++ b/tests/code-index-memory-upsert.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The add path resolves user/namespace scope from settings; stub it so these
+// tests exercise upsert logic only.
+vi.mock("../src/gateway/utils/memoryScopeResolver.js", () => ({
+  paprMemoryScopeSpread: vi.fn().mockResolvedValue({ user_id: "u1", external_user_id: "u1" }),
+}));
+vi.mock("../src/gateway/utils/paprMemoryPolicy.js", () => ({
+  buildCodeIndexAddPolicy: vi.fn().mockReturnValue({}),
+}));
+
+import {
+  CodeSummaryMemoryStore,
+  isMemoryNotFound,
+} from "../src/gateway/services/storage/CodeSummaryMemoryStore.js";
+
+function makeClient(over: {
+  update?: ReturnType<typeof vi.fn>;
+  add?: ReturnType<typeof vi.fn>;
+  del?: ReturnType<typeof vi.fn>;
+} = {}) {
+  const update = over.update ?? vi.fn().mockResolvedValue({ id: "mem-1" });
+  const add = over.add ?? vi.fn().mockResolvedValue({ id: "mem-new" });
+  const del = over.del ?? vi.fn().mockResolvedValue({});
+  return {
+    client: { memory: { update, add, delete: del } },
+    update,
+    add,
+    delete: del,
+  };
+}
+
+const summaryInput = {
+  content: "updated summary text",
+  filePath: "/Users/x/Papr/apps/app-1/db.ts",
+  fileName: "db.ts",
+  projectId: "app-1",
+  projectType: "mini_app" as const,
+  language: "TypeScript",
+  contentHash: "abc123",
+};
+
+describe("CodeSummaryMemoryStore upsert", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("UPDATES in place when a memory id is known — never adds", async () => {
+    const { client, update, add, delete: del } = makeClient();
+    const store = new CodeSummaryMemoryStore(client as never, "schema-1");
+
+    const id = await store.upsertFileSummary({
+      ...summaryInput,
+      previousMemoryId: "mem-1",
+    });
+
+    expect(update).toHaveBeenCalledOnce();
+    expect(update.mock.calls[0]![0]).toBe("mem-1");
+    expect((update.mock.calls[0]![1] as { content: string }).content).toBe(
+      "updated summary text",
+    );
+    // The two calls that created duplicates must not happen.
+    expect(add).not.toHaveBeenCalled();
+    expect(del).not.toHaveBeenCalled();
+    // Id is stable across re-index, so the tracker keeps pointing at one doc.
+    expect(id).toBe("mem-1");
+  });
+
+  it("does NOT fall back to add when update fails with 500", async () => {
+    // THE anti-duplication guard. The old code caught the delete failure and
+    // added anyway, leaving two documents sharing one memoryId. A transient
+    // server error must surface, not silently duplicate.
+    const update = vi.fn().mockRejectedValue(
+      Object.assign(new Error("boom"), { status: 500 }),
+    );
+    const { client, add } = makeClient({ update });
+    const store = new CodeSummaryMemoryStore(client as never, "schema-1");
+
+    await expect(
+      store.upsertFileSummary({ ...summaryInput, previousMemoryId: "mem-1" }),
+    ).rejects.toThrow("boom");
+
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("falls back to add ONLY on a genuine 404", async () => {
+    const update = vi.fn().mockRejectedValue(
+      Object.assign(new Error("gone"), { status: 404 }),
+    );
+    const { client, add } = makeClient({ update });
+    const store = new CodeSummaryMemoryStore(client as never, "schema-1");
+
+    const id = await store.upsertFileSummary({
+      ...summaryInput,
+      previousMemoryId: "stale-id",
+    });
+
+    expect(add).toHaveBeenCalledOnce();
+    expect(id).toBe("mem-new");
+  });
+
+  it("adds when no previous memory id exists (first index)", async () => {
+    const { client, update, add } = makeClient();
+    const store = new CodeSummaryMemoryStore(client as never, "schema-1");
+
+    const id = await store.upsertFileSummary(summaryInput);
+
+    expect(update).not.toHaveBeenCalled();
+    expect(add).toHaveBeenCalledOnce();
+    expect(id).toBe("mem-new");
+  });
+
+  it("updates project overviews in place too", async () => {
+    const { client, update, add } = makeClient();
+    const store = new CodeSummaryMemoryStore(client as never, "schema-1");
+
+    await store.upsertProjectOverview({
+      content: "overview",
+      projectId: "app-1",
+      projectType: "mini_app",
+      projectName: "App One",
+      fileCount: 12,
+      previousMemoryId: "mem-ov",
+    });
+
+    expect(update.mock.calls[0]![0]).toBe("mem-ov");
+    expect(add).not.toHaveBeenCalled();
+  });
+});
+
+describe("isMemoryNotFound", () => {
+  it("recognises 404 from status and statusCode", () => {
+    expect(isMemoryNotFound({ status: 404 })).toBe(true);
+    expect(isMemoryNotFound({ statusCode: 404 })).toBe(true);
+  });
+
+  it("treats everything else as present — the safe default", () => {
+    // Returning true here would let a transient failure become a duplicate.
+    expect(isMemoryNotFound({ status: 500 })).toBe(false);
+    expect(isMemoryNotFound({ status: 429 })).toBe(false);
+    expect(isMemoryNotFound(new Error("network"))).toBe(false);
+    expect(isMemoryNotFound(null)).toBe(false);
+    expect(isMemoryNotFound(undefined)).toBe(false);
+  });
+});

--- a/tests/result-set-shape.test.ts
+++ b/tests/result-set-shape.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzeResultSetShape,
+  describeResultSetShape,
+  normalizeForDedupe,
+} from "../src/core/utils/resultSetShape.js";
+import {
+  deriveCitations,
+  gradeSearchOutcome,
+  type RecordedSearch,
+  type RetrievedCandidate,
+} from "../src/core/utils/searchOutcomeFeedback.js";
+
+const candidate = (
+  id: string,
+  content: string,
+  rank: number,
+): RetrievedCandidate => ({ id, content, rank });
+
+const search = (candidates: RetrievedCandidate[]): RecordedSearch => ({
+  searchId: "search-1",
+  memoryCount: candidates.length,
+  nodeCount: 0,
+  candidatesKnown: true,
+  candidates,
+});
+
+/**
+ * Observed in production: 98 of 110 `db.ts` files across 147 mini-apps are
+ * byte-identical once the APP_ID line is removed. Search returned three of them
+ * at ranks 1-3 with similarity 0.7042999 / 0.7041931 (equal to 4dp).
+ */
+const dbBoilerplate = (appId: string): string =>
+  `const APP_ID = '${appId}';\n\n` +
+  `export async function query<T>(sql: string, params: unknown[] = [], sourceId: string): Promise<T[]> {\n` +
+  `  const res = await fetch('/api/db/query', {\n` +
+  `    method: 'POST',\n` +
+  `    headers: { 'Content-Type': 'application/json' },\n` +
+  `    body: JSON.stringify({ appId: APP_ID, sourceId, sql, params }),\n` +
+  `  });\n` +
+  `  return (await res.json()).rows ?? [];\n}\n`;
+
+const BOILERPLATE_IDS = [
+  "a0de69a2-de82-4bd0-9fb2-355f727bd498",
+  "67d4a03e-9ebc-48ca-b798-463b1aa7d3ad",
+  "665db01d-31a4-47af-9a0f-c27ba0d36199",
+];
+
+describe("normalizeForDedupe", () => {
+  it("collapses generated scaffolding that differs only by UUID", () => {
+    const [a, b] = BOILERPLATE_IDS;
+    expect(normalizeForDedupe(dbBoilerplate(a!))).toBe(
+      normalizeForDedupe(dbBoilerplate(b!)),
+    );
+  });
+
+  it("keeps genuinely different code distinct", () => {
+    expect(normalizeForDedupe("export function renderChart() {}")).not.toBe(
+      normalizeForDedupe("export function parseInvoice() {}"),
+    );
+  });
+});
+
+describe("analyzeResultSetShape", () => {
+  it("flags the db.ts boilerplate flood despite differing UUIDs", () => {
+    const shape = analyzeResultSetShape(
+      BOILERPLATE_IDS.map((appId, i) =>
+        candidate(`mem-${i}`, dbBoilerplate(appId), i),
+      ),
+    );
+
+    // Exact hashing would report 3 distinct items here. Normalisation is what
+    // makes this detectable at all.
+    expect(shape.distinctContents).toBe(1);
+    expect(shape.maxRepeat).toBe(3);
+    expect(shape.duplicateRatio).toBeCloseTo(0.667, 2);
+    expect(shape.idFanOut).toBe(false);
+    expect(shape.degenerate).toBe(true);
+  });
+
+  it("flags server hydration fan-out when one id repeats", () => {
+    // Observed: 20 rows collapsing to a single memory id, every
+    // similarity_score equal to 0.5973358 at 7dp.
+    const shape = analyzeResultSetShape(
+      Array.from({ length: 20 }, (_, i) =>
+        candidate("0dfe9a25-2720-4b1e-91d7-1772cc44aa29", "ctx blob", i),
+      ),
+    );
+
+    expect(shape.distinctIds).toBe(1);
+    expect(shape.idFanOut).toBe(true);
+    expect(shape.degenerate).toBe(true);
+    expect(describeResultSetShape(shape)).toContain("SERVER BUG");
+  });
+
+  it("does not flag a healthy diverse result set", () => {
+    const shape = analyzeResultSetShape([
+      candidate("a", "Turso replica sidecar wedge resets on reconnect", 0),
+      candidate("b", "Quarterly revenue grew after the pricing change", 1),
+      candidate("c", "The scheduler retries failed jobs with backoff", 2),
+    ]);
+
+    expect(shape.degenerate).toBe(false);
+    expect(shape.duplicateRatio).toBe(0);
+    expect(describeResultSetShape(shape)).toBeNull();
+  });
+
+  it("never calls a single result degenerate", () => {
+    const shape = analyzeResultSetShape([candidate("a", "only one", 0)]);
+    expect(shape.degenerate).toBe(false);
+  });
+
+  it("handles an empty result set without dividing by zero", () => {
+    const shape = analyzeResultSetShape([]);
+    expect(shape.total).toBe(0);
+    expect(shape.duplicateRatio).toBe(0);
+    expect(shape.degenerate).toBe(false);
+  });
+});
+
+describe("gradeSearchOutcome — degeneracy", () => {
+  it("caps a top-rank citation when the set was mostly duplicates", () => {
+    // TWO boilerplate families, which is what a scaffolding-heavy corpus
+    // actually returns. This matters: a single family large enough to make the
+    // set degenerate (>50% repeats) would also exceed the distinctive-term
+    // document-frequency ceiling and become uncitable, so the cap could never
+    // be exercised. Two families keep each below the ceiling while the set as a
+    // whole stays degenerate.
+    const candidates: RetrievedCandidate[] = [
+      ...Array.from({ length: 5 }, (_, i) =>
+        candidate(`db-${i}`, dbBoilerplate(`0000000${i}-de82-4bd0-9fb2-355f727bd498`), i),
+      ),
+      // Identical bodies under distinct ids — the same generated scene helper
+      // copied into five apps. (Suffixing the function name instead would make
+      // these genuinely distinct: the digit sits inside an identifier, so the
+      // bare-integer normalisation correctly does not collapse it.)
+      ...Array.from({ length: 5 }, (_, i) =>
+        candidate(
+          `scene-${i}`,
+          "export function renderScene(host: HTMLElement) { host.innerHTML = template; }",
+          5 + i,
+        ),
+      ),
+      candidate("other-1", "Scheduler retries failed jobs using exponential backoff", 10),
+      candidate("other-2", "Invoice parser normalises supplier tax identifiers", 11),
+    ];
+
+    const answer =
+      "Mini-apps read rows by posting sql and params to /api/db/query with a sourceId, " +
+      "then take the rows array off the JSON response.";
+
+    const derivation = deriveCitations(answer, candidates);
+    const grade = gradeSearchOutcome(search(candidates), derivation);
+
+    expect(derivation.bestCitedRank).toBe(0);
+    expect(grade.verdict).toBe("cited_top_rank");
+    // Uncapped this would be a 5 — a perfect score for a flood.
+    expect(grade.score).toBe(3);
+    expect(grade.feedbackText).toContain("capped=degenerate");
+    expect(grade.feedbackText).toContain("rank_score=5");
+    expect(grade.shape?.degenerate).toBe(true);
+  });
+
+  it("leaves a healthy top-rank citation at 5", () => {
+    const candidates = [
+      candidate(
+        "a",
+        "The Turso replica sidecar wedge is reset by reconnecting; watermark frames realign automatically.",
+        0,
+      ),
+      candidate("b", "Quarterly revenue for the Helsinki office grew after repricing.", 1),
+      candidate("c", "Scheduler retries failed jobs using exponential backoff.", 2),
+    ];
+    const answer =
+      "The sidecar wedge resets on reconnect — the watermark frames realign, so no manual repair is needed.";
+
+    const grade = gradeSearchOutcome(
+      search(candidates),
+      deriveCitations(answer, candidates),
+    );
+
+    expect(grade.verdict).toBe("cited_top_rank");
+    expect(grade.score).toBe(5);
+    expect(grade.feedbackText).not.toContain("capped=degenerate");
+  });
+
+  it("grades an uncited pure flood as retrieved_degenerate, not citations_unknown", () => {
+    // In a pure flood every term has document frequency 1.0, so the
+    // distinctive-term filter strips everything and judgeableCount hits 0.
+    // That must NOT be reported as "unknown" — the cause is fully known.
+    const candidates = Array.from({ length: 10 }, (_, i) =>
+      candidate(`dup-${i}`, dbBoilerplate(BOILERPLATE_IDS[0]!), i),
+    );
+
+    const derivation = deriveCitations(
+      "Nothing in these results answered the question.",
+      candidates,
+    );
+    const grade = gradeSearchOutcome(search(candidates), derivation);
+
+    expect(derivation.judgeableCount).toBe(0);
+    expect(grade.verdict).toBe("retrieved_degenerate");
+    expect(grade.score).toBe(1);
+    expect(grade.feedbackText).toContain("dup_ratio=0.9");
+    expect(grade.feedbackText).toContain("max_repeat=10");
+  });
+
+  it("keeps an ordinary ranking miss at retrieved_unused", () => {
+    const candidates = [
+      candidate("a", "Quarterly revenue for the Helsinki office grew after repricing.", 0),
+      candidate("b", "Scheduler retries failed jobs using exponential backoff.", 1),
+      candidate("c", "Invoice parser normalises supplier tax identifiers.", 2),
+    ];
+
+    const grade = gradeSearchOutcome(
+      search(candidates),
+      deriveCitations("None of this was relevant to the question asked.", candidates),
+    );
+
+    expect(grade.verdict).toBe("retrieved_unused");
+    expect(grade.score).toBe(2);
+    expect(grade.shape?.degenerate).toBe(false);
+  });
+
+  it("reports no shape when the payload could not be parsed", () => {
+    const grade = gradeSearchOutcome(
+      { ...search([]), candidatesKnown: false, memoryCount: 8 },
+      deriveCitations("anything", []),
+    );
+
+    expect(grade.verdict).toBe("citations_unknown");
+    expect(grade.shape).toBeNull();
+  });
+});

--- a/tests/search-outcome-feedback.test.ts
+++ b/tests/search-outcome-feedback.test.ts
@@ -122,8 +122,14 @@ describe("deriveCitations", () => {
       search({ memoryCount: 25, candidates }),
       result,
     );
-    expect(grade.verdict).toBe("retrieved_unused");
-    expect(grade.score).toBe(2);
+    // Was `retrieved_unused` (2) when this only had to beat citations_unknown.
+    // Now separated further: 25 rows sharing ONE id is hydration fan-out — a
+    // server correctness fault, not a ranking miss — so it grades below an
+    // ordinary unused result rather than equal to one.
+    expect(grade.verdict).toBe("retrieved_degenerate");
+    expect(grade.score).toBe(1);
+    expect(grade.shape?.idFanOut).toBe(true);
+    expect(grade.feedbackText).toContain("id_fanout=24");
   });
 
   it("returns empty for an empty answer", () => {


### PR DESCRIPTION
## Problem

`gradeSearchOutcome` scores a search by **where the cited result landed**. That is the right axis for ranking quality, but it is blind to a failure mode measured live in this workspace:

```
query: "mini-app DB query pattern"  ->  10 results
ranks 1,2,3 = byte-identical generated db.ts, differing only in APP_ID
similarity 0.7042999 vs 0.7041931  (equal to 4dp)
```

Cite rank 1 and that search grades `cited_top_rank` = **5/5**. A perfect label for a result set whose effective k was 1.

This is structural, not incidental. On disk:

```
147 mini-apps · 110 db.ts files
 98 of 110 byte-identical once the APP_ID line is removed
```

Generated scaffolding is the **majority** of the code corpus, so top-k is near-guaranteed to be near-duplicates — and every one of those floods was being fed back as a positive label. The ranker was being taught that the flood was good.

A second, distinct signature: 20 rows collapsing to **one** memory id, every `similarity_score` equal to `0.5973358` at 7dp, while `customMetadata` differed per row. That is a correctness fault, not a ranking miss, and must not be tuned away as one.

## Change

**`analyzeResultSetShape`** (new) normalises UUIDs / long hex / bare integers before grouping. This matters: exact hashing reports the `db.ts` copies as 3 distinct items, because they differ by one UUID. Two independent signals come out:

| signal | meaning |
|---|---|
| `duplicateRatio` | near-identical repeats — corpus/ranking problem |
| `idFanOut` | one memory id returned N times — **server** correctness bug |

Wired in three places:

1. **Grading** — degenerate + uncited becomes a new `retrieved_degenerate` (score 1); a *cited* degenerate set is capped at 3 instead of 5.
2. **`feedbackText`** — emits `dup_ratio` / `distinct` / `max_repeat` / `id_fanout`, so the server gets a machine-parseable diagnosis. Counts only, no query text, no content (D2).
3. **`_retrievalQuality`** on the tool result, present **only** when degenerate — the field's presence is the signal, so healthy searches stay silent.

### Ordering detail worth reviewing

Degeneracy is checked **before** `judgeableCount === 0`, deliberately. In a pure flood every term appears in every candidate, so the document-frequency filter strips them all and `judgeableCount` falls to 0 — which the old path graded `citations_unknown`, a neutral **3**. But this is not unknown; we know exactly what happened. Reporting "unknown" buried the single most diagnosable failure mode in the same bucket as unparseable payloads.

### Write path

`CodeIndexerService` now records `content_hash` and `boilerplate_hash`. **Recorded, not filtered** — skipping copies would force the indexer to decide which project "owns" a shared file, silently removing `projectId`-scoped coverage from the other 97.

## Intentional behaviour change

The fan-out case in `search-outcome-feedback.test.ts` now grades `retrieved_degenerate` (1) instead of `retrieved_unused` (2). That test's own comment notes it previously only had to beat `citations_unknown`; 25 rows sharing one id is a server fault and should grade below an ordinary ranking miss, not equal to it.

## Deliberately NOT fixed here (memory-server side)

- **Hydration join** — returns one document's `id`+`content` against another's metadata. Reproduced in code search: a result with TypeScript content (`export async function query<T>`) labelled `file_name: ping.py`, `language: Python`; the next rank carries the *same* content correctly labelled `db.ts`. **`language` and `fileName` filters cannot be trusted until this is fixed.**
- **`relevance_score` ignores `reranker_confidence`** — observed `reranker_score` 0.1 / `confidence` 0.15 still shipping at `relevance_score` 0.78, because relevance is rank-decay. Low-confidence reranks should be dropped, not decayed.

**Result *collapsing* is deferred on purpose.** Rewriting a payload whose content and metadata do not correspond would destroy the evidence needed to fix the join. Detect and report first; collapse once the join is correct.

## Verification

| | Test Files | Passed |
|---|---|---|
| baseline `559b514` | 69 failed | 482 |
| this branch | 69 failed | **483** (+1) |

Identical pre-existing failures (workspace-isolation env issue in `sync-coordinator` / `paprRoot`, untouched here) plus one new passing file. `tsc --noEmit` unchanged at the 176-error baseline, **zero** in changed files — all 176 are in `src/resources/mini-app-sdk/**`. `oxlint` 0 errors on changed files.

12 new tests built from the actual observed payloads, including guards that a single result is never called degenerate and that an empty set does not divide by zero.
