### PR TITLE
Fix the Claude OAuth credential path, a locked-replica dashboard, a Turso push livelock, and per-chat model controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5020,6 +5020,37 @@ Claude Code stores all three fields (`accessToken`, `refreshToken`, `expiresAt`)
 
 ---
 
+### Issue 80: "Today's Brief" Showed "database is locked" — The Missing `busy_timeout` ✅ FIXED
+**Added:** 2026-09-07
+**Problem:** Clicking Home hung on "Loading today's brief" and surfaced `database is locked`. Startup logs also repeated `[TursoReplicaCutover] Startup migration repair failed … database is locked` and `Migration 0002_feed_schema is in schema_migrations but missing on the replica handle — re-applying` on **every** launch.
+**Root Cause:** A lock was treated as a permanent error at every layer it reached.
+1. **Nothing waited.** `connectTursoReplica` passes no busy timeout, and its retry ladder fires only for `isTursoHostNotReadyError`. Every `better-sqlite3` path in the repo waits out a contended file (3s on the mini-app read worker, 5s on the CDC writer); the replica engine had no equivalent, so a read landing during a push or migration failed on its first attempt.
+2. **The one retry that existed didn't recognise it.** `runQuery` recovers only when `isReplicaReadTransportError` matches — checkpoint errors, `timed out after`, `REPLICA_GEN_DRIFT`. `"database is locked"` matches none, so it rethrew immediately, through `DbRouter` → `/api/db/query-batch` → `res.status(500).json({ error: message })` → `data.js`, which renders the raw string. That is the verbatim path from engine to your screen.
+3. **The startup repair gave up for the session.** A busy error was caught, `console.warn`ed, and abandoned with no retry and no state marked — so the ledger/schema drift the function exists to heal stayed in place and the same warning reappeared next launch, forever.
+4. **The busy detector was too narrow to fire.** `isSqliteBusyError` checked only `code === "SQLITE_BUSY"`. Two engines touch these files and only one sets a code: better-sqlite3 raises the code, `@tursodatabase/sync` surfaces a bare `"database is locked"`. So every "DB busy, defer and retry" branch (`TursoLinkedDbWatcher`, `workspaceLogSync`) silently never ran for replica-backed databases. A **second, correct** copy of the predicate already lived in `registryDbSchemaReader.ts` and matched the message.
+**The trap:** the obvious fix — adding `"database is locked"` to `isReplicaReadTransportError` — is wrong and destructive. That classifier's recovery calls `recoverReadWedge`, which closes the handle and **resets the sync sidecars**. Doing sidecar surgery because another operation briefly held the lock is the wrong remedy: a lock means the previous holder is mid-flight, so the fix is to wait. Contention and damage need separate classifiers, and a test pins them disjoint.
+**Solution:**
+1. `isReplicaBusyError` — a distinct classifier for contention (`database is locked`, `database table is locked`, `sqlite_busy`), deliberately *not* wired into wedge recovery.
+2. `retryWhileReplicaBusy` (`replicaBusyRetry.ts`) — the missing `busy_timeout`: 5 attempts over ~2.4s, in the same range as the better-sqlite3 read path's 3s, well under `REPLICA_OPERATION_TIMEOUT_MS`. Retries **only** on a lock; anything else propagates on the first attempt. Waiting inside the caller's scheduler slot is intentional — that is what `busy_timeout` does too (it blocks the connection rather than yielding it). Applied to `runQuery` and `runSchema`.
+3. **Startup repair retries.** Databases that failed *only* because they were locked are collected and re-attempted (2 rounds, 30s apart) instead of abandoned, so the drift actually heals rather than re-logging every launch. A non-lock failure still reports immediately.
+4. **One busy detector.** Moved into `tursoReplicaErrors.ts` (the native-import-free classifier module, reachable from the sync worker), broadened to match code **or** message, re-exported from `tursoSyncBridgeCore` for existing importers, and the duplicate in `registryDbSchemaReader.ts` deleted.
+**Changed an existing assertion — deliberately.** `tests/turso-sync-bridge.test.ts` asserted `isSqliteBusyError(new Error("database is locked")) === false`. It carried no rationale and arrived inside a large squashed commit, so it pinned the implementation rather than a requirement — and it was wrong: the later sibling implementation matched the message, and every consumer uses this predicate to decide "defer and retry". Corrected, with the reasoning recorded in the test.
+**Files Created:** `src/gateway/services/tursoReplica/replicaBusyRetry.ts`, `tests/replica-busy-retry.test.ts` (15 tests)
+**Files Changed:** `tursoReplicaErrors.ts`, `TursoReplicaService.ts`, `cutover/tursoReplicaCutoverMigrationAuthority.ts`, `tursoSyncBridgeCore.ts`, `jobs/registryDbSchemaReader.ts`, `tests/turso-sync-bridge.test.ts`
+**Prevention:** Two engines on one file need one busy predicate, and it cannot key on a field only one of them sets. When a retry classifier's recovery has side effects, do not widen it — a transient condition and a damaged one need different remedies even though both surface as an error string. And an error that is retryable must be *recognised* as retryable at the layer that owns the retry; a wait budget nothing consults is not a wait.
+
+---
+
+### Issue 81: Duplicate React Keys in Related Memories ✅ FIXED
+**Added:** 2026-09-07
+**Problem:** `Encountered two children with the same key` from `RelatedMemoriesPanel`, `WikiEntityPage`, `WikiLibrary`, and `MemoryView`.
+**Root Cause:** Papr search returns a memory **once per matching chunk**, so `_fetchRelatedMemories` emitted the same `id` several times. The UI keys the list by `id` *and* resolves "which one is open" with a find-by-id, so a repeat broke reconciliation and made the lookup ambiguous. A data defect, not a rendering one — fixing it at the `key` would have hidden it.
+**Solution:** `toRelatedMemories()` keeps the first hit per id (search returns strongest-first, so the best match wins), drops hits with no id or no content, and coerces the untyped payload's fields. Deduped at the source so every consumer benefits.
+**Files Changed:** `src/gateway/services/KnowledgeGraphWikiService.ts`; `tests/wiki-related-memories.test.ts` (8 tests)
+**Prevention:** A React key warning names the symptom, not the bug. If a list is keyed by an id that also serves as a lookup key, uniqueness is a data invariant — enforce it where the data is produced.
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**
 
 ### Issue 79: A Render Error Wiped the Composer and Looked Like an App Reload ✅ FIXED

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4964,4 +4964,35 @@ That assumption holds only while the server list is the *whole* history. It isn'
 
 ---
 
+### Enhancement 77: Per-Chat Model Controls — Thinking, Fast, Context, Effort ✅ IMPLEMENTED
+**Added:** 2026-09-07
+**Problem:** The four things that decide what a turn costs were all unreachable from the composer, so a chat ran at whatever the model advertised. On a 1M-window model the history budget computes to ~636K tokens, and everything inside that budget is re-sent on **every step** of a turn that can run to 100 steps. Console usage for Sep 2–6 sits almost entirely in the `200k – 1M` bucket.
+**Not the cause:** the window is not a price *tier* — Anthropic dropped the >200K surcharge in March 2026. But input is billed per token, so the window is a spend dial either way.
+**Root Causes:** Three separate gaps, only one of which was a missing UI:
+1. **Effort was expressed as a separate model per level.** `gpt-5-6-sol-low` / `gpt-5-6-sol` / `gpt-5-6-sol-high` are one API model with three `reasoning.effort` values, and the picker listed all three as if they were different models — advertising packaging as capability while leaving the parameter itself unreachable.
+2. **No context cap existed** anywhere in `AgentConfig`, so `computeHistoryTokenBudget` had nothing to narrow against.
+3. **Thinking had no off switch**, even on the providers whose request carries one.
+**Solution:** One popover on the composer pill, governed by a single rule — **a row appears only when the request can actually carry it**. Capability is derived from the model (`ui/constants/modelControls.ts`) rather than hand-listed, because a switch wired to nothing is worse than no switch. Context options are **200K / 400K / 1M defaulting to 200K**; defaulting low is the part that saves money. Effort variants collapse into base + effort (picker: ~11 rows → ~7) with migration on both the visible list and each chat's stored settings.
+**Two traps worth naming:**
+- **`thinkingBudget: 0` cannot mean "thinking off."** Opus 5 and Fable 5.1 ship `defaultThinkingBudget: 0` and still think adaptively, so overloading it would have silently disabled reasoning on exactly the models people reach for it on. The off state is its own field: `AgentConfig.thinking?: false`, only ever `false`, absent meaning "provider default".
+- **Anthropic `effort` is an adaptive-thinking field.** Sonnet 4.6 / Haiku 4.5 / Opus 4.6 take `{type:"enabled", budgetTokens}` and have no effort field. UI gate and gateway gate call the *same* predicate (`anthropicModelUsesAdaptiveThinking`) instead of mirroring a list. `max` is offered only on Fable and Opus 5, matching the gateway's own `xhigh -> max` promotion.
+**Context is a cap, never a widener:** `resolveEffectiveContextWindow` = `min(modelWindow, max(userCap, 128K))`. The 128K floor exists because a turn carries ~86K of tool schemas before any conversation; a lower cap leaves no room for the history it is meant to be budgeting.
+**Files Created:**
+- `ui/constants/modelControls.ts`, `ui/utils/chatModelSettings.ts`, `ui/utils/buildAgentConfig.ts`
+- `ui/components/Chat/ModelSettingsPopover.tsx` / `.css`, `ui/components/Chat/ModelSettingsButton.tsx`
+- `tests/model-controls.test.ts` — 40 tests
+- `docs/PER_CHAT_MODEL_CONTROLS.md`
+**Files Changed:**
+- `src/core/types/agents.ts` — `contextLimit`, `thinking?: false`, `speed`
+- `src/gateway/services/agent/contextBudget.ts` — `resolveEffectiveContextWindow`
+- `src/gateway/services/AgentService.ts` — honour all four on the AI SDK route
+- `src/gateway/services/providers/piAiAnthropicAdaptiveThinking.ts` — off switch on the OAuth route
+- `ui/constants/modelPicker.ts`, `ui/components/Chat/{ChatContainer,InputBar,ModelPickerDropdown}.tsx`, `ui/hooks/useChat.ts`, `ui/stores/chatStore.ts`
+**Drift guards:** `MODEL_CONTEXT_WINDOWS` restates the gateway's `ModelFallback` (the renderer cannot import it — its relative imports carry `.js` specifiers Vite will not resolve back to `.ts`), and a test asserts every entry equals `ModelFallback.getModelInfo(id).contextWindow`.
+**Prevention:** Do not express a parameter as a separate model id. Do not overload a numeric default (`0`) to mean "off" when the provider already uses that value as a real default. And before wiring a control, confirm the SDK accepts the field — a toggle whose value is silently dropped is worse than no toggle.
+**Related:** Issue 74 (per-chat model scoping — same persistence pattern, and the reason a per-chat read never falls back to a global), Enhancement 51 (tool result truncation — the other half of what a step re-sends)
+**See:** `docs/PER_CHAT_MODEL_CONTROLS.md`
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5021,3 +5021,24 @@ Claude Code stores all three fields (`accessToken`, `refreshToken`, `expiresAt`)
 ---
 
 **This file is living documentation. Update it as we learn and make decisions.**
+
+### Issue 79: A Render Error Wiped the Composer and Looked Like an App Reload ✅ FIXED
+**Added:** 2026-09-07
+**Problem:** A render-time throw in one chat tab blanked the whole window and destroyed a half-typed message. Separately, `ChatContainer` logged `Maximum update depth exceeded` continuously while a mini-app tab was in use.
+**Three defects, only one of which was the crash:**
+1. **Nothing contained a render error.** With no error boundary anywhere in the tree, React unmounted the entire app on any throw — indistinguishable from a reload. React's own console output said as much (`Consider adding an error boundary`) and it had never been acted on.
+2. **The draft existed in exactly one place, and it was volatile.** `draftByChatId` was an in-memory `Map` in `chatStore`. Unsent text is the only chat state with no other copy — messages come back from the server, a half-typed message does not — so a reload, a renderer crash, or `resetForWorkspaceSwitch()` took it with them.
+3. **An infinite render loop.** `useModelPickerSettings` returned `pickerModels: getPickerModels(enabledIds)` — a new array identity every render. `ChatContainer` has an effect depending on it, so that effect re-ran every render, and inside it `setModelSettings(readChatSettings(chatId))` set a **freshly built object** every time. New identity in, state change reported out, render, repeat. The loop needed both halves; either alone is inert, which is why this only surfaced once the model-settings effect was added.
+**Not the cause:** the reported `ReferenceError: EFFORT_VARIANT_MODELS is not defined` was an HMR artifact — a partially-applied module graph mid-update, at `?t=1788797208544`. The imports are correct and the production build is clean. Chasing it would have fixed nothing; the app should not die on *any* render throw, whatever its origin.
+**Solution:**
+1. **`PaneErrorBoundary` around every pane** (`ContentArea`), keyed on `paneKey` so switching tabs clears a previous error rather than pinning it. Shows a retry card and states the draft is safe.
+2. **`chatDraftStore`** — durable per-chat drafts in `localStorage`, written on the debounce that already fed the map, with LRU eviction (50 chats), a 100K per-draft cap, and quota/corruption handled by degrading to memory-only. `getDraftMessage` falls back to it, so `InputBar`'s lazy `useState` seed repaints a surviving draft instead of an empty box. A `pagehide` listener plus an unmount flush closes the 300ms debounce window. Renamed on temp→permanent id (reachable: typing a second message while the first streams) and forgotten on delete.
+3. **Break the loop at both ends** — `useMemo` on `pickerModels`, and a `sameSettings` bail-out in the `setModelSettings` updater. Fixing only one end would leave the other as a live trap for the next effect added.
+**Files Created:**
+- `ui/utils/chatDraftStore.ts`, `ui/components/Layout/PaneErrorBoundary.tsx` / `.css`
+- `tests/chat-draft-store.test.ts` (21), `tests/render-loop-invariants.test.ts` (10), `ui/__tests__/hooks/useModelPickerSettings.test.tsx` (3)
+**Files Changed:**
+- `ui/stores/chatStore.ts` — durable drafts; side effects moved out of the `set` updater to keep it pure
+- `ui/components/Chat/InputBar.tsx`, `ui/hooks/useChat.ts`, `ui/hooks/useModelPickerSettings.ts`, `ui/components/Chat/ChatContainer.tsx`, `ui/components/Layout/ContentArea.tsx`, `ui/utils/chatModelSettings.ts`
+**Prevention:** A React tree with no error boundary treats every render throw as fatal to the whole app. State the user typed and has not sent needs a durable copy — it is the only state you cannot re-fetch. And an effect that both depends on a value and re-derives it must compare by content: a fresh object read is never reference-equal, so `setState` from one always reports a change.
+**Related:** Issue 75 (chat pane stranded after a store wipe), Issue 74 (per-chat model scoping), Enhancement 77 (per-chat model controls — the effect that completed the loop)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4995,4 +4995,29 @@ That assumption holds only while the server list is the *whole* history. It isn'
 
 ---
 
+### Issue 78: Claude OAuth 401s — A Fabricated Token Lifetime ✅ FIXED
+**Added:** 2026-09-07
+**Problem:** Switching Claude from an API key to OAuth produced `OAuth access token is invalid.` on the next turn, while Settings reported **Connected · Expires in 360d**.
+**Root Cause:** Adopting Claude Code's credentials read only `accessToken` and then *invented* the other two fields — `refreshToken` was set to a copy of the access token, and `expiresIn` to a flat 365 days. Claude Code's access token lasts about **8 hours**, so requests began failing the same day. Neither recovery path could fire:
+1. `isTokenExpired()` never returned true, because the invented year had not elapsed.
+2. Had it fired, the refresh grant would have posted an *access* token as a refresh token, which can only fail.
+
+Claude Code stores all three fields (`accessToken`, `refreshToken`, `expiresAt`). We were reading one of them.
+**Solution:** Parse the credentials as stored, in one place. `src/core/services/claudeCliCredentials.ts` is a pure module answering two questions: is this refresh token actually redeemable (`isUsableRefreshToken` rejects the echoed-token shape, and the whitespace-only case a failing test caught), and when does this really expire. Used at the three sites that previously fabricated a lifetime. A pasted setup token — which genuinely has no refresh token — is still accepted.
+**Self-healing:** installs already holding a fabricated record repair themselves. `refreshTokenIfNeeded` re-reads Claude Code's storage and adopts its current refresh token and expiry rather than waiting for an expiry that never arrives. No disconnect/reconnect needed.
+**The badge could not be honest without the data fix:** it showed a countdown while every request 401'd. The renderer already sees that error when a turn fails, so no new network call or IPC was needed — `useAgent` records it against the provider (`providerAuthStore`) and the AI Models card swaps the countdown for **Reconnect needed** plus a Reconnect button. Cleared on the next successful turn, or on reconnect/disconnect. Deliberately **not persisted**: it records a rejection we *observed*, so after a restart we hold no evidence and should not claim any.
+**Files Created:**
+- `src/core/services/claudeCliCredentials.ts` — credential parsing + lifetime derivation
+- `ui/utils/providerAuthRejection.ts` — `isProviderAuthRejection`, shared with `useAgent`'s existing 401 branch so the two cannot drift on what counts as an auth failure
+- `ui/stores/providerAuthStore.ts` — transient rejection record
+- `tests/claude-cli-credentials.test.ts` (13), `tests/provider-auth-rejection.test.ts` (10)
+**Files Changed:**
+- `src/core/services/ClaudeSetupTokenService.ts` — `readCredentialsFromCLIStorage`
+- `src/electron/ipc/oauth.ts` — the three fabrication sites, plus repair-on-refresh
+- `ui/hooks/useAgent.ts`, `ui/components/Settings/OAuthSection.tsx`, `ui/components/Settings/SettingsView.css`
+**Prevention:** Never invent a value you could read. A fabricated expiry does not just fail — it disables the recovery that would have caught the failure, and it makes the UI confidently wrong. If a field is unknown, model it as absent rather than as a plausible-looking default.
+**Related:** Enhancement 63 (Claude CLI curl installer), Issue 65 (pi-ai OAuth path)
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3630,6 +3630,30 @@ if (delegationCardMap.size > 0) {
 
 ---
 
+### Issue 77: Spent Quota Reported as a Transient Rate Limit ✅ FIXED
+**Added:** 2026-09-10
+**Problem:** A message failed with "The AI provider is rate limited. Tap Resume when ready to continue." The real cause was an Anthropic spend cap — "You have reached your specified API usage limits. You will regain access on 2026-10-01 at 00:00 UTC" — and separately a claude.ai weekly quota at 100%. Switching OAuth → API key changed nothing, because both were exhausted for different reasons and the app described both the same way.
+**Root Causes:**
+1. **The provider's explanation was discarded.** `createRateLimitExhaustedError()` took no arguments and returned a fixed string. At all four raise sites in `PiCodexStreamWithToolLoop.ts` the real error was in scope (`err`, `apiError`, `chunk.error`) and dropped.
+2. **Spent allowance was classified as capacity pressure.** Anthropic returns both a per-minute burst limit and a monthly spend cap as HTTP 429 with `type: "rate_limit_error"`, so the status code cannot separate them — only the sentence can. `isRetryableProviderCapacityError` matched on `429`/`rate limit`, so a cap clearing in three weeks got three attempts a second apart and then offered **Resume**, an affordance that could not work.
+3. **`collectErrorStrings` never parsed `responseBody`.** Anthropic's message lives in `error.message` inside that JSON, so the raw string matched substrings but could not be quoted back.
+**Solution:** `detectProviderQuotaExhaustion()` classifies a refusal as spent allowance (`api_spend_cap` | `api_credits` | `subscription_quota`), extracts the provider's sentence verbatim and a reset time, and returns null for anything waiting could fix. Quota refusals get their own code (`provider_quota_exhausted`) so `useAgent` withholds Resume and shows the composed message naming the limit, the reset and where to change it.
+**Design notes:**
+- **Transient signals win.** `per-minute`, `tokens per minute`, `concurrent` short-circuit to transient, because the two mistakes are not symmetric: calling a burst limit "spent" deletes a retry that works, while the reverse only wastes three attempts.
+- **Reset times must be anchored** to a reset word (`resets`, `regain access on`, or the `usage limit reached|<epoch>` pipe). An unanchored date scan would report an unrelated timestamp as the reset, and a confidently wrong date is worse than none.
+**Files Changed:** `src/gateway/utils/providerRateLimitRetry.ts`, `src/gateway/services/providers/PiCodexStreamWithToolLoop.ts`, `ui/hooks/useAgent.ts`, `tests/provider-quota-exhaustion.test.ts` (16 tests)
+**Prevention:** When a provider hands you a reason, pass it on — a fixed string thrown over a specific error turns a solvable problem into a mystery. Do not classify on a status code that two different conditions share. Only offer a retry affordance for something retrying can fix.
+
+### Issue 78: Refresh Tick Warned About a Healthy Token ✅ FIXED
+**Added:** 2026-09-10
+**Problem:** Every two minutes the log read `Not adopting Claude Code credentials: access token expired 2026-04-24…`, which users reasonably read as their own token having expired. It had not — the stored token showed "Expires in 362d" and was in use.
+**Root Cause:** Two credentials, and the message named neither. The user's stored token was healthy; *Claude Code's* Keychain copy had been dead since April. The CLI-adoption repair ran before the expiry check on every tick — necessarily, since a pasted setup token carries an assumed year-long expiry and so never *looks* expired, making adoption the only path that can ever upgrade it. So a token good for another year triggered a Keychain read and an expiry warning on a timer, while nothing was wrong.
+**Solution:** Keep the repair reachable but stop it being constant — attempt it once per session (tracked in `cliAdoptionAttempted`, cleared on connect and disconnect) plus whenever expiry genuinely approaches. Reworded the message to lead with whose token is unaffected and to name Claude Code's copy as the stale one.
+**Files Changed:** `src/electron/ipc/oauth.ts`
+**Prevention:** Reordering a guard is not free when the check below it is the only thing that repairs a case the check above can never detect. And when two credentials are in play, a log line must say which one it means — "expired" plus a date reads as an alarm about whichever one the user is thinking about.
+
+---
+
 **This file is living documentation. Update it as we learn and make decisions.**
 
 ### Issue 66: Telemetry Anonymous ID Mismatch ✅ FIXED

--- a/docs/PER_CHAT_MODEL_CONTROLS.md
+++ b/docs/PER_CHAT_MODEL_CONTROLS.md
@@ -1,0 +1,123 @@
+# Per-Chat Model Controls (Thinking, Fast, Context, Effort)
+
+**Added:** 2026-09-07
+
+## Why
+
+Four things decide what a turn costs, and none of them were reachable from the
+composer:
+
+1. **Context** was whatever the model advertised. On a 1M-window model the
+   history budget computes to ~636K tokens, and everything inside that budget is
+   re-sent on **every step** of a turn that can run to 100 steps. Anthropic
+   dropped the >200K surcharge in March 2026, so the window is not a price
+   *tier* — but input is billed per token, so it is a spend dial regardless.
+   Console usage for Sep 2–6 shows the overwhelming majority of tokens in the
+   `200k – 1M` bucket.
+2. **Effort** was expressed by shipping a *separate model per level*.
+   `gpt-5-6-sol-low` / `gpt-5-6-sol` / `gpt-5-6-sol-high` are one API model with
+   three `reasoning.effort` values, and the picker listed all three as if they
+   were different models.
+3. **Thinking** could not be turned off at all, even on the providers whose
+   request has a real off switch.
+4. **Fast** (Anthropic, ~2× rate) was not exposed anywhere.
+
+## The rule that shapes the UI
+
+**A row appears only when the request can actually carry it.** A switch wired to
+nothing is worse than no switch, so capability is derived from the model rather
+than hand-listed per control (`ui/constants/modelControls.ts`):
+
+| Control  | Offered when |
+|----------|--------------|
+| Thinking | Provider has a real off switch: Anthropic `thinking: {type:"disabled"}`, Google zero budget, Ollama `think: false`. **Not** OpenAI — reasoning is intrinsic there and effort is the only dial. |
+| Fast     | Anthropic **and** Opus-5 class **and** API key. pi-ai has no `speed` parameter, so it is hidden on OAuth. Labeled `2× cost`. |
+| Context  | More than one option fits inside the model's own window. |
+| Effort   | Provider carries a reasoning-effort field **and** thinking is on. On Anthropic, additionally only the *adaptive*-thinking models — see below. |
+
+### Anthropic effort is an adaptive-thinking field
+
+`effort` lives on Anthropic's adaptive thinking surface. The budget-thinking
+models (Sonnet 4.6, Haiku 4.5, Opus 4.6) take `{type: "enabled", budgetTokens}`
+and have no effort field, so offering the row there would send a parameter the
+request cannot carry. Both the UI gate and the gateway gate call the *same*
+predicate — `anthropicModelUsesAdaptiveThinking` — rather than mirroring a list.
+`max` is offered only on Fable and Opus 5, matching the gateway's own
+`xhigh -> max` promotion; Sonnet 5 tops out at `high`.
+
+### `thinkingBudget: 0` cannot mean "thinking off"
+
+Opus 5 and Fable 5.1 ship `defaultThinkingBudget: 0` and still think
+adaptively. So the off state is its own field — `AgentConfig.thinking?: false`,
+only ever `false`, absent meaning "provider default". Overloading the budget
+would have silently disabled reasoning on exactly the models people reach for it
+on.
+
+## Context is a cap, never a widener
+
+`resolveEffectiveContextWindow` takes `min(modelWindow, max(userCap, 128K))`:
+
+- Asking for 1M on a 200K model does not widen anything.
+- The 128K floor exists because a turn carries ~86K of tool schemas before any
+  conversation; a cap below that leaves no room for the history it is meant to be
+  budgeting and every turn would trim to the 8K floor.
+
+Options are **200K / 400K / 1M, defaulting to 200K**. Defaulting low is the part
+that saves money.
+
+## Picker collapse
+
+Effort variants are packaging, not models. `EFFORT_VARIANT_MODELS` unpacks each
+retired id into `{ modelId, effort }`, so a chat pinned to `gpt-5-6-sol-high`
+keeps running at high effort after the picker stops listing it as its own row.
+The picker drops from ~11 rows to ~7.
+
+Migration runs on two paths: `migratePickerModelId` for the visible list, and
+`adoptEffortFromVariant` for a chat's stored settings.
+
+## Persistence
+
+`ui/utils/chatModelSettings.ts`, same shape as `chatModelMemory`: per-`chatId`,
+bounded LRU, plus a separate `NEW_CHAT_DEFAULT_KEY` for what a *new* chat
+starts on. Per Issue 74, a read for a specific chat never falls back to the
+global value — that is how a previous chat's model leaked across chats.
+
+Settings are forgotten on chat delete (`useChat`) and carried across the
+temp→permanent id rename (`chatStore.migrateChatId`).
+
+## Files
+
+**New:**
+- `ui/constants/modelControls.ts` — capability derivation, variant unpacking, context table
+- `ui/utils/chatModelSettings.ts` — per-chat persistence
+- `ui/utils/buildAgentConfig.ts` — single place that turns model + settings into `AgentConfig`
+- `ui/components/Chat/ModelSettingsPopover.tsx` / `.css` — the popover
+- `ui/components/Chat/ModelSettingsButton.tsx` — the composer pill
+- `tests/model-controls.test.ts` — 40 tests
+
+**Changed:**
+- `src/core/types/agents.ts` — `contextLimit`, `thinking?: false`, `speed`
+- `src/gateway/services/agent/contextBudget.ts` — `resolveEffectiveContextWindow`
+- `src/gateway/services/AgentService.ts` — honour all four on the AI SDK route
+- `src/gateway/services/providers/piAiAnthropicAdaptiveThinking.ts` — off switch on the OAuth route
+- `ui/constants/modelPicker.ts` — collapse + migration
+- `ui/components/Chat/{ChatContainer,InputBar,ModelPickerDropdown}.tsx`
+
+## Drift guards
+
+Two copies exist for build reasons and both are pinned by tests:
+
+- `MODEL_CONTEXT_WINDOWS` restates the gateway's `ModelFallback` because the
+  renderer cannot import that module (its relative imports carry `.js`
+  specifiers Vite will not resolve back to `.ts`). A test asserts every entry
+  equals `ModelFallback.getModelInfo(id).contextWindow`.
+- The Anthropic effort gate is asserted on both sides against the same model
+  lists.
+
+## Prevention
+
+Do not express a parameter as a separate model id — the picker then advertises
+packaging as capability, and the parameter stays unreachable. Do not overload a
+numeric default (`0`) to mean "off" when a provider already uses that value as a
+real default. And before wiring a control, check the SDK actually accepts the
+field: a toggle whose value is silently dropped is worse than no toggle.

--- a/src/core/services/ClaudeOAuthService.ts
+++ b/src/core/services/ClaudeOAuthService.ts
@@ -26,7 +26,12 @@ export class ClaudeOAuthService {
     // Official Claude Code client ID (public client, supports loopback redirects)
     clientId: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
     authorizationUrl: "https://claude.ai/oauth/authorize",
-    tokenUrl: "https://claude.ai/api/oauth/token",
+    // The platform API, not the consumer web app. `claude.ai/api/oauth/token`
+    // sits behind Cloudflare's managed bot check, which answers a non-browser
+    // POST with a 403 and an HTML challenge page — so every background refresh
+    // failed and the connection expired with no way to renew itself. This is
+    // the endpoint pi-ai uses on the streaming path, where refresh works.
+    tokenUrl: "https://platform.claude.com/v1/oauth/token",
     // Claude Code uses http://localhost:{PORT}/callback (not 127.0.0.1, not /auth/callback)
     redirectUri: "http://localhost:1456/callback",
     scopes: "user:profile user:inference",
@@ -78,9 +83,58 @@ export class ClaudeOAuthService {
   }
 
   /**
+   * POST a grant to the token endpoint.
+   *
+   * The body is JSON, not form-urlencoded. RFC 6749 §4.1.3 does specify
+   * form encoding, but this endpoint expects JSON and pi-ai — whose refresh
+   * works today — sends JSON. Following the spec over the server cost us every
+   * token renewal, so match the server.
+   */
+  private async postTokenGrant(
+    grant: Record<string, string>,
+    label: string,
+  ): Promise<{
+    access_token: string;
+    refresh_token?: string;
+    expires_in: number;
+  }> {
+    const response = await fetch(this.config.tokenUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(grant),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    const body = await response.text();
+
+    if (!response.ok) {
+      // Truncated: a bot-challenge or gateway error page runs to tens of
+      // kilobytes of HTML, and dumping it into the log buries the one line
+      // that says what went wrong.
+      throw new Error(
+        `${label} failed: ${response.status} - ${body.slice(0, 400)}`,
+      );
+    }
+
+    try {
+      return JSON.parse(body) as {
+        access_token: string;
+        refresh_token?: string;
+        expires_in: number;
+      };
+    } catch {
+      throw new Error(
+        `${label} returned a non-JSON response: ${body.slice(0, 400)}`,
+      );
+    }
+  }
+
+  /**
    * Exchange authorization code for tokens
    * Note: Claude returns code and state as separate query parameters
-   * IMPORTANT: Must use application/x-www-form-urlencoded per OAuth 2.0 RFC 6749 Section 4.1.3
    */
   async handleCallback(
     code: string,
@@ -91,33 +145,26 @@ export class ClaudeOAuthService {
     if (state !== expectedState) {
       throw new Error("OAuth state mismatch - possible CSRF attack");
     }
-    // OAuth 2.0 RFC 6749 requires form-urlencoded, not JSON!
-    const params = new URLSearchParams({
-      code,
-      grant_type: "authorization_code",
-      client_id: this.config.clientId,
-      redirect_uri: this.config.redirectUri,
-      code_verifier: verifier,
-    });
-
-    const response = await fetch(this.config.tokenUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
+    const data = await this.postTokenGrant(
+      {
+        grant_type: "authorization_code",
+        client_id: this.config.clientId,
+        code,
+        // Sent alongside the code, matching pi-ai's working exchange.
+        state,
+        redirect_uri: this.config.redirectUri,
+        code_verifier: verifier,
       },
-      body: params.toString(),
-    });
+      "Token exchange",
+    );
 
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Token exchange failed: ${response.status} - ${error}`);
+    if (!data.refresh_token) {
+      // Fail loudly instead of storing a connection that can never renew
+      // itself — that silent gap is what produced 403s a day after connecting.
+      throw new Error(
+        "Token exchange succeeded but returned no refresh token; cannot establish a renewable connection",
+      );
     }
-
-    const data = (await response.json()) as {
-      access_token: string;
-      refresh_token: string;
-      expires_in: number;
-    };
 
     return {
       provider: "anthropic",
@@ -129,34 +176,16 @@ export class ClaudeOAuthService {
 
   /**
    * Refresh access token using refresh token
-   * IMPORTANT: Must use application/x-www-form-urlencoded per OAuth 2.0 RFC 6749
    */
   async refreshToken(refreshToken: string): Promise<OAuthTokenInput> {
-    // OAuth 2.0 RFC 6749 requires form-urlencoded, not JSON!
-    const params = new URLSearchParams({
-      grant_type: "refresh_token",
-      refresh_token: refreshToken,
-      client_id: this.config.clientId,
-    });
-
-    const response = await fetch(this.config.tokenUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
+    const data = await this.postTokenGrant(
+      {
+        grant_type: "refresh_token",
+        client_id: this.config.clientId,
+        refresh_token: refreshToken,
       },
-      body: params.toString(),
-    });
-
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Token refresh failed: ${response.status} - ${error}`);
-    }
-
-    const data = (await response.json()) as {
-      access_token: string;
-      refresh_token?: string;
-      expires_in: number;
-    };
+      "Token refresh",
+    );
 
     return {
       provider: "anthropic",

--- a/src/core/services/ClaudeSetupTokenService.ts
+++ b/src/core/services/ClaudeSetupTokenService.ts
@@ -6,6 +6,10 @@
 
 import { spawn, exec } from "child_process";
 import { promisify } from "util";
+import {
+  parseClaudeCliCredentials,
+  type ClaudeCliCredentials,
+} from "./claudeCliCredentials.js";
 
 const execAsync = promisify(exec);
 
@@ -348,6 +352,19 @@ export class ClaudeSetupTokenService {
    * - Linux: ~/.claude/.credentials.json
    */
   async readTokenFromCLIStorage(): Promise<string | null> {
+    const credentials = await this.readCredentialsFromCLIStorage();
+    return credentials?.accessToken ?? null;
+  }
+
+  /**
+   * Read Claude Code's full credential record, not just the access token.
+   *
+   * The refresh token and expiry live alongside the access token in the same
+   * blob. Callers that persist the token need all three: without the refresh
+   * token the copy cannot be renewed, and without the real expiry nothing
+   * knows when to try.
+   */
+  async readCredentialsFromCLIStorage(): Promise<ClaudeCliCredentials | null> {
     try {
       // Try platform-specific credential storage first
       if (process.platform === "darwin") {
@@ -362,18 +379,20 @@ export class ClaudeSetupTokenService {
             "security find-generic-password -s 'Claude Code-credentials' -w",
             { timeout: 5000 }
           );
-          
-          const credentialsJson = stdout.trim();
-          if (credentialsJson) {
-            const credentials = JSON.parse(credentialsJson);
-            const rawToken =
-              credentials?.claudeAiOauth?.accessToken ||
-              credentials?.accessToken;
-            if (rawToken && typeof rawToken === 'string') {
-              const token = rawToken.replace(/\s+/g, "");
-              console.log("[ClaudeSetupToken] Found token in Keychain (length: " + token.length + ")");
-              return token;
-            }
+
+          const credentials = parseClaudeCliCredentials(stdout);
+          if (credentials) {
+            console.log(
+              "[ClaudeSetupToken] Found credentials in Keychain " +
+                `(length: ${credentials.accessToken.length}, ` +
+                `refreshToken: ${credentials.refreshToken ? "yes" : "no"}, ` +
+                `expiresAt: ${
+                  credentials.expiresAt
+                    ? new Date(credentials.expiresAt).toISOString()
+                    : "unknown"
+                })`,
+            );
+            return credentials;
           }
         } catch (keychainError) {
           console.log("[ClaudeSetupToken] Could not read from Keychain:", (keychainError as Error).message);
@@ -390,11 +409,14 @@ export class ClaudeSetupTokenService {
       
       try {
         const content = await fs.readFile(credPath, "utf-8");
-        const credentials = JSON.parse(content);
-        
-        if (credentials.accessToken) {
-          console.log("[ClaudeSetupToken] Found token in ~/.claude/.credentials.json");
-          return String(credentials.accessToken).replace(/\s+/g, "");
+        // This file nests under claudeAiOauth like the Keychain entry does.
+        // Reading only a root-level accessToken missed it entirely, which is
+        // why the non-macOS paths never found a token.
+        const credentials = parseClaudeCliCredentials(content);
+
+        if (credentials) {
+          console.log("[ClaudeSetupToken] Found credentials in ~/.claude/.credentials.json");
+          return credentials;
         }
       } catch (fileError) {
         console.log("[ClaudeSetupToken] Could not read from ~/.claude/.credentials.json:", (fileError as Error).message);
@@ -404,15 +426,11 @@ export class ClaudeSetupTokenService {
       const tokenPath = `${homeDir}/.claude.json`;
       try {
         const content = await fs.readFile(tokenPath, "utf-8");
-        const config = JSON.parse(content);
+        const credentials = parseClaudeCliCredentials(content);
 
-        if (config.oauthAccount?.accessToken) {
-          console.log("[ClaudeSetupToken] Found token in ~/.claude.json");
-          return String(config.oauthAccount.accessToken).replace(/\s+/g, "");
-        }
-
-        if (config.accessToken) {
-          return String(config.accessToken).replace(/\s+/g, "");
+        if (credentials) {
+          console.log("[ClaudeSetupToken] Found credentials in ~/.claude.json");
+          return credentials;
         }
       } catch (jsonError) {
         console.log("[ClaudeSetupToken] Could not read from ~/.claude.json:", (jsonError as Error).message);

--- a/src/core/services/claudeCliCredentials.ts
+++ b/src/core/services/claudeCliCredentials.ts
@@ -120,6 +120,35 @@ export function isUsableRefreshToken(
 }
 
 /**
+ * Whether adopting these credentials would produce a connection that can
+ * actually authenticate — now or after a refresh.
+ *
+ * Connect short-circuits when it finds credentials in Claude Code's storage.
+ * Finding them is not the same as them working: an expired access token with
+ * no way to renew authenticates nothing, and adopting it puts the card back
+ * into the state the user pressed Connect to escape. Checking usability here
+ * is what lets Connect fall through to a real sign-in instead.
+ */
+export function claudeCredentialsAreUsable(
+  credentials: ClaudeCliCredentials,
+  now: number = Date.now(),
+): boolean {
+  // A usable refresh token can mint a new access token, so an expired access
+  // token is recoverable and worth adopting.
+  if (isUsableRefreshToken(credentials.refreshToken, credentials.accessToken)) {
+    return true;
+  }
+
+  // No refresh path, so the access token itself has to still be alive. An
+  // absent expiry means the source never told us one — a pasted setup token
+  // being the usual case — and those are assumed live, matching the fallback
+  // TTL callers already apply.
+  if (credentials.expiresAt === undefined) return true;
+
+  return credentials.expiresAt > now;
+}
+
+/**
  * Map credentials onto the fields `OAuthTokenStorage.storeToken` requires.
  *
  * `fallbackTtlSeconds` is only consulted when the source gave us no expiry, so

--- a/src/core/services/claudeCliCredentials.ts
+++ b/src/core/services/claudeCliCredentials.ts
@@ -148,6 +148,39 @@ export function claudeCredentialsAreUsable(
   return credentials.expiresAt > now;
 }
 
+/** Clock skew allowance so a token about to lapse is not treated as live. */
+export const CREDENTIAL_EXPIRY_SKEW_MS = 60_000;
+
+/**
+ * Whether the access token itself is still usable right now, ignoring any
+ * refresh token.
+ *
+ * This is deliberately stricter than `claudeCredentialsAreUsable`, and the two
+ * answer different questions. That one asks "could these ever authenticate?",
+ * where a refresh token counts because it can mint a new access token — the
+ * right test for deciding whether Connect should short-circuit.
+ *
+ * Adoption asks something else: "will replacing what I already hold with this
+ * leave me better off?" There a refresh token earns nothing, because the only
+ * moment adoption runs as recovery is immediately after a refresh token was
+ * rejected. Counting a second unproven refresh token as evidence of health is
+ * how a credential that expired months ago came to overwrite a working one.
+ */
+export function claudeAccessTokenIsLive(
+  credentials: ClaudeCliCredentials,
+  options?: { now?: number; skewMs?: number },
+): boolean {
+  const now = options?.now ?? Date.now();
+  const skewMs = options?.skewMs ?? CREDENTIAL_EXPIRY_SKEW_MS;
+
+  // No expiry means the source never told us one — a pasted setup-token is the
+  // usual case. Callers already apply a fallback TTL to those, so treat them as
+  // live rather than discarding a credential that is most likely fine.
+  if (credentials.expiresAt === undefined) return true;
+
+  return credentials.expiresAt > now + skewMs;
+}
+
 /**
  * Map credentials onto the fields `OAuthTokenStorage.storeToken` requires.
  *

--- a/src/core/services/claudeCliCredentials.ts
+++ b/src/core/services/claudeCliCredentials.ts
@@ -119,35 +119,6 @@ export function isUsableRefreshToken(
   return true;
 }
 
-/**
- * Whether adopting these credentials would produce a connection that can
- * actually authenticate — now or after a refresh.
- *
- * Connect short-circuits when it finds credentials in Claude Code's storage.
- * Finding them is not the same as them working: an expired access token with
- * no way to renew authenticates nothing, and adopting it puts the card back
- * into the state the user pressed Connect to escape. Checking usability here
- * is what lets Connect fall through to a real sign-in instead.
- */
-export function claudeCredentialsAreUsable(
-  credentials: ClaudeCliCredentials,
-  now: number = Date.now(),
-): boolean {
-  // A usable refresh token can mint a new access token, so an expired access
-  // token is recoverable and worth adopting.
-  if (isUsableRefreshToken(credentials.refreshToken, credentials.accessToken)) {
-    return true;
-  }
-
-  // No refresh path, so the access token itself has to still be alive. An
-  // absent expiry means the source never told us one — a pasted setup token
-  // being the usual case — and those are assumed live, matching the fallback
-  // TTL callers already apply.
-  if (credentials.expiresAt === undefined) return true;
-
-  return credentials.expiresAt > now;
-}
-
 /** Clock skew allowance so a token about to lapse is not treated as live. */
 export const CREDENTIAL_EXPIRY_SKEW_MS = 60_000;
 
@@ -155,16 +126,17 @@ export const CREDENTIAL_EXPIRY_SKEW_MS = 60_000;
  * Whether the access token itself is still usable right now, ignoring any
  * refresh token.
  *
- * This is deliberately stricter than `claudeCredentialsAreUsable`, and the two
- * answer different questions. That one asks "could these ever authenticate?",
- * where a refresh token counts because it can mint a new access token — the
- * right test for deciding whether Connect should short-circuit.
+ * There used to be a laxer companion to this — `claudeCredentialsAreUsable` —
+ * which counted the mere presence of a refresh token as proof the credentials
+ * would work, on the theory that an expired access token is recoverable. That
+ * theory is an assumption, and it was wrong often enough to cause the same bug
+ * at all three call sites: it let a credential five months dead overwrite a
+ * working token, report a successful sign-in without opening the terminal, and
+ * satisfy the poll that waits for the user to finish signing in.
  *
- * Adoption asks something else: "will replacing what I already hold with this
- * leave me better off?" There a refresh token earns nothing, because the only
- * moment adoption runs as recovery is immediately after a refresh token was
- * rejected. Counting a second unproven refresh token as evidence of health is
- * how a credential that expired months ago came to overwrite a working one.
+ * The concept survives where it was genuinely wanted, but verified rather than
+ * assumed: callers that can accept a renewable credential now attempt the
+ * refresh and check whether it succeeded. Nobody has to guess.
  */
 export function claudeAccessTokenIsLive(
   credentials: ClaudeCliCredentials,

--- a/src/core/services/claudeCliCredentials.ts
+++ b/src/core/services/claudeCliCredentials.ts
@@ -1,0 +1,153 @@
+/**
+ * Parsing for Claude Code's stored OAuth credentials.
+ *
+ * Claude Code keeps a JSON blob (macOS Keychain entry "Claude Code-credentials",
+ * or ~/.claude/.credentials.json elsewhere) holding three fields that all matter:
+ * a short-lived `accessToken`, the long-lived `refreshToken` that is the only way
+ * to mint a new one, and `expiresAt`. Paprwork used to keep the access token and
+ * invent the other two, which is why a Claude account could look connected for a
+ * year and start returning 401 the same afternoon.
+ */
+
+/** Anthropic access tokens; short-lived, sent as the bearer credential. */
+const ACCESS_TOKEN_PREFIX = "sk-ant-oat";
+
+export interface ClaudeCliCredentials {
+  accessToken: string;
+  /** Absent when the source did not provide one (e.g. a pasted setup-token). */
+  refreshToken?: string;
+  /** Epoch milliseconds. Absent when the source did not provide one. */
+  expiresAt?: number;
+}
+
+export interface OAuthTokenLifetimeFields {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cleanToken(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const cleaned = value.replace(/\s+/g, "");
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
+function readExpiresAt(source: Record<string, unknown>): number | undefined {
+  const raw = source.expiresAt ?? source.expires_at;
+
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+    // Claude Code writes epoch milliseconds. Treating a seconds value as
+    // milliseconds would date the expiry to 1970 and mark every token dead.
+    return raw < 1e12 ? raw * 1000 : raw;
+  }
+
+  if (typeof raw === "string") {
+    const numeric = Number(raw);
+    if (Number.isFinite(numeric) && numeric > 0) {
+      return numeric < 1e12 ? numeric * 1000 : numeric;
+    }
+    const parsed = Date.parse(raw);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+
+  return undefined;
+}
+
+/**
+ * Read credentials out of one of Claude Code's storage shapes. Returns null when
+ * the blob carries no access token, so callers can fall through to the next
+ * source rather than adopting a half-empty record.
+ */
+export function parseClaudeCliCredentials(
+  raw: string | null | undefined,
+): ClaudeCliCredentials | null {
+  if (!raw || raw.trim().length === 0) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed)) return null;
+
+  // Keychain and ~/.claude/.credentials.json nest under claudeAiOauth;
+  // ~/.claude.json uses oauthAccount; older writers used the root.
+  const candidates = [parsed.claudeAiOauth, parsed.oauthAccount, parsed].filter(
+    isRecord,
+  );
+
+  for (const candidate of candidates) {
+    const accessToken = cleanToken(
+      candidate.accessToken ?? candidate.access_token,
+    );
+    if (!accessToken) continue;
+
+    return {
+      accessToken,
+      refreshToken: cleanToken(
+        candidate.refreshToken ?? candidate.refresh_token,
+      ),
+      expiresAt: readExpiresAt(candidate),
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Whether a stored refresh token can actually be exchanged for a new access
+ * token. A refresh grant only accepts a refresh token, so posting an access
+ * token into that field fails — and echoing the access token is exactly what
+ * the old connect path stored.
+ */
+export function isUsableRefreshToken(
+  refreshToken: string | undefined,
+  accessToken: string,
+): boolean {
+  // Callers include stored records that never went through cleanToken, so a
+  // blank value has to be rejected here rather than assumed away.
+  const candidate = refreshToken?.trim();
+  if (!candidate) return false;
+  if (candidate === accessToken.trim()) return false;
+  if (candidate.startsWith(ACCESS_TOKEN_PREFIX)) return false;
+  return true;
+}
+
+/**
+ * Map credentials onto the fields `OAuthTokenStorage.storeToken` requires.
+ *
+ * `fallbackTtlSeconds` is only consulted when the source gave us no expiry, so
+ * every assumed lifetime is declared by the caller rather than hidden in here.
+ * A past `expiresAt` yields a negative `expiresIn` on purpose: that records the
+ * token as already expired and lets the refresh path pick it up.
+ */
+export function claudeCredentialsToTokenLifetime(
+  credentials: ClaudeCliCredentials,
+  options: { fallbackTtlSeconds: number; now?: number },
+): OAuthTokenLifetimeFields {
+  const now = options.now ?? Date.now();
+  const hasUsableRefresh = isUsableRefreshToken(
+    credentials.refreshToken,
+    credentials.accessToken,
+  );
+
+  return {
+    accessToken: credentials.accessToken,
+    // storeToken requires a string. Echoing the access token keeps that
+    // contract; isUsableRefreshToken is what stops the refresh path from
+    // attempting a grant that cannot succeed.
+    refreshToken: hasUsableRefresh
+      ? (credentials.refreshToken as string)
+      : credentials.accessToken,
+    expiresIn:
+      credentials.expiresAt !== undefined
+        ? Math.round((credentials.expiresAt - now) / 1000)
+        : options.fallbackTtlSeconds,
+  };
+}

--- a/src/core/services/oauthRefreshRejection.ts
+++ b/src/core/services/oauthRefreshRejection.ts
@@ -1,0 +1,61 @@
+/**
+ * Tracking for refresh tokens the provider has already rejected.
+ *
+ * A refresh grant is deterministic: if the authorization server answers
+ * `invalid_grant` ("Refresh token not found or invalid"), that same token will
+ * be rejected every subsequent time. The refresh timer does not know that, so
+ * it re-posts the dead grant on every tick — a doomed network call, a keychain
+ * decrypt, an error log, and a status broadcast that flaps the UI, forever.
+ *
+ * Held in memory on purpose. This records a rejection we *observed*; after a
+ * restart we hold no such evidence and should try again rather than carry a
+ * verdict we can no longer justify.
+ */
+
+/** `invalid_grant` is the OAuth 2.0 code for a refresh token that will not work. */
+const INVALID_GRANT = "invalid_grant";
+
+/**
+ * Whether the failure means the refresh token itself is dead, as opposed to a
+ * transport or gateway problem.
+ *
+ * Deliberately narrow: a 403 Cloudflare challenge or a network timeout says
+ * nothing about the token and must stay retryable, so only the explicit
+ * `invalid_grant` code counts.
+ */
+export function isInvalidGrantError(error: unknown): boolean {
+  const message =
+    error instanceof Error ? error.message : typeof error === "string"
+      ? error
+      : "";
+  return message.toLowerCase().includes(INVALID_GRANT);
+}
+
+/**
+ * Remembers which refresh tokens have been rejected, keyed by the token value
+ * itself so a newly issued one is never covered by an older verdict.
+ */
+export class RefreshRejectionLedger {
+  private readonly rejected = new Map<string, Set<string>>();
+
+  /** Record that `refreshToken` was rejected outright for `provider`. */
+  record(provider: string, refreshToken: string): void {
+    const key = refreshToken.trim();
+    if (!key) return;
+    const existing = this.rejected.get(provider);
+    if (existing) existing.add(key);
+    else this.rejected.set(provider, new Set([key]));
+  }
+
+  /** Whether posting `refreshToken` again is known to be pointless. */
+  isRejected(provider: string, refreshToken: string | undefined): boolean {
+    const key = refreshToken?.trim();
+    if (!key) return false;
+    return this.rejected.get(provider)?.has(key) === true;
+  }
+
+  /** Forget a provider's verdicts, e.g. after the user reconnects. */
+  clear(provider: string): void {
+    this.rejected.delete(provider);
+  }
+}

--- a/src/core/types/agents.ts
+++ b/src/core/types/agents.ts
@@ -63,6 +63,25 @@ export interface AgentConfig {
   maxTokens?: number; // Output token limit
   thinkingBudget?: number;
   reasoning?: ModelReasoning;
+  /**
+   * User-chosen cap on the context window, in tokens.
+   *
+   * Separate from `thinkingBudget: 0`, which cannot mean "no thinking" —
+   * Opus 5 and Fable 5.1 ship a default budget of 0 and still think adaptively.
+   * Absent means "use the model's advertised window".
+   */
+  contextLimit?: number;
+  /**
+   * Explicitly disable reasoning. Only ever `false`; absent means the provider
+   * default applies. Honoured where the request has a real off switch
+   * (Anthropic `thinking: disabled`, Google zero budget, Ollama `think`).
+   */
+  thinking?: false;
+  /**
+   * Anthropic fast mode. Billed at roughly 2× standard rates and available on
+   * the first-party API only, so it is never set on the pi-ai (OAuth) path.
+   */
+  speed?: "fast" | "standard";
 }
 
 /**

--- a/src/electron/ipc/oauth.ts
+++ b/src/electron/ipc/oauth.ts
@@ -12,6 +12,7 @@ import { OAuthCallbackServer } from "../../core/services/OAuthCallbackServer.js"
 import { invalidateKeyCache } from "./customKeys.js";
 import { sanitizeOAuthAccessToken } from "../../core/utils/oauthTokenSanitize.js";
 import {
+  claudeCredentialsAreUsable,
   claudeCredentialsToTokenLifetime,
   isUsableRefreshToken,
 } from "../../core/services/claudeCliCredentials.js";
@@ -576,6 +577,12 @@ export async function initializeOAuthIPC(
         accountId: token.accountId,
         expiresAt: token.expiresAt,
         isExpired,
+        // An expired token that can still be refreshed renews itself on the
+        // next request, so the card must not raise an alarm about it. Only one
+        // that has expired with no way back needs the user. Without this the
+        // UI cannot tell those apart, so it has to either cry wolf or, as it
+        // did, stay green while every request was being refused.
+        canRenew: isUsableRefreshToken(token.refreshToken, token.accessToken),
       };
     } catch (error) {
       console.error("[OAuth IPC] Failed to get OpenAI status:", error);
@@ -627,7 +634,22 @@ export async function initializeOAuthIPC(
       // Step 0: Check for existing token in Keychain / credential files
       const existingCredentials =
         await claudeSetupTokenService!.readCredentialsFromCLIStorage();
-      if (existingCredentials) {
+      // Adopt them only if they can actually authenticate. Credentials that
+      // have expired with no way to renew are worse than none: adopting them
+      // reports success and lands the user back on the expired card they
+      // pressed Connect to escape, with the terminal sign-in below never
+      // reached. Falling through gets them a real token.
+      if (
+        existingCredentials &&
+        !claudeCredentialsAreUsable(existingCredentials)
+      ) {
+        console.log(
+          "[OAuth IPC] Ignoring Claude CLI credentials: expired with no usable " +
+            "refresh token — continuing to sign-in instead of adopting them",
+        );
+      }
+
+      if (existingCredentials && claudeCredentialsAreUsable(existingCredentials)) {
         console.log("[OAuth IPC] Found existing Claude credentials in CLI storage");
         trackOAuthStep("anthropic", "keychain_token_found", { source: telemetrySource });
         const tokenInput = {
@@ -717,6 +739,12 @@ export async function initializeOAuthIPC(
         accountId: token.accountId,
         expiresAt: token.expiresAt,
         isExpired,
+        // An expired token that can still be refreshed renews itself on the
+        // next request, so the card must not raise an alarm about it. Only one
+        // that has expired with no way back needs the user. Without this the
+        // UI cannot tell those apart, so it has to either cry wolf or, as it
+        // did, stay green while every request was being refused.
+        canRenew: isUsableRefreshToken(token.refreshToken, token.accessToken),
       };
     } catch (error) {
       console.error("[OAuth IPC] Failed to get Claude status:", error);
@@ -772,6 +800,15 @@ export async function initializeOAuthIPC(
         const credentials =
           await claudeSetupTokenService!.readCredentialsFromCLIStorage();
         if (!credentials) {
+          return { success: false, reason: "not_found" as const };
+        }
+
+        // This polls while the user completes sign-in in the terminal, so the
+        // stale credential that sign-in is meant to replace is still on disk
+        // for most of that window. Treat an unusable one as absent, otherwise
+        // the first poll adopts it and reports success before the user has
+        // finished — which is the same false success Connect used to give.
+        if (!claudeCredentialsAreUsable(credentials)) {
           return { success: false, reason: "not_found" as const };
         }
 

--- a/src/electron/ipc/oauth.ts
+++ b/src/electron/ipc/oauth.ts
@@ -118,6 +118,8 @@ async function persistOAuthConnection(
   },
 ): Promise<void> {
   await oauthTokenStorage!.storeToken(tokenInput);
+  // A new token is worth one fresh look at the CLI's credentials.
+  cliAdoptionAttempted.delete(provider);
   trackOAuthStep(provider, "token_stored", options);
 
   await syncOAuthTokenToApiKeys(provider, tokenInput.accessToken);
@@ -157,6 +159,15 @@ function sendOAuthStatus(provider: "openai" | "anthropic", status: "connected" |
 let refreshTimer: NodeJS.Timeout | null = null;
 const REFRESH_CHECK_INTERVAL = 2 * 60 * 1000; // Check every 2 minutes
 const REFRESH_BUFFER = 15 * 60; // Refresh 15 minutes before expiry
+
+/**
+ * Providers whose stored token we have already tried to upgrade from the CLI's
+ * own credentials this session.
+ *
+ * Cleared whenever the stored token changes, since a fresh sign-in is exactly
+ * the event that makes another look worthwhile.
+ */
+const cliAdoptionAttempted = new Set<"openai" | "anthropic">();
 
 /**
  * Sync OAuth token to CustomKeysStorage as an API key
@@ -360,10 +371,15 @@ async function adoptClaudeCredentialsFromCLIStorage(
   // working token for a dead one and — because the replacement is expired on
   // arrival — arms the very next refresh tick to do it again.
   if (!claudeAccessTokenIsLive(credentials)) {
+    // Lead with whose token is fine. The earlier wording opened with "access
+    // token expired" and a date, which reads as an alarm about the token the
+    // user is actually using — and the reassuring half was at the end.
     console.warn(
-      `[OAuth IPC] Not adopting Claude Code credentials: access token expired ` +
-        `${describeExpiry(credentials.expiresAt)}. Keeping the stored token; ` +
-        `sign in to Claude Code again to refresh this source.`,
+      `[OAuth IPC] Keeping your stored Claude token, which is unaffected. ` +
+        `Claude Code's own copy is stale (its access token lapsed ` +
+        `${describeExpiry(credentials.expiresAt)}), so there is no live ` +
+        `credential to adopt from it. Sign in to Claude Code again if you want ` +
+        `it usable as a refresh source.`,
     );
     return false;
   }
@@ -413,6 +429,11 @@ async function refreshTokenIfNeeded(
       return false;
     }
 
+    const needsRefreshSoon = oauthTokenStorage.isTokenExpired(
+      token,
+      REFRESH_BUFFER / 60,
+    );
+
     const canRedeemRefreshToken = isUsableRefreshToken(
       token.refreshToken,
       token.accessToken,
@@ -422,13 +443,24 @@ async function refreshTokenIfNeeded(
     // slot alongside an invented year-long expiry, so they can neither be
     // refreshed nor ever look expired. Re-reading Claude Code's own storage
     // replaces that copy with the real refresh token and expiry.
+    //
+    // The check cannot be moved below the expiry test — such a token never
+    // looks expired, so this is the only path that ever repairs it. What it can
+    // stop being is constant: the repair matters before the token lapses, not
+    // sixty times an hour while it is still good for a year. Attempting it once
+    // per session (and whenever expiry actually approaches) keeps the repair
+    // and drops the Keychain read, and with it a warning about Claude Code's
+    // stale copy that fired on a timer while nothing was wrong.
     if (provider === "anthropic" && !canRedeemRefreshToken) {
+      if (!needsRefreshSoon && cliAdoptionAttempted.has(provider)) {
+        return false;
+      }
+      cliAdoptionAttempted.add(provider);
       return await adoptClaudeCredentialsFromCLIStorage(token.id);
     }
 
-    // Check if token needs refresh (within buffer time)
-    if (!oauthTokenStorage.isTokenExpired(token, REFRESH_BUFFER / 60)) {
-      // Token is still valid, no refresh needed
+    if (!needsRefreshSoon) {
+      // Token is still valid, no refresh needed.
       return false;
     }
 
@@ -731,6 +763,7 @@ export async function initializeOAuthIPC(
       await oauthTokenStorage!.deleteTokenByProvider("openai");
       activeFlows.delete("openai");
       refreshRejections.clear("openai");
+      cliAdoptionAttempted.delete("openai");
 
       // Remove OAuth-managed API key from CustomKeysStorage
       await removeOAuthManagedApiKey("openai");
@@ -910,6 +943,7 @@ export async function initializeOAuthIPC(
       await oauthTokenStorage!.deleteTokenByProvider("anthropic");
       activeFlows.delete("anthropic");
       refreshRejections.clear("anthropic");
+      cliAdoptionAttempted.delete("anthropic");
 
       // Remove OAuth-managed API key from CustomKeysStorage
       await removeOAuthManagedApiKey("anthropic");

--- a/src/electron/ipc/oauth.ts
+++ b/src/electron/ipc/oauth.ts
@@ -367,7 +367,35 @@ async function refreshTokenIfNeeded(
     return true;
   } catch (error) {
     console.error(`[OAuth IPC] Failed to refresh ${provider} token:`, error);
-    // TODO: Notify user about refresh failure
+
+    // Claude Code keeps its own access token renewed and is the authority for
+    // these credentials, so a failed refresh of our copy is recoverable: adopt
+    // its current record instead. Previously this path just returned, leaving
+    // the stored token expired with nothing that would ever renew it.
+    if (provider === "anthropic" && oauthTokenStorage) {
+      const token = oauthTokenStorage.getTokenByProvider(provider);
+      if (token) {
+        try {
+          if (await adoptClaudeCredentialsFromCLIStorage(token.id)) {
+            console.log(
+              "[OAuth IPC] Recovered from failed refresh by adopting Claude Code credentials",
+            );
+            return true;
+          }
+        } catch (adoptError) {
+          console.error(
+            "[OAuth IPC] Adopting Claude Code credentials also failed:",
+            adoptError,
+          );
+        }
+      }
+    }
+
+    sendOAuthStatus(
+      provider,
+      "error",
+      error instanceof Error ? error.message : "Token refresh failed",
+    );
     return false;
   }
 }

--- a/src/electron/ipc/oauth.ts
+++ b/src/electron/ipc/oauth.ts
@@ -13,9 +13,9 @@ import { invalidateKeyCache } from "./customKeys.js";
 import { sanitizeOAuthAccessToken } from "../../core/utils/oauthTokenSanitize.js";
 import {
   claudeAccessTokenIsLive,
-  claudeCredentialsAreUsable,
   claudeCredentialsToTokenLifetime,
   isUsableRefreshToken,
+  type ClaudeCliCredentials,
 } from "../../core/services/claudeCliCredentials.js";
 import {
   isInvalidGrantError,
@@ -277,6 +277,57 @@ function tokenCanRenew(
 ): boolean {
   if (!isUsableRefreshToken(token.refreshToken, token.accessToken)) return false;
   return !refreshRejections.isRejected(provider, token.refreshToken);
+}
+
+/**
+ * Decide whether Claude Code's stored credentials can be adopted instead of
+ * sending the user to a terminal, renewing them first when only the access
+ * token has lapsed. Returns null when a real sign-in is required.
+ *
+ * Pressing Sign in states an intent the short-circuit has to honour. Adopting
+ * a credential that cannot authenticate reports success, skips the terminal,
+ * and returns the user to the card they pressed the button to escape — which
+ * reads, correctly, as the button doing nothing.
+ */
+async function resolveAdoptableClaudeCredentials(
+  credentials: ClaudeCliCredentials,
+): Promise<ClaudeCliCredentials | null> {
+  // Live access token: adopt as-is, no network round trip.
+  if (claudeAccessTokenIsLive(credentials)) return credentials;
+
+  const refreshToken = credentials.refreshToken;
+  if (
+    !refreshToken ||
+    !isUsableRefreshToken(refreshToken, credentials.accessToken) ||
+    !claudeOAuthService
+  ) {
+    return null;
+  }
+
+  // A grant the provider has already refused will be refused again.
+  if (refreshRejections.isRejected("anthropic", refreshToken)) return null;
+
+  // Only the access token has lapsed, which is the ordinary state of a Claude
+  // Code login left idle for a few hours. Renewing keeps that case off the
+  // terminal path — but the credential is adopted on the refresh *succeeding*,
+  // never on a refresh token merely being present.
+  try {
+    const renewed = await claudeOAuthService.refreshToken(refreshToken);
+    return {
+      accessToken: renewed.accessToken,
+      refreshToken: renewed.refreshToken,
+      expiresAt: Date.now() + renewed.expiresIn * 1000,
+    };
+  } catch (error) {
+    if (isInvalidGrantError(error)) {
+      refreshRejections.record("anthropic", refreshToken);
+    }
+    console.warn(
+      "[OAuth IPC] Claude Code credentials could not be renewed — continuing to sign-in:",
+      (error as Error).message,
+    );
+    return null;
+  }
 }
 
 async function adoptClaudeCredentialsFromCLIStorage(
@@ -715,30 +766,33 @@ export async function initializeOAuthIPC(
       oauthFlowStartedAt.set("anthropic", Date.now());
       trackOAuthStep("anthropic", "flow_started", { source: telemetrySource });
 
-      // Step 0: Check for existing token in Keychain / credential files
+      // Step 0: Check for existing token in Keychain / credential files.
+      // Finding credentials is not the same as their working, so they are only
+      // adopted once they demonstrably authenticate — live, or successfully
+      // renewed. Anything else falls through to the real sign-in below.
       const existingCredentials =
         await claudeSetupTokenService!.readCredentialsFromCLIStorage();
-      // Adopt them only if they can actually authenticate. Credentials that
-      // have expired with no way to renew are worse than none: adopting them
-      // reports success and lands the user back on the expired card they
-      // pressed Connect to escape, with the terminal sign-in below never
-      // reached. Falling through gets them a real token.
-      if (
-        existingCredentials &&
-        !claudeCredentialsAreUsable(existingCredentials)
-      ) {
+      const adoptableCredentials = existingCredentials
+        ? await resolveAdoptableClaudeCredentials(existingCredentials)
+        : null;
+
+      if (existingCredentials && !adoptableCredentials) {
         console.log(
-          "[OAuth IPC] Ignoring Claude CLI credentials: expired with no usable " +
-            "refresh token — continuing to sign-in instead of adopting them",
+          "[OAuth IPC] Claude CLI credentials cannot authenticate (expired " +
+            `${
+              existingCredentials.expiresAt === undefined
+                ? "unknown"
+                : new Date(existingCredentials.expiresAt).toISOString()
+            }, not renewable) — continuing to sign-in instead of adopting them`,
         );
       }
 
-      if (existingCredentials && claudeCredentialsAreUsable(existingCredentials)) {
+      if (adoptableCredentials) {
         console.log("[OAuth IPC] Found existing Claude credentials in CLI storage");
         trackOAuthStep("anthropic", "keychain_token_found", { source: telemetrySource });
         const tokenInput = {
           provider: "anthropic" as const,
-          ...claudeCredentialsToTokenLifetime(existingCredentials, {
+          ...claudeCredentialsToTokenLifetime(adoptableCredentials, {
             fallbackTtlSeconds: SETUP_TOKEN_ASSUMED_TTL_SECONDS,
           }),
         };
@@ -890,10 +944,12 @@ export async function initializeOAuthIPC(
 
         // This polls while the user completes sign-in in the terminal, so the
         // stale credential that sign-in is meant to replace is still on disk
-        // for most of that window. Treat an unusable one as absent, otherwise
-        // the first poll adopts it and reports success before the user has
-        // finished — which is the same false success Connect used to give.
-        if (!claudeCredentialsAreUsable(credentials)) {
+        // for most of that window. What we are waiting for is a freshly minted
+        // token, and those are live by definition — so liveness is the test.
+        // Accepting a merely renewable credential here would let the very first
+        // poll adopt the stale one and report success before the user has
+        // typed anything, which is the same false success Connect used to give.
+        if (!claudeAccessTokenIsLive(credentials)) {
           return { success: false, reason: "not_found" as const };
         }
 

--- a/src/electron/ipc/oauth.ts
+++ b/src/electron/ipc/oauth.ts
@@ -12,6 +12,10 @@ import { OAuthCallbackServer } from "../../core/services/OAuthCallbackServer.js"
 import { invalidateKeyCache } from "./customKeys.js";
 import { sanitizeOAuthAccessToken } from "../../core/utils/oauthTokenSanitize.js";
 import {
+  claudeCredentialsToTokenLifetime,
+  isUsableRefreshToken,
+} from "../../core/services/claudeCliCredentials.js";
+import {
   getOAuthCompletedEventName,
   getOAuthFailedEventName,
   getOAuthStepEventName,
@@ -28,6 +32,15 @@ type OAuthTelemetryTracker = (
 type OAuthStartTelemetryOptions = {
   source?: string;
 };
+
+/**
+ * A pasted `claude setup-token` carries no expiry of its own, and Anthropic
+ * issues those for about a year. Consulted only when the source told us
+ * nothing: credentials read from Claude Code's own storage bring a real
+ * expiresAt, and assuming a year for those is what let an access token that
+ * had already died keep reporting itself as connected.
+ */
+const SETUP_TOKEN_ASSUMED_TTL_SECONDS = 365 * 24 * 60 * 60;
 
 function resolveOAuthTelemetrySource(source?: string): string {
   if (source === "onboarding" || source === "settings") {
@@ -237,6 +250,46 @@ async function removeOAuthManagedApiKey(
 }
 
 /**
+ * Replace our stored Claude token with a fresh read of Claude Code's own
+ * credentials. Claude Code keeps its access token renewed, so adopting its
+ * record recovers both a redeemable refresh token and a truthful expiry.
+ *
+ * Returns whether anything was adopted.
+ */
+async function adoptClaudeCredentialsFromCLIStorage(
+  tokenId: string,
+): Promise<boolean> {
+  if (!oauthTokenStorage || !claudeSetupTokenService) return false;
+
+  const credentials =
+    await claudeSetupTokenService.readCredentialsFromCLIStorage();
+  if (!credentials) {
+    console.warn(
+      "[OAuth IPC] Claude token cannot be refreshed and Claude Code has no credentials to adopt — reconnect required",
+    );
+    return false;
+  }
+
+  if (!isUsableRefreshToken(credentials.refreshToken, credentials.accessToken)) {
+    // A setup-token has no refresh token to adopt, so there is nothing to
+    // improve. Leave the stored record alone.
+    return false;
+  }
+
+  const lifetime = claudeCredentialsToTokenLifetime(credentials, {
+    fallbackTtlSeconds: SETUP_TOKEN_ASSUMED_TTL_SECONDS,
+  });
+
+  await oauthTokenStorage.updateToken(tokenId, lifetime);
+  await syncOAuthTokenToApiKeys("anthropic", lifetime.accessToken);
+
+  console.log(
+    "[OAuth IPC] Adopted Claude Code credentials (real refresh token + expiry)",
+  );
+  return true;
+}
+
+/**
  * Refresh OAuth token if it's about to expire
  */
 async function refreshTokenIfNeeded(
@@ -254,9 +307,31 @@ async function refreshTokenIfNeeded(
       return false;
     }
 
+    const canRedeemRefreshToken = isUsableRefreshToken(
+      token.refreshToken,
+      token.accessToken,
+    );
+
+    // Tokens stored by older builds echoed the access token into the refresh
+    // slot alongside an invented year-long expiry, so they can neither be
+    // refreshed nor ever look expired. Re-reading Claude Code's own storage
+    // replaces that copy with the real refresh token and expiry.
+    if (provider === "anthropic" && !canRedeemRefreshToken) {
+      return await adoptClaudeCredentialsFromCLIStorage(token.id);
+    }
+
     // Check if token needs refresh (within buffer time)
     if (!oauthTokenStorage.isTokenExpired(token, REFRESH_BUFFER / 60)) {
       // Token is still valid, no refresh needed
+      return false;
+    }
+
+    if (!canRedeemRefreshToken) {
+      // A refresh grant only accepts a refresh token; sending the access token
+      // would 400. Nothing to do but let the UI ask for a reconnect.
+      console.warn(
+        `[OAuth IPC] ${provider} token expired but no usable refresh token is stored — reconnect required`,
+      );
       return false;
     }
 
@@ -522,15 +597,16 @@ export async function initializeOAuthIPC(
       trackOAuthStep("anthropic", "flow_started", { source: telemetrySource });
 
       // Step 0: Check for existing token in Keychain / credential files
-      const existingToken = await claudeSetupTokenService!.readTokenFromCLIStorage();
-      if (existingToken) {
-        console.log("[OAuth IPC] Found existing Claude token in CLI storage");
+      const existingCredentials =
+        await claudeSetupTokenService!.readCredentialsFromCLIStorage();
+      if (existingCredentials) {
+        console.log("[OAuth IPC] Found existing Claude credentials in CLI storage");
         trackOAuthStep("anthropic", "keychain_token_found", { source: telemetrySource });
         const tokenInput = {
           provider: "anthropic" as const,
-          accessToken: existingToken,
-          refreshToken: existingToken,
-          expiresIn: 365 * 24 * 60 * 60,
+          ...claudeCredentialsToTokenLifetime(existingCredentials, {
+            fallbackTtlSeconds: SETUP_TOKEN_ASSUMED_TTL_SECONDS,
+          }),
         };
         await persistOAuthConnection("anthropic", tokenInput, {
           flow_source: "keychain",
@@ -665,8 +741,9 @@ export async function initializeOAuthIPC(
     async (_event, options?: OAuthStartTelemetryOptions) => {
       const telemetrySource = resolveOAuthTelemetrySource(options?.source);
       try {
-        const token = await claudeSetupTokenService!.readTokenFromCLIStorage();
-        if (!token) {
+        const credentials =
+          await claudeSetupTokenService!.readCredentialsFromCLIStorage();
+        if (!credentials) {
           return { success: false, reason: "not_found" as const };
         }
 
@@ -676,9 +753,9 @@ export async function initializeOAuthIPC(
 
         const tokenInput = {
           provider: "anthropic" as const,
-          accessToken: token,
-          refreshToken: token,
-          expiresIn: 365 * 24 * 60 * 60,
+          ...claudeCredentialsToTokenLifetime(credentials, {
+            fallbackTtlSeconds: SETUP_TOKEN_ASSUMED_TTL_SECONDS,
+          }),
         };
 
         await persistOAuthConnection("anthropic", tokenInput, {
@@ -730,11 +807,16 @@ export async function initializeOAuthIPC(
         };
       }
 
+      // A pasted setup-token arrives on its own: no refresh token, no expiry.
+      // claudeCredentialsToTokenLifetime echoes the access token into the
+      // refresh slot to satisfy storeToken, and isUsableRefreshToken keeps the
+      // refresh path from trying to redeem it.
       const tokenInput = {
         provider: "anthropic" as const,
-        accessToken: cleanedToken,
-        refreshToken: cleanedToken,
-        expiresIn: 365 * 24 * 60 * 60,
+        ...claudeCredentialsToTokenLifetime(
+          { accessToken: cleanedToken },
+          { fallbackTtlSeconds: SETUP_TOKEN_ASSUMED_TTL_SECONDS },
+        ),
       };
 
       await persistOAuthConnection("anthropic", tokenInput, {

--- a/src/electron/ipc/oauth.ts
+++ b/src/electron/ipc/oauth.ts
@@ -12,10 +12,15 @@ import { OAuthCallbackServer } from "../../core/services/OAuthCallbackServer.js"
 import { invalidateKeyCache } from "./customKeys.js";
 import { sanitizeOAuthAccessToken } from "../../core/utils/oauthTokenSanitize.js";
 import {
+  claudeAccessTokenIsLive,
   claudeCredentialsAreUsable,
   claudeCredentialsToTokenLifetime,
   isUsableRefreshToken,
 } from "../../core/services/claudeCliCredentials.js";
+import {
+  isInvalidGrantError,
+  RefreshRejectionLedger,
+} from "../../core/services/oauthRefreshRejection.js";
 import {
   getOAuthCompletedEventName,
   getOAuthFailedEventName,
@@ -57,6 +62,7 @@ let claudeSetupTokenService: ClaudeSetupTokenService | null = null;
 let claudeOAuthService: ClaudeOAuthService | null = null;
 let trackOAuthEvent: OAuthTelemetryTracker | undefined;
 const oauthFlowStartedAt = new Map<OAuthProviderId, number>();
+const refreshRejections = new RefreshRejectionLedger();
 
 function trackOAuthStep(
   provider: OAuthProviderId,
@@ -257,8 +263,25 @@ async function removeOAuthManagedApiKey(
  *
  * Returns whether anything was adopted.
  */
+/**
+ * Whether the stored token can actually mint a new access token.
+ *
+ * Well-formedness is necessary but not sufficient: a grant the provider has
+ * already answered `invalid_grant` to renews nothing, however valid it looks.
+ * Reporting it as renewable is what let the card stay reassuring while every
+ * refresh was being refused.
+ */
+function tokenCanRenew(
+  provider: "openai" | "anthropic",
+  token: { refreshToken: string; accessToken: string },
+): boolean {
+  if (!isUsableRefreshToken(token.refreshToken, token.accessToken)) return false;
+  return !refreshRejections.isRejected(provider, token.refreshToken);
+}
+
 async function adoptClaudeCredentialsFromCLIStorage(
   tokenId: string,
+  options?: { mustOutliveMs?: number },
 ): Promise<boolean> {
   if (!oauthTokenStorage || !claudeSetupTokenService) return false;
 
@@ -277,6 +300,36 @@ async function adoptClaudeCredentialsFromCLIStorage(
     return false;
   }
 
+  const describeExpiry = (ms: number | undefined): string =>
+    ms === undefined ? "unknown" : new Date(ms).toISOString();
+
+  // Adoption overwrites a credential the user may have just entered by hand, so
+  // it has to be an upgrade. Claude Code's stored copy is only authoritative
+  // while it is current; once its access token has lapsed, adopting it swaps a
+  // working token for a dead one and — because the replacement is expired on
+  // arrival — arms the very next refresh tick to do it again.
+  if (!claudeAccessTokenIsLive(credentials)) {
+    console.warn(
+      `[OAuth IPC] Not adopting Claude Code credentials: access token expired ` +
+        `${describeExpiry(credentials.expiresAt)}. Keeping the stored token; ` +
+        `sign in to Claude Code again to refresh this source.`,
+    );
+    return false;
+  }
+
+  if (
+    options?.mustOutliveMs !== undefined &&
+    credentials.expiresAt !== undefined &&
+    credentials.expiresAt <= options.mustOutliveMs
+  ) {
+    console.warn(
+      `[OAuth IPC] Not adopting Claude Code credentials: they expire ` +
+        `${describeExpiry(credentials.expiresAt)}, no later than the stored ` +
+        `token (${describeExpiry(options.mustOutliveMs)}).`,
+    );
+    return false;
+  }
+
   const lifetime = claudeCredentialsToTokenLifetime(credentials, {
     fallbackTtlSeconds: SETUP_TOKEN_ASSUMED_TTL_SECONDS,
   });
@@ -285,7 +338,8 @@ async function adoptClaudeCredentialsFromCLIStorage(
   await syncOAuthTokenToApiKeys("anthropic", lifetime.accessToken);
 
   console.log(
-    "[OAuth IPC] Adopted Claude Code credentials (real refresh token + expiry)",
+    `[OAuth IPC] Adopted Claude Code credentials (expires ` +
+      `${describeExpiry(credentials.expiresAt)}, refreshable)`,
   );
   return true;
 }
@@ -336,6 +390,15 @@ async function refreshTokenIfNeeded(
       return false;
     }
 
+    // A grant the server already answered `invalid_grant` to will be refused
+    // identically every time, so re-posting it each tick only produces noise.
+    if (refreshRejections.isRejected(provider, token.refreshToken)) {
+      console.warn(
+        `[OAuth IPC] ${provider} refresh token was already rejected by the provider — reconnect required`,
+      );
+      return false;
+    }
+
     console.log(`[OAuth IPC] Refreshing ${provider} token (expires soon)`);
 
     // Get the appropriate OAuth service for refresh
@@ -369,15 +432,35 @@ async function refreshTokenIfNeeded(
   } catch (error) {
     console.error(`[OAuth IPC] Failed to refresh ${provider} token:`, error);
 
+    // Only an explicit `invalid_grant` condemns the token; a Cloudflare
+    // challenge or a network fault says nothing about it and stays retryable.
+    if (isInvalidGrantError(error)) {
+      const rejectedToken =
+        oauthTokenStorage?.getTokenByProvider(provider)?.refreshToken;
+      if (rejectedToken) refreshRejections.record(provider, rejectedToken);
+    }
+
     // Claude Code keeps its own access token renewed and is the authority for
     // these credentials, so a failed refresh of our copy is recoverable: adopt
     // its current record instead. Previously this path just returned, leaving
     // the stored token expired with nothing that would ever renew it.
+    //
+    // The stored expiry is passed as the bar to beat. We only reach here after
+    // a refresh was rejected, so Claude Code's copy is a candidate, not an
+    // authority — adopting one that dies sooner than what we already hold is a
+    // downgrade, and adopting an already-dead one is what overwrote tokens the
+    // user had just entered by hand.
     if (provider === "anthropic" && oauthTokenStorage) {
       const token = oauthTokenStorage.getTokenByProvider(provider);
       if (token) {
+        const storedExpiresAtMs = Date.parse(token.expiresAt);
+        const baseline: { mustOutliveMs?: number } = Number.isNaN(
+          storedExpiresAtMs,
+        )
+          ? {}
+          : { mustOutliveMs: storedExpiresAtMs };
         try {
-          if (await adoptClaudeCredentialsFromCLIStorage(token.id)) {
+          if (await adoptClaudeCredentialsFromCLIStorage(token.id, baseline)) {
             console.log(
               "[OAuth IPC] Recovered from failed refresh by adopting Claude Code credentials",
             );
@@ -582,7 +665,7 @@ export async function initializeOAuthIPC(
         // that has expired with no way back needs the user. Without this the
         // UI cannot tell those apart, so it has to either cry wolf or, as it
         // did, stay green while every request was being refused.
-        canRenew: isUsableRefreshToken(token.refreshToken, token.accessToken),
+        canRenew: tokenCanRenew("openai", token),
       };
     } catch (error) {
       console.error("[OAuth IPC] Failed to get OpenAI status:", error);
@@ -596,6 +679,7 @@ export async function initializeOAuthIPC(
       // Remove OAuth token from OAuthTokenStorage
       await oauthTokenStorage!.deleteTokenByProvider("openai");
       activeFlows.delete("openai");
+      refreshRejections.clear("openai");
 
       // Remove OAuth-managed API key from CustomKeysStorage
       await removeOAuthManagedApiKey("openai");
@@ -744,7 +828,7 @@ export async function initializeOAuthIPC(
         // that has expired with no way back needs the user. Without this the
         // UI cannot tell those apart, so it has to either cry wolf or, as it
         // did, stay green while every request was being refused.
-        canRenew: isUsableRefreshToken(token.refreshToken, token.accessToken),
+        canRenew: tokenCanRenew("anthropic", token),
       };
     } catch (error) {
       console.error("[OAuth IPC] Failed to get Claude status:", error);
@@ -771,6 +855,7 @@ export async function initializeOAuthIPC(
       // Remove OAuth token from OAuthTokenStorage
       await oauthTokenStorage!.deleteTokenByProvider("anthropic");
       activeFlows.delete("anthropic");
+      refreshRejections.clear("anthropic");
 
       // Remove OAuth-managed API key from CustomKeysStorage
       await removeOAuthManagedApiKey("anthropic");

--- a/src/gateway/services/AgentService.ts
+++ b/src/gateway/services/AgentService.ts
@@ -18,7 +18,11 @@ import {
   initializeMemorySearchGate,
   wrapToolsWithMemorySearchFirstGate,
 } from "../../core/utils/memorySearchFirstGate.js";
-import { allTools, getApiKeysForSanitization, legacyToolAliases } from "../../core/tools/index.js";
+import {
+  allTools,
+  getApiKeysForSanitization,
+  legacyToolAliases,
+} from "../../core/tools/index.js";
 import {
   ACTIVE_PLANS_MESSAGE_PREFIX,
   buildSystemPrompt,
@@ -80,7 +84,10 @@ import {
   type ToolCallEvent,
   type ToolResultEvent,
 } from "./agent/streamChunks.js";
-import { orchestrateModelStream, sequenceEndsWithToolWithoutTrailingText } from "./agent/streamOrchestrator.js";
+import {
+  orchestrateModelStream,
+  sequenceEndsWithToolWithoutTrailingText,
+} from "./agent/streamOrchestrator.js";
 import {
   explainPostStreamWrapUp,
   logAgentTurnEnd,
@@ -219,9 +226,8 @@ export class AgentService {
       this.toolRegistry.registerLegacy(registryTool);
     }
 
-    const { isPlanACloudDbAuthority } = await import(
-      "./tursoReplica/replicaSchemaPolicy.js"
-    );
+    const { isPlanACloudDbAuthority } =
+      await import("./tursoReplica/replicaSchemaPolicy.js");
     if (isPlanACloudDbAuthority()) {
       for (const recoveryToolId of ["papr_db_push", "papr_db_pull"] as const) {
         const recoveryTool = this.toolRegistry.getTool(recoveryToolId);
@@ -344,11 +350,11 @@ export class AgentService {
 
       const fallback = generateFallbackTitle(firstMessage);
       await this.storageManager.updateChat(chatId, { title: fallback });
-      
+
       // Broadcast chat list update
       const { broadcast } = await import("../websocket/index.js");
       broadcast({ type: "chat:list-updated" });
-      
+
       return fallback;
     }
 
@@ -357,11 +363,11 @@ export class AgentService {
     await this.storageManager.updateChat(chatId, { title });
 
     console.log(`✓ Generated title for ${chatId}: "${title}"`);
-    
+
     // Broadcast chat list update
     const { broadcast } = await import("../websocket/index.js");
     broadcast({ type: "chat:list-updated" });
-    
+
     return title;
   }
 
@@ -370,7 +376,7 @@ export class AgentService {
    */
   async updateChatTitle(chatId: string, title: string): Promise<void> {
     await this.storageManager.updateChat(chatId, { title });
-    
+
     // Broadcast chat list update
     const { broadcast } = await import("../websocket/index.js");
     broadcast({ type: "chat:list-updated" });
@@ -523,9 +529,8 @@ export class AgentService {
     this.sessionManager.setAbortController(chatId, abortController);
 
     if (!skipConcurrencyGate) {
-      const { getAgentStreamConcurrencyGate } = await import(
-        "./agent/agentStreamConcurrency.js"
-      );
+      const { getAgentStreamConcurrencyGate } =
+        await import("./agent/agentStreamConcurrency.js");
       const gate = getAgentStreamConcurrencyGate();
       try {
         for await (const event of gate.acquireWithEvents(
@@ -817,68 +822,92 @@ export class AgentService {
       t = performance.now();
       const historyRaw = await this.storageManager.loadMessagesForLLM(chatId);
 
-      console.log(`\n${'='.repeat(100)}`);
-      console.log(`🔵 STAGE 2.5: MESSAGES RECEIVED FROM STORAGE (Before LLM formatting)`);
-      console.log(`${'='.repeat(100)}`);
-      console.log(`[STAGE 2.5] Received ${historyRaw.length} items from storage`);
-      
+      console.log(`\n${"=".repeat(100)}`);
+      console.log(
+        `🔵 STAGE 2.5: MESSAGES RECEIVED FROM STORAGE (Before LLM formatting)`,
+      );
+      console.log(`${"=".repeat(100)}`);
+      console.log(
+        `[STAGE 2.5] Received ${historyRaw.length} items from storage`,
+      );
+
       // Check for summary
-      const hasSummary = historyRaw.some(item => typeof item === "object" && item !== null && "__summary" in item);
+      const hasSummary = historyRaw.some(
+        (item) =>
+          typeof item === "object" && item !== null && "__summary" in item,
+      );
       console.log(`[STAGE 2.5] Contains __summary object: ${hasSummary}`);
-      
+
       // Log role distribution
       const roleCount = historyRaw.reduce((acc: any, item: any) => {
-        if ('__summary' in item) {
-          acc['__summary'] = (acc['__summary'] || 0) + 1;
+        if ("__summary" in item) {
+          acc["__summary"] = (acc["__summary"] || 0) + 1;
         } else {
           acc[item.role] = (acc[item.role] || 0) + 1;
         }
         return acc;
       }, {});
       console.log(`[STAGE 2.5] Item distribution:`, roleCount);
-      
+
       // Log first few items
       console.log(`[STAGE 2.5] First 5 items from storage:`);
       historyRaw.slice(0, 5).forEach((item: any, i: number) => {
-        if ('__summary' in item) {
+        if ("__summary" in item) {
           console.log(`  [${i}] __summary (${item.__summary.length} chars)`);
         } else {
-          const content = typeof item.content === 'string' ? item.content : JSON.stringify(item.content);
-          const timestamp = item.timestamp || item.createdAt || 'no-timestamp';
-          console.log(`  [${i}] ${item.role.padEnd(10)} | ${timestamp.substring(11, 19)} | ${content.substring(0, 50)}...`);
+          const content =
+            typeof item.content === "string"
+              ? item.content
+              : JSON.stringify(item.content);
+          const timestamp = item.timestamp || item.createdAt || "no-timestamp";
+          console.log(
+            `  [${i}] ${item.role.padEnd(10)} | ${timestamp.substring(11, 19)} | ${content.substring(0, 50)}...`,
+          );
         }
       });
 
       // Extract summary if present (injected by storage providers)
       let conversationSummary: string | undefined;
-      
+
       const history = historyRaw.filter((msg) => {
         if (typeof msg === "object" && msg !== null && "__summary" in msg) {
           conversationSummary = (msg as { __summary: string }).__summary;
-          console.log(`[STAGE 2.5] ✅ Extracted summary (${conversationSummary.length} chars)`);
+          console.log(
+            `[STAGE 2.5] ✅ Extracted summary (${conversationSummary.length} chars)`,
+          );
           return false; // Remove from history
         }
         return true; // Keep in history
       });
 
-      console.log(`[STAGE 2.5] After extracting summary: ${history.length} messages`);
-      
+      console.log(
+        `[STAGE 2.5] After extracting summary: ${history.length} messages`,
+      );
+
       // Log role distribution after summary extraction
       const historyRoleCount = history.reduce((acc: any, m: any) => {
         acc[m.role] = (acc[m.role] || 0) + 1;
         return acc;
       }, {});
-      console.log(`[STAGE 2.5] Role distribution (no summary):`, historyRoleCount);
-      
+      console.log(
+        `[STAGE 2.5] Role distribution (no summary):`,
+        historyRoleCount,
+      );
+
       // Log last 5 messages that will go to LLM
       console.log(`[STAGE 2.5] Last 5 messages going to LLM:`);
       history.slice(-5).forEach((msg: any, i: number) => {
-        const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
-        const timestamp = msg.timestamp || msg.createdAt || 'no-timestamp';
+        const content =
+          typeof msg.content === "string"
+            ? msg.content
+            : JSON.stringify(msg.content);
+        const timestamp = msg.timestamp || msg.createdAt || "no-timestamp";
         const actualIdx = history.length - 5 + i;
-        console.log(`  [${actualIdx}] ${msg.role.padEnd(10)} | ${timestamp.substring(11, 19)} | ${content.substring(0, 50)}...`);
+        console.log(
+          `  [${actualIdx}] ${msg.role.padEnd(10)} | ${timestamp.substring(11, 19)} | ${content.substring(0, 50)}...`,
+        );
       });
-      console.log(`${'='.repeat(100)}\n`);
+      console.log(`${"=".repeat(100)}\n`);
 
       timings.loadHistory = performance.now() - t;
 
@@ -910,7 +939,8 @@ export class AgentService {
         await this.triggerSummarization(chatId, {
           force: geminiResummarize || historyStats.has_summary,
         });
-        const reloadedRaw = await this.storageManager.loadMessagesForLLM(chatId);
+        const reloadedRaw =
+          await this.storageManager.loadMessagesForLLM(chatId);
         conversationSummary = undefined;
         history.length = 0;
         for (const msg of reloadedRaw) {
@@ -937,17 +967,27 @@ export class AgentService {
         const skillService = getSkillService();
         const allSkills = await skillService.listSkills();
         const active = allSkills.filter((s: SkillRecord) => s.enabled);
-        console.log(`[AgentService] 📚 Loaded ${active.length} enabled skills for system prompt`);
+        console.log(
+          `[AgentService] 📚 Loaded ${active.length} enabled skills for system prompt`,
+        );
         if (active.length > 0) {
           enabledSkills = active.map((s: SkillRecord) => ({
             id: s.id,
             name: s.name,
             description: s.description,
           }));
-          console.log(`[AgentService] Skills sample: ${enabledSkills.slice(0, 3).map(s => s.name).join(', ')}...`);
+          console.log(
+            `[AgentService] Skills sample: ${enabledSkills
+              .slice(0, 3)
+              .map((s) => s.name)
+              .join(", ")}...`,
+          );
         }
       } catch (error) {
-        console.warn('[AgentService] ⚠️  Skills not initialized yet:', (error as Error).message);
+        console.warn(
+          "[AgentService] ⚠️  Skills not initialized yet:",
+          (error as Error).message,
+        );
         // Skills not initialized yet — proceed without them
       }
       timings.loadSkills = performance.now() - t;
@@ -1008,9 +1048,8 @@ export class AgentService {
       const useAnthropicPromptCache =
         config.provider === "anthropic" && config.authType !== "oauth";
       if (useAnthropicPromptCache) {
-        const { applyAnthropicPromptCacheControl } = await import(
-          "./agent/promptCacheControl.js"
-        );
+        const { applyAnthropicPromptCacheControl } =
+          await import("./agent/promptCacheControl.js");
         const cachedMessages = applyAnthropicPromptCacheControl(messages, {
           provider: config.provider,
           authType: config.authType,
@@ -1067,11 +1106,15 @@ export class AgentService {
           ? priorJobEnv
           : collectJobEnvFromProcess();
       setToolContext(chatId, {
-        ...(Object.keys(mergedJobEnv).length > 0 ? { jobEnv: mergedJobEnv } : {}),
+        ...(Object.keys(mergedJobEnv).length > 0
+          ? { jobEnv: mergedJobEnv }
+          : {}),
       });
       const piToolContext = {
         chatId,
-        ...(Object.keys(mergedJobEnv).length > 0 ? { jobEnv: mergedJobEnv } : {}),
+        ...(Object.keys(mergedJobEnv).length > 0
+          ? { jobEnv: mergedJobEnv }
+          : {}),
       };
 
       // Get model from session
@@ -1103,15 +1146,18 @@ export class AgentService {
           };
         };
         anthropic?: {
-          thinking?: { type: "adaptive"; display?: "summarized" };
+          thinking?:
+            | { type: "adaptive"; display?: "summarized" }
+            | { type: "disabled" };
+          effort?: "low" | "medium" | "high" | "xhigh" | "max";
+          speed?: "fast" | "standard";
         };
       } = {};
 
       // For OpenAI GPT-5.x models with reasoning effort and summary
       if (config.provider === "openai" && config.reasoning?.effort) {
-        const { toOpenAIReasoningEffort } = await import(
-          "../utils/modelNormalizer.js"
-        );
+        const { toOpenAIReasoningEffort } =
+          await import("../utils/modelNormalizer.js");
         providerOptions.openai = {
           reasoningEffort: toOpenAIReasoningEffort(config.reasoning.effort),
           reasoningSummary: "detailed", // Enable detailed reasoning summaries for streaming
@@ -1119,7 +1165,13 @@ export class AgentService {
       }
 
       // For Google Gemini models with thinking capabilities
-      if (
+      if (config.provider === "google" && config.thinking === false) {
+        // Omitting the config lets Gemini apply its own default, which may
+        // think anyway — an explicit zero budget is what actually turns it off.
+        providerOptions.google = {
+          thinkingConfig: { includeThoughts: false, thinkingBudget: 0 },
+        };
+      } else if (
         config.provider === "google" &&
         config.thinkingBudget !== undefined &&
         config.thinkingBudget > 0
@@ -1134,19 +1186,28 @@ export class AgentService {
 
       // For Z.ai GLM models (OpenAI-compatible API with thinking + reasoning_effort)
       if (config.provider === "zai") {
-        const { buildZaiProviderOptions } = await import("../utils/zaiModel.js");
-        Object.assign(providerOptions, buildZaiProviderOptions(config.model, config.reasoning));
+        const { buildZaiProviderOptions } =
+          await import("../utils/zaiModel.js");
+        Object.assign(
+          providerOptions,
+          buildZaiProviderOptions(config.model, config.reasoning),
+        );
       }
 
       // For Groq models (OpenAI-compatible — GPT-OSS supports reasoning_effort)
       if (config.provider === "groq") {
-        const { buildGroqProviderOptions } = await import("../utils/groqModel.js");
-        Object.assign(providerOptions, buildGroqProviderOptions(config.model, config.reasoning));
+        const { buildGroqProviderOptions } =
+          await import("../utils/groqModel.js");
+        Object.assign(
+          providerOptions,
+          buildGroqProviderOptions(config.model, config.reasoning),
+        );
       }
 
       // For Moonshot Kimi K3 (OpenAI-compatible — reasoning_effort=max always)
       if (config.provider === "moonshot") {
-        const { buildMoonshotProviderOptions } = await import("../utils/moonshotModel.js");
+        const { buildMoonshotProviderOptions } =
+          await import("../utils/moonshotModel.js");
         Object.assign(
           providerOptions,
           buildMoonshotProviderOptions(config.model, config.reasoning),
@@ -1162,13 +1223,47 @@ export class AgentService {
       // drops unsigned reasoning with a warning rather than sending a block the API
       // would reject. Turning it off would discard the model's own signed reasoning
       // between tool steps for no safety gain.
-      if (
-        config.provider === "anthropic" &&
-        anthropicModelUsesAdaptiveThinking(config.model)
-      ) {
-        providerOptions.anthropic = {
-          thinking: { type: "adaptive", display: "summarized" },
-        };
+      //
+      // Effort and speed are set here rather than left to the API default so the
+      // AI SDK route matches the pi-ai one, which has always passed effort
+      // through. Without this the same chat reasons at a different depth
+      // depending only on whether the user signed in with a key or with OAuth.
+      if (config.provider === "anthropic") {
+        const anthropicOptions: NonNullable<typeof providerOptions.anthropic> =
+          {};
+
+        if (config.thinking === false) {
+          // The user turned reasoning off. `thinkingBudget: 0` cannot express
+          // this — Opus 5 and Fable 5.1 default to a 0 budget and still think.
+          anthropicOptions.thinking = { type: "disabled" };
+        } else if (anthropicModelUsesAdaptiveThinking(config.model)) {
+          anthropicOptions.thinking = {
+            type: "adaptive",
+            display: "summarized",
+          };
+        }
+
+        // `effort` belongs to the adaptive thinking surface. The budget-thinking
+        // models (Sonnet 4.6, Haiku 4.5, Opus 4.6) take a token budget instead
+        // and have no effort field, so sending it there would be a parameter the
+        // request cannot carry.
+        if (
+          config.reasoning?.effort &&
+          config.thinking !== false &&
+          anthropicModelUsesAdaptiveThinking(config.model)
+        ) {
+          anthropicOptions.effort = config.reasoning.effort;
+        }
+
+        // Fast mode roughly doubles the rate, so it is only ever on when the
+        // user asked for it explicitly.
+        if (config.speed === "fast") {
+          anthropicOptions.speed = "fast";
+        }
+
+        if (Object.keys(anthropicOptions).length > 0) {
+          providerOptions.anthropic = anthropicOptions;
+        }
       }
 
       // For Ollama models (Qwen, Gemma, etc.) — thinking + adaptive context
@@ -1185,7 +1280,7 @@ export class AgentService {
         }
 
         providerOptions.ollama = {
-          think: true,
+          think: config.thinking !== false,
           options: {
             // Context size: 8K for <16GB, 16K for 16-31GB, 32K for 32GB+
             num_ctx: totalRamGb < 16 ? 8192 : totalRamGb < 32 ? 16384 : 32768,
@@ -1239,9 +1334,12 @@ export class AgentService {
         modelId: config.model,
         toolTokenEstimate: toolTokens,
         maxOutputTokens: effectiveMaxTokens,
+        contextLimit: config.contextLimit,
       });
       console.log(
-        `  Model context window: ${modelContextWindow}, history budget: ~${historyTokenBudget} tokens`,
+        `  Model context window: ${modelContextWindow}` +
+          (config.contextLimit ? ` (user cap: ${config.contextLimit})` : "") +
+          `, history budget: ~${historyTokenBudget} tokens`,
       );
       console.log(
         `  Config: maxTokens=${config.maxTokens || "NOT SET"}, maxSteps=${options?.maxSteps || 100}`,
@@ -1254,8 +1352,7 @@ export class AgentService {
         maxTokens: historyTokenBudget,
       });
       if (preFlightTrim.trimmed) {
-        const postTrimEstimate =
-          estimateMessagesTokens(messages) + toolTokens;
+        const postTrimEstimate = estimateMessagesTokens(messages) + toolTokens;
         console.log(
           `[AgentService] Pre-flight context trim (${config.model}): ` +
             `removed ${preFlightTrim.removedTurns} turn(s), ` +
@@ -1284,6 +1381,7 @@ export class AgentService {
       let cumulativeSteps = 0;
       cumulativePromptTokens = 0; // Track actual token usage for adaptive truncation
 
+
       // Native provider search tools (OpenAI web_search, Gemini google_search) target
       // direct provider APIs — they break when the model routes through Papr proxy.
       const nativeSearchTools = config.usePaprProxy
@@ -1298,7 +1396,7 @@ export class AgentService {
       const streamTextOptions: any = {
         model,
         messages,
-        tools: { 
+        tools: {
           ...(tools as unknown as ToolSet),
           ...nativeSearchTools, // Merge native search tools
         },
@@ -1314,7 +1412,7 @@ export class AgentService {
           const stepCount = stopOptions.steps.length;
           const maxSteps = options?.maxSteps ?? 100;
           const FORCE_STOP = 95;
-          
+
           if (stepCount >= FORCE_STOP) {
             console.warn(
               `[AgentService] 🛑 Force stopping at step ${stepCount} (threshold: ${FORCE_STOP}/${maxSteps})`,
@@ -1330,7 +1428,7 @@ export class AgentService {
             );
             return true;
           }
-          
+
           return stepCount >= maxSteps;
         },
         // ⚡ NO TIMEOUT - Allow agents to work as long as needed
@@ -1360,7 +1458,9 @@ export class AgentService {
             usage?: { promptTokens?: number; completionTokens?: number };
           }>;
         }) => {
-          const stepMessageTokens = estimateMessagesTokens(stepOptions.messages);
+          const stepMessageTokens = estimateMessagesTokens(
+            stepOptions.messages,
+          );
           const totalPromptTokens =
             cumulativePromptTokens > 0
               ? cumulativePromptTokens
@@ -1400,9 +1500,8 @@ export class AgentService {
           });
 
           if (useAnthropicPromptCache) {
-            const { applyAnthropicPromptCacheControl } = await import(
-              "./agent/promptCacheControl.js"
-            );
+            const { applyAnthropicPromptCacheControl } =
+              await import("./agent/promptCacheControl.js");
             const cached = applyAnthropicPromptCacheControl(msgs, {
               provider: config.provider,
               authType: config.authType,
@@ -1435,9 +1534,8 @@ export class AgentService {
           cumulativePromptTokens = inputTokens;
 
           if (useAnthropicPromptCache) {
-            const { extractCacheUsageFromStep } = await import(
-              "./agent/promptCacheControl.js"
-            );
+            const { extractCacheUsageFromStep } =
+              await import("./agent/promptCacheControl.js");
             const cache = extractCacheUsageFromStep(step);
             lastCacheReadTokens = cache.cacheReadTokens;
             lastCacheWriteTokens = cache.cacheWriteTokens;
@@ -1472,13 +1570,15 @@ export class AgentService {
             streamOpts: Record<string, unknown>;
           }
         | undefined;
-      
+
       // Check if model is actually supported by pi-ai before using OAuth route
-      const { isOpenAICodexModel } = await import("../utils/modelNormalizer.js");
-      const modelSupportsPiAi = config.provider === "openai" || config.provider === "openai-codex"
-        ? isOpenAICodexModel(config.model)
-        : true; // Anthropic models always support pi-ai
-      
+      const { isOpenAICodexModel } =
+        await import("../utils/modelNormalizer.js");
+      const modelSupportsPiAi =
+        config.provider === "openai" || config.provider === "openai-codex"
+          ? isOpenAICodexModel(config.model)
+          : true; // Anthropic models always support pi-ai
+
       const usePiAiOpenAI =
         (config.provider === "openai" || config.provider === "openai-codex") &&
         config.authType === "oauth" &&
@@ -1515,7 +1615,7 @@ export class AgentService {
           ? "openai-codex-responses"
           : "anthropic-messages";
         const envKey = useCodex ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
-        
+
         // Use apiKey from config (which includes OAuth tokens)
         const token = config.apiKey || process.env[envKey];
         const errorHint = useCodex
@@ -1524,8 +1624,8 @@ export class AgentService {
 
         console.log(
           `[AgentService] Pi-ai token check: provider=${piProvider} ` +
-          `hasConfigApiKey=${!!config.apiKey} hasEnvKey=${!!process.env[envKey]} ` +
-          `tokenLength=${token?.length || 0}`
+            `hasConfigApiKey=${!!config.apiKey} hasEnvKey=${!!process.env[envKey]} ` +
+            `tokenLength=${token?.length || 0}`,
         );
 
         if (!token) {
@@ -1533,7 +1633,7 @@ export class AgentService {
             `${piProvider === "anthropic" ? "Anthropic" : "OpenAI"} token not found. ${errorHint}`,
           );
         }
-        
+
         // Set token in environment for pi-ai (it reads from process.env)
         const piToken =
           useCodex && config.authType === "oauth"
@@ -1543,17 +1643,19 @@ export class AgentService {
             : token;
         // This env var doubles as the Platform API key, so keep the real one
         // recoverable for when the user switches this provider to API key mode.
-        (
-          await import("../utils/keyResolver.js")
-        ).preserveEnvKeyBeforeOverwrite(envKey);
+        (await import("../utils/keyResolver.js")).preserveEnvKeyBeforeOverwrite(
+          envKey,
+        );
         process.env[envKey] = piToken;
-        console.log(`[AgentService] Set ${envKey} in process.env (length: ${piToken.length})`);
+        console.log(
+          `[AgentService] Set ${envKey} in process.env (length: ${piToken.length})`,
+        );
 
         const piModel = (getModel as (p: string, m: string) => unknown)(
           piProvider,
           piModelId,
         );
-        
+
         // If model not found in pi-ai registry, create it manually
         // Both ChatGPT and Claude backends support models not yet in pi-ai registry
         let finalModel = piModel;
@@ -1562,7 +1664,7 @@ export class AgentService {
             console.log(
               `[AgentService] Model ${piModelId} not in pi-ai registry, creating manually for ChatGPT backend`,
             );
-            
+
             // Create model object matching pi-ai's Model interface
             // Manual registry entry when pi-ai has not listed the id yet
             const isMini = piModelId === "gpt-5.4-mini";
@@ -1610,7 +1712,7 @@ export class AgentService {
                       : isMini
                         ? "GPT-5.4 mini"
                         : "GPT-5.4";
-            
+
             finalModel = {
               id: piModelId,
               name: displayName,
@@ -1633,7 +1735,7 @@ export class AgentService {
             console.log(
               `[AgentService] Model ${piModelId} not in pi-ai registry, creating manually for Anthropic backend`,
             );
-            
+
             // Map model ID to display name and pricing
             const modelInfo = piModelId.includes("fable")
               ? {
@@ -1661,33 +1763,33 @@ export class AgentService {
                       contextWindow: 1000000,
                     }
                   : piModelId.includes("opus")
-                  ? {
-                      name: "Claude Opus 4.6",
-                      inputCost: 15.0,
-                      outputCost: 75.0,
-                      contextWindow: 200000,
-                    }
-                : piModelId.includes("sonnet-5")
-                  ? {
-                      name: "Claude Sonnet 5",
-                      inputCost: 3.0,
-                      outputCost: 15.0,
-                      contextWindow: 1000000,
-                    }
-                  : piModelId.includes("sonnet")
                     ? {
-                        name: "Claude Sonnet 4.6",
-                        inputCost: 3.0,
-                        outputCost: 15.0,
+                        name: "Claude Opus 4.6",
+                        inputCost: 15.0,
+                        outputCost: 75.0,
                         contextWindow: 200000,
                       }
-                    : {
-                        name: "Claude Haiku 4.5",
-                        inputCost: 0.8,
-                        outputCost: 4.0,
-                        contextWindow: 200000,
-                      };
-            
+                    : piModelId.includes("sonnet-5")
+                      ? {
+                          name: "Claude Sonnet 5",
+                          inputCost: 3.0,
+                          outputCost: 15.0,
+                          contextWindow: 1000000,
+                        }
+                      : piModelId.includes("sonnet")
+                        ? {
+                            name: "Claude Sonnet 4.6",
+                            inputCost: 3.0,
+                            outputCost: 15.0,
+                            contextWindow: 200000,
+                          }
+                        : {
+                            name: "Claude Haiku 4.5",
+                            inputCost: 0.8,
+                            outputCost: 4.0,
+                            contextWindow: 200000,
+                          };
+
             finalModel = {
               id: piModelId,
               name: modelInfo.name,
@@ -1716,16 +1818,17 @@ export class AgentService {
             };
           }
         }
-        
+
         console.log(
-          `[AgentService] Using pi-ai model: ${finalModel ? (finalModel as any).id : 'null'} ` +
-          `api=${finalModel ? (finalModel as any).api : 'null'} ` +
-          `baseUrl=${finalModel ? (finalModel as any).baseUrl : 'null'}`
+          `[AgentService] Using pi-ai model: ${finalModel ? (finalModel as any).id : "null"} ` +
+            `api=${finalModel ? (finalModel as any).api : "null"} ` +
+            `baseUrl=${finalModel ? (finalModel as any).baseUrl : "null"}`,
         );
-        
+
         // Build native web search tools for pi-ai providers
-        const nativeSearchTools = this.buildNativeSearchToolsForPiAi(piProvider);
-        
+        const nativeSearchTools =
+          this.buildNativeSearchToolsForPiAi(piProvider);
+
         const piContext = buildPiContext({
           messages: messages as any[],
           tools: tools as any,
@@ -1736,15 +1839,19 @@ export class AgentService {
         });
 
         // 🔍 LOG EXACT CONTEXT SENT TO PI-AI
-        console.log(`\n${'='.repeat(100)}`);
+        console.log(`\n${"=".repeat(100)}`);
         console.log(`🟡 STAGE 3: SENDING CONTEXT TO LLM (PI-AI)`);
-        console.log(`${'='.repeat(100)}`);
+        console.log(`${"=".repeat(100)}`);
         console.log(`[STAGE 3] Model: ${piModelId}`);
         console.log(`[STAGE 3] Provider: ${piProvider}`);
-        console.log(`[STAGE 3] Total messages: ${piContext.messages?.length || 0}`);
-        console.log(`[STAGE 3] System prompt length: ${piContext.systemPrompt?.length || 0} chars`);
+        console.log(
+          `[STAGE 3] Total messages: ${piContext.messages?.length || 0}`,
+        );
+        console.log(
+          `[STAGE 3] System prompt length: ${piContext.systemPrompt?.length || 0} chars`,
+        );
         console.log(`[STAGE 3] Tools available: ${Object.keys(tools).length}`);
-        
+
         // Log role distribution
         if (piContext.messages && Array.isArray(piContext.messages)) {
           const roleCount = piContext.messages.reduce((acc: any, m: any) => {
@@ -1753,36 +1860,42 @@ export class AgentService {
           }, {});
           console.log(`[STAGE 3] Role distribution in context:`, roleCount);
         }
-        
+
         console.log(`\n[STAGE 3] FIRST 5 MESSAGES (should be oldest):`);
-        console.log(`${'─'.repeat(100)}`);
+        console.log(`${"─".repeat(100)}`);
         if (piContext.messages && Array.isArray(piContext.messages)) {
           piContext.messages.slice(0, 5).forEach((msg: any, i: number) => {
-            const contentPreview = typeof msg.content === 'string' 
-              ? msg.content.substring(0, 80)
-              : Array.isArray(msg.content)
-                ? `Array[${msg.content.length}]: ${JSON.stringify(msg.content[0]).substring(0, 60)}...`
-                : JSON.stringify(msg.content).substring(0, 80);
-            const timestamp = msg.timestamp || 'no-timestamp';
-            console.log(`  [${i}] ${msg.role.padEnd(12)} | ts:${timestamp} | ${contentPreview}`);
+            const contentPreview =
+              typeof msg.content === "string"
+                ? msg.content.substring(0, 80)
+                : Array.isArray(msg.content)
+                  ? `Array[${msg.content.length}]: ${JSON.stringify(msg.content[0]).substring(0, 60)}...`
+                  : JSON.stringify(msg.content).substring(0, 80);
+            const timestamp = msg.timestamp || "no-timestamp";
+            console.log(
+              `  [${i}] ${msg.role.padEnd(12)} | ts:${timestamp} | ${contentPreview}`,
+            );
           });
         }
         console.log(`\n[STAGE 3] LAST 10 MESSAGES (should be newest):`);
-        console.log(`${'─'.repeat(100)}`);
+        console.log(`${"─".repeat(100)}`);
         if (piContext.messages && Array.isArray(piContext.messages)) {
           const startIdx = Math.max(0, piContext.messages.length - 10);
           piContext.messages.slice(startIdx).forEach((msg: any, i: number) => {
             const actualIdx = startIdx + i;
-            const contentPreview = typeof msg.content === 'string' 
-              ? msg.content.substring(0, 80)
-              : Array.isArray(msg.content)
-                ? `Array[${msg.content.length}]: ${JSON.stringify(msg.content[0]).substring(0, 60)}...`
-                : JSON.stringify(msg.content).substring(0, 80);
-            const timestamp = msg.timestamp || 'no-timestamp';
-            console.log(`  [${actualIdx}] ${msg.role.padEnd(12)} | ts:${timestamp} | ${contentPreview}`);
+            const contentPreview =
+              typeof msg.content === "string"
+                ? msg.content.substring(0, 80)
+                : Array.isArray(msg.content)
+                  ? `Array[${msg.content.length}]: ${JSON.stringify(msg.content[0]).substring(0, 60)}...`
+                  : JSON.stringify(msg.content).substring(0, 80);
+            const timestamp = msg.timestamp || "no-timestamp";
+            console.log(
+              `  [${actualIdx}] ${msg.role.padEnd(12)} | ts:${timestamp} | ${contentPreview}`,
+            );
           });
         }
-        console.log(`${'='.repeat(100)}\n`);
+        console.log(`${"=".repeat(100)}\n`);
 
         const piHistoryTrimBounds = computeHistoryTrimBounds(
           (piContext.messages ?? []) as Array<{
@@ -1829,18 +1942,17 @@ export class AgentService {
 
         let streamOpts: PiAiStreamOptions = baseStreamOpts;
         if (useCodex) {
-          const { augmentPiAiCodexStreamOptions } = await import(
-            "./providers/piAiCodexResponsesLite.js"
-          );
+          const { augmentPiAiCodexStreamOptions } =
+            await import("./providers/piAiCodexResponsesLite.js");
           streamOpts = augmentPiAiCodexStreamOptions(piModelId, baseStreamOpts);
         } else {
-          const { augmentPiAiAnthropicStreamOptions } = await import(
-            "./providers/piAiAnthropicAdaptiveThinking.js"
-          );
+          const { augmentPiAiAnthropicStreamOptions } =
+            await import("./providers/piAiAnthropicAdaptiveThinking.js");
           streamOpts = augmentPiAiAnthropicStreamOptions(
             piModelId,
             reasoningLevel,
             baseStreamOpts,
+            config.thinking !== false,
           );
         }
         const apiKeys = getApiKeysForSanitization();
@@ -1861,6 +1973,7 @@ export class AgentService {
           piToolContext,
           // Resume the loop when the model stops with plan work outstanding.
           async (stopInfo) => {
+
             if (abortController.signal.aborted) {
               return null;
             }
@@ -1906,6 +2019,7 @@ export class AgentService {
         getStreamProfiler(chatId)?.mark("gateway.piAiInit");
       } else {
         // Use AI SDK for standard providers (OpenAI Platform, Anthropic, Google)
+
         
         const streamProfiler = getStreamProfiler(chatId);
         await streamProfiler?.measure("gateway.aiSdk.contextLog", async () => {
@@ -1935,15 +2049,15 @@ export class AgentService {
 
         aiSdkStreamResult = await streamText(streamTextOptions);
         if (config.provider === "groq") {
-          const { adaptGroqAISDKFullStream } = await import(
-            "../utils/groqProvider.js"
-          );
+          const { adaptGroqAISDKFullStream } =
+            await import("../utils/groqProvider.js");
           fullStream = adaptGroqAISDKFullStream(aiSdkStreamResult.fullStream);
         } else if (config.provider === "moonshot") {
-          const { adaptMoonshotAISDKFullStream } = await import(
-            "../utils/moonshotProvider.js"
+          const { adaptMoonshotAISDKFullStream } =
+            await import("../utils/moonshotProvider.js");
+          fullStream = adaptMoonshotAISDKFullStream(
+            aiSdkStreamResult.fullStream,
           );
-          fullStream = adaptMoonshotAISDKFullStream(aiSdkStreamResult.fullStream);
         } else {
           fullStream = aiSdkStreamResult.fullStream;
         }
@@ -1960,12 +2074,17 @@ export class AgentService {
       // turn was saved with sequence=NULL and the UI rendered the legacy
       // duplicate-narration layout.
       sequence = [];
-      const streamIterator = orchestrateModelStream(fullStream, chatId, apiKeys, {
-        sequence,
-        ...(config.provider === "groq" || config.provider === "moonshot"
-          ? { textBufferMin: 1 }
-          : {}),
-      });
+      const streamIterator = orchestrateModelStream(
+        fullStream,
+        chatId,
+        apiKeys,
+        {
+          sequence,
+          ...(config.provider === "groq" || config.provider === "moonshot"
+            ? { textBufferMin: 1 }
+            : {}),
+        },
+      );
 
       // Tell the UI the stable row id before any content chunks so reconnect /
       // history merge cannot fork one turn into two message ids.
@@ -2112,23 +2231,29 @@ export class AgentService {
         // authoritative copy until it returns (next.done).
         const chunkType = next.value.type;
         if (chunkType === "text-delta") {
-          const textPayload = next.value.payload as { text?: string } | undefined;
+          const textPayload = next.value.payload as
+            | { text?: string }
+            | undefined;
           if (textPayload?.text) {
             assistantText += textPayload.text;
             checkpointBytesEstimate += textPayload.text.length;
           }
         } else if (chunkType === "reasoning-delta") {
-          const reasonPayload = next.value.payload as { text?: string } | undefined;
+          const reasonPayload = next.value.payload as
+            | { text?: string }
+            | undefined;
           if (reasonPayload?.text) {
             thinkingText += reasonPayload.text;
             checkpointBytesEstimate += reasonPayload.text.length;
           }
         } else if (chunkType === "tool-call") {
-          const tcPayload = next.value.payload as {
-            toolCallId?: string;
-            toolName?: string;
-            args?: Record<string, unknown>;
-          } | undefined;
+          const tcPayload = next.value.payload as
+            | {
+                toolCallId?: string;
+                toolName?: string;
+                args?: Record<string, unknown>;
+              }
+            | undefined;
           if (tcPayload?.toolCallId) {
             toolCalls.push({
               toolCallId: tcPayload.toolCallId,
@@ -2141,11 +2266,13 @@ export class AgentService {
             immediateCheckpoint();
           }
         } else if (chunkType === "tool-result") {
-          const trPayload = next.value.payload as {
-            toolCallId?: string;
-            toolName?: string;
-            result?: unknown;
-          } | undefined;
+          const trPayload = next.value.payload as
+            | {
+                toolCallId?: string;
+                toolName?: string;
+                result?: unknown;
+              }
+            | undefined;
           if (trPayload?.toolCallId) {
             recordInFlightToolResult(
               chatId,
@@ -2341,9 +2468,8 @@ export class AgentService {
       // turn is complete"; sending that while steps are still pending reports
       // unfinished work to the user as done, so pending steps switch it to an
       // honest status request instead.
-      const { WRAP_UP_WITH_PLAN_INCOMPLETE } = await import(
-        "./agent/wrapUpContinuation.js"
-      );
+      const { WRAP_UP_WITH_PLAN_INCOMPLETE } =
+        await import("./agent/wrapUpContinuation.js");
       const turnEndPlanState = await this.loadPendingPlanState(chatId);
       const wrapUpNeeded = shouldRequestWrapUpSummary({
         sequence,
@@ -2512,11 +2638,15 @@ export class AgentService {
         toolCalls.length === 0 &&
         !abortController.signal.aborted;
 
-      if (isEmpty && !options?._isSilentRetry && !options?._isContextCompressRetry) {
+      if (
+        isEmpty &&
+        !options?._isSilentRetry &&
+        !options?._isContextCompressRetry
+      ) {
         console.warn(
           `[AgentService] Empty completion detected (model returned 0 tokens of content). ` +
-          `Silently retrying once to self-heal — likely caused by a stale orphaned tool_use ` +
-          `in history that gets fixed on reload. chatId=${chatId} model=${config.model}`,
+            `Silently retrying once to self-heal — likely caused by a stale orphaned tool_use ` +
+            `in history that gets fixed on reload. chatId=${chatId} model=${config.model}`,
         );
 
         // Don't save the empty assistant message. Don't yield 'done'. Just
@@ -2548,7 +2678,7 @@ export class AgentService {
         // naturally retry the conversation with healed history.
         console.warn(
           `[AgentService] Silent retry also returned empty completion. ` +
-          `Skipping save to keep chat clean. chatId=${chatId}`,
+            `Skipping save to keep chat clean. chatId=${chatId}`,
         );
         // DON'T yield "done" here - if this is a nested call (compression retry),
         // the parent would pass it to UI and create an empty message. Just return.
@@ -2610,7 +2740,7 @@ export class AgentService {
       // 6. Check if summarization is needed
       // Use actual context size (from AI SDK or tokenUsage) not just message tokens
       const stats = await this.storageManager.getChatStats(chatId);
-      
+
       const actualContextTokens = this.resolveActualContextTokens({
         cumulativePromptTokens,
         piAiContextTokens,
@@ -2619,13 +2749,17 @@ export class AgentService {
         lastCacheWriteTokens,
       });
       const messageTokens = stats.token_count;
-      
+
       console.log(`[AgentService] 📊 Chat stats after stream:`);
-      console.log(`  Messages in DB: ${stats.message_count}, has_summary: ${stats.has_summary}`);
+      console.log(
+        `  Messages in DB: ${stats.message_count}, has_summary: ${stats.has_summary}`,
+      );
       console.log(`  Message tokens (DB): ${messageTokens}`);
       console.log(`  Actual context tokens: ${actualContextTokens}`);
-      console.log(`  Context overhead: ${actualContextTokens - messageTokens} tokens (system prompts, tools, attachments, etc.)`);
-      
+      console.log(
+        `  Context overhead: ${actualContextTokens - messageTokens} tokens (system prompts, tools, attachments, etc.)`,
+      );
+
       const estimatedFullContextTokens = Math.ceil(
         JSON.stringify(messages).length / 4,
       );
@@ -2666,9 +2800,8 @@ export class AgentService {
       await persistIncompleteAssistant({ asAbort: true });
 
       if (concurrencyLease) {
-        const { getAgentStreamConcurrencyGate } = await import(
-          "./agent/agentStreamConcurrency.js"
-        );
+        const { getAgentStreamConcurrencyGate } =
+          await import("./agent/agentStreamConcurrency.js");
         getAgentStreamConcurrencyGate().release(concurrencyLease);
       }
 
@@ -2702,9 +2835,8 @@ export class AgentService {
     // Release concurrency lease immediately so replacement streams don't queue.
     // The generator's finally block will also call release(), but that's a no-op
     // if the lease was already released (token won't match).
-    const { getAgentStreamConcurrencyGate } = await import(
-      "./agent/agentStreamConcurrency.js"
-    );
+    const { getAgentStreamConcurrencyGate } =
+      await import("./agent/agentStreamConcurrency.js");
     getAgentStreamConcurrencyGate().forceReleaseByChatId(chatId);
   }
 
@@ -2797,12 +2929,8 @@ export class AgentService {
     }
     return (
       (params.tokenUsage.promptTokens || 0) +
-      (params.tokenUsage.cacheReadTokens ||
-        params.lastCacheReadTokens ||
-        0) +
-      (params.tokenUsage.cacheWriteTokens ||
-        params.lastCacheWriteTokens ||
-        0)
+      (params.tokenUsage.cacheReadTokens || params.lastCacheReadTokens || 0) +
+      (params.tokenUsage.cacheWriteTokens || params.lastCacheWriteTokens || 0)
     );
   }
 
@@ -2892,9 +3020,8 @@ export class AgentService {
           });
           if (response.summaries) {
             const s = response.summaries;
-            const { extractEnhancedFields } = await import(
-              "./storage/summaryFormatting.js"
-            );
+            const { extractEnhancedFields } =
+              await import("./storage/summaryFormatting.js");
             const summary: import("./storage/IStorageProvider.js").StoredSummary =
               {
                 short_term: s.short_term ?? "",
@@ -2983,9 +3110,8 @@ export class AgentService {
         : conversationText;
 
     // Select cheapest available model (OAuth or API key)
-    const { generateCheapSummaryText } = await import(
-      "../utils/cheapSummarizerModel.js"
-    );
+    const { generateCheapSummaryText } =
+      await import("../utils/cheapSummarizerModel.js");
 
     const systemPrompt = `You are a conversation summarizer. Produce a JSON object with exactly these four fields:
 
@@ -3089,7 +3215,11 @@ ${last15.substring(0, 8_000)}`;
   /**
    * Get chat history
    */
-  async getChatHistory(chatId: string, limit?: number, skip?: number): Promise<StoredMessage[]> {
+  async getChatHistory(
+    chatId: string,
+    limit?: number,
+    skip?: number,
+  ): Promise<StoredMessage[]> {
     return await this.storageManager.loadMessages(chatId, limit, skip);
   }
 
@@ -3139,7 +3269,7 @@ ${last15.substring(0, 8_000)}`;
   /**
    * Get detailed context breakdown for inspection
    * Shows what will be sent to the LLM on next turn
-   * 
+   *
    * CRITICAL: This MUST use the exact same logic as streamText() to ensure
    * the context inspector shows exactly what the LLM sees
    */
@@ -3156,9 +3286,13 @@ ${last15.substring(0, 8_000)}`;
     const session = this.sessionManager.getSessionIfExists(chatId);
     if (session) {
       actualModel = session.config.model;
-      console.log(`[AgentService] Context inspector: using session model ${actualModel} instead of UI model ${selectedModel}`);
+      console.log(
+        `[AgentService] Context inspector: using session model ${actualModel} instead of UI model ${selectedModel}`,
+      );
     } else {
-      console.log(`[AgentService] Context inspector: no active session, using UI model ${selectedModel}`);
+      console.log(
+        `[AgentService] Context inspector: no active session, using UI model ${selectedModel}`,
+      );
     }
 
     // Load history - EXACTLY the same way as the actual agent run
@@ -3176,8 +3310,11 @@ ${last15.substring(0, 8_000)}`;
     });
 
     // Load skills
-    let enabledSkills: Array<{ id: string; name: string; description: string }> =
-      [];
+    let enabledSkills: Array<{
+      id: string;
+      name: string;
+      description: string;
+    }> = [];
     try {
       const { getSkillService } = await import("./SkillService.js");
       const skillService = getSkillService();
@@ -3203,14 +3340,16 @@ ${last15.substring(0, 8_000)}`;
 
     // Get all available tools
     const allTools = this.toolRegistry.getTools();
-    const toolSchemas = Object.entries(allTools).map(([id, tool]: [string, any]) => ({
-      id,
-      description: tool.description,
-      // Simplified schema for display
-      parameters: tool.inputSchema
-        ? JSON.parse(JSON.stringify(tool.inputSchema))
-        : null,
-    }));
+    const toolSchemas = Object.entries(allTools).map(
+      ([id, tool]: [string, any]) => ({
+        id,
+        description: tool.description,
+        // Simplified schema for display
+        parameters: tool.inputSchema
+          ? JSON.parse(JSON.stringify(tool.inputSchema))
+          : null,
+      }),
+    );
 
     // Load workspace context separately for display
     // NOTE: Workspace files are ALREADY in the system prompt
@@ -3273,7 +3412,10 @@ ${last15.substring(0, 8_000)}`;
           { mode: "inspect" },
         );
       } catch (error) {
-        console.warn("[AgentService] Context inspector memory bootstrap failed:", error);
+        console.warn(
+          "[AgentService] Context inspector memory bootstrap failed:",
+          error,
+        );
       }
     }
 
@@ -3326,14 +3468,11 @@ ${last15.substring(0, 8_000)}`;
       ? estimateTokens(relatedMemoryContent)
       : 0;
     const memoryBootstrapTokens =
-      goalsOkrsTokens +
-      useCasesTokens +
-      syncTiersTokens +
-      relatedMemoryTokens;
+      goalsOkrsTokens + useCasesTokens + syncTiersTokens + relatedMemoryTokens;
 
     // Break down token counts
     const systemPromptTokens = estimateTokens(systemPrompt);
-    
+
     // Conversation summary is injected as a USER message, not in system prompt
     const conversationSummaryTokens = conversationSummary
       ? estimateTokens(conversationSummary)
@@ -3409,12 +3548,14 @@ ${last15.substring(0, 8_000)}`;
         if (textParts.length > 0) {
           content = textParts.map((p: any) => p.text).join(" ");
         }
-        
+
         // If this assistant message has tool-calls, look for the next tool message
         if (toolCallParts.length > 0) {
-          const toolNames = toolCallParts.map((p: any) => p.toolName).join(", ");
+          const toolNames = toolCallParts
+            .map((p: any) => p.toolName)
+            .join(", ");
           content += `\n→ Called tools: ${toolNames}`;
-          
+
           // Look ahead for the tool results message (should be next)
           if (i + 1 < messages.length && messages[i + 1].role === "tool") {
             const toolMsg = messages[i + 1];
@@ -3496,8 +3637,10 @@ ${last15.substring(0, 8_000)}`;
         memoryBootstrap: {
           tokens: memoryBootstrapTokens,
           wouldRunOnNextTurn: memoryBootstrapOnNextTurn,
-          deferredBootstrap:
-            memoryContextService.willInjectOnNextSend(chatId, history),
+          deferredBootstrap: memoryContextService.willInjectOnNextSend(
+            chatId,
+            history,
+          ),
           note: memoryBootstrapOnNextTurn
             ? memoryContextService.willInjectOnNextSend(chatId, history)
               ? "Deferred bootstrap ready — injects as user messages on your next send (after summary, before history)"
@@ -3544,9 +3687,7 @@ ${last15.substring(0, 8_000)}`;
           note: "Skill references are in system prompt (counted there)",
         },
         plans: {
-          tokens: activePlansContext
-            ? estimateTokens(activePlansContext)
-            : 0,
+          tokens: activePlansContext ? estimateTokens(activePlansContext) : 0,
           count: activePlans.length,
           plans: activePlans,
           note: "Injected as user message after history (not in cached system prompt)",
@@ -3828,59 +3969,64 @@ ${last15.substring(0, 8_000)}`;
       }
 
       if (!resolvedExplicitFallback) {
-      // Try smart fallback based on original model capabilities
-      const { getBestFallbackModel } = await import("../utils/smartFallback.js");
-      const { getAvailableProviders } = await import("../utils/defaultProvider.js");
-      
-      const available = await getAvailableProviders();
-      const fallback = await getBestFallbackModel(
-        originalProvider,
-        input.model || "unknown",
-        available,
-      );
+        // Try smart fallback based on original model capabilities
+        const { getBestFallbackModel } =
+          await import("../utils/smartFallback.js");
+        const { getAvailableProviders } =
+          await import("../utils/defaultProvider.js");
 
-      if (fallback) {
-        provider = fallback.provider;
-        model = fallback.model;
-        console.log(
-          `[AgentService] Smart fallback: ${originalProvider}/${input.model || "default"} → ${provider}/${model} (capability-matched)`,
+        const available = await getAvailableProviders();
+        const fallback = await getBestFallbackModel(
+          originalProvider,
+          input.model || "unknown",
+          available,
         );
-      } else {
-        // No smart fallback available, use basic default
-        const { getDefaultProviderAndModel } = await import("../utils/defaultProvider.js");
-        const defaults = await getDefaultProviderAndModel();
-        provider = defaults.provider;
-        model = defaults.model;
-        console.log(
-          `[AgentService] Falling back from ${originalProvider} to ${provider}/${model}`,
-        );
-      }
 
-      // Re-check auth for fallback provider
-      if (provider === "openai" || provider === "anthropic") {
-        const auth = await getProviderAuth(provider);
-        if (!auth) {
-          throw new Error(
-            `No authentication found for fallback provider (${provider}). Please configure at least one provider.`,
+        if (fallback) {
+          provider = fallback.provider;
+          model = fallback.model;
+          console.log(
+            `[AgentService] Smart fallback: ${originalProvider}/${input.model || "default"} → ${provider}/${model} (capability-matched)`,
+          );
+        } else {
+          // No smart fallback available, use basic default
+          const { getDefaultProviderAndModel } =
+            await import("../utils/defaultProvider.js");
+          const defaults = await getDefaultProviderAndModel();
+          provider = defaults.provider;
+          model = defaults.model;
+          console.log(
+            `[AgentService] Falling back from ${originalProvider} to ${provider}/${model}`,
           );
         }
-        apiKey = auth.type === "oauth" ? auth.token : auth.key;
-        authType = auth.type;
-      } else if (provider === "google") {
-        const keys = await getApiKeys(["GOOGLE_API_KEY"]);
-        apiKey = keys.GOOGLE_API_KEY;
-        if (!apiKey) {
-          throw new Error(`Missing API key for fallback provider: GOOGLE_API_KEY`);
+
+        // Re-check auth for fallback provider
+        if (provider === "openai" || provider === "anthropic") {
+          const auth = await getProviderAuth(provider);
+          if (!auth) {
+            throw new Error(
+              `No authentication found for fallback provider (${provider}). Please configure at least one provider.`,
+            );
+          }
+          apiKey = auth.type === "oauth" ? auth.token : auth.key;
+          authType = auth.type;
+        } else if (provider === "google") {
+          const keys = await getApiKeys(["GOOGLE_API_KEY"]);
+          apiKey = keys.GOOGLE_API_KEY;
+          if (!apiKey) {
+            throw new Error(
+              `Missing API key for fallback provider: GOOGLE_API_KEY`,
+            );
+          }
+        } else if (provider === "ollama") {
+          // Ollama doesn't need auth
+          apiKey = ""; // Empty string for Ollama
+        } else {
+          // Unexpected provider without auth setup
+          throw new Error(
+            `No authentication configuration found for fallback provider: ${provider}`,
+          );
         }
-      } else if (provider === "ollama") {
-        // Ollama doesn't need auth
-        apiKey = ""; // Empty string for Ollama
-      } else {
-        // Unexpected provider without auth setup
-        throw new Error(
-          `No authentication configuration found for fallback provider: ${provider}`,
-        );
-      }
       }
     }
 
@@ -3910,113 +4056,118 @@ ${last15.substring(0, 8_000)}`;
 
     try {
       try {
-        for await (const chunk of this.streamAgent(chatId, input.prompt, config, {
-          allowedToolIds: input.allowedToolIds,
-          maxSteps: input.maxTurns,
-        })) {
-        if (chunk.type === "error") {
-          const errMsg =
-            (chunk.payload as { error?: string })?.error ?? "Model API error";
-          lastStreamError = errMsg;
+        for await (const chunk of this.streamAgent(
+          chatId,
+          input.prompt,
+          config,
+          {
+            allowedToolIds: input.allowedToolIds,
+            maxSteps: input.maxTurns,
+          },
+        )) {
+          if (chunk.type === "error") {
+            const errMsg =
+              (chunk.payload as { error?: string })?.error ?? "Model API error";
+            lastStreamError = errMsg;
 
-          // Check if this is an OAuth rate limit error
-          if (
-            authType === "oauth" &&
-            (errMsg.includes("usage limit") ||
-              errMsg.includes("rate limit") ||
-              errMsg.includes("Try again in"))
-          ) {
-            console.log(
-              `[AgentService] OAuth rate limit hit for ${provider}. Retrying with API key...`,
+            // Check if this is an OAuth rate limit error
+            if (
+              authType === "oauth" &&
+              (errMsg.includes("usage limit") ||
+                errMsg.includes("rate limit") ||
+                errMsg.includes("Try again in"))
+            ) {
+              console.log(
+                `[AgentService] OAuth rate limit hit for ${provider}. Retrying with API key...`,
+              );
+              retryWithApiKey = true;
+              break; // Exit the stream loop to retry
+            }
+
+            throw new Error(
+              `Agent job model error (${provider}/${model}): ${errMsg}`,
             );
-            retryWithApiKey = true;
-            break; // Exit the stream loop to retry
           }
 
-          throw new Error(
-            `Agent job model error (${provider}/${model}): ${errMsg}`,
-          );
-        }
-
-        // Log structured activity to job logs (thinking, tool calls, results)
-        if (chunk.type === "tool-call") {
-          toolCallCount += 1;
-        } else if (chunk.type === "tool-result") {
-          const payload = chunk.payload as ToolResultPayload;
-          const resultRecord =
-            payload.result != null && typeof payload.result === "object"
-              ? (payload.result as Record<string, unknown>)
-              : null;
-          if (resultRecord?.__orphan === true) {
-            orphanToolCount += 1;
-          }
-        }
-
-        if (input.appendLog) {
-          if (chunk.type === "reasoning-delta") {
-            const payload = chunk.payload as ReasoningDeltaPayload;
-            if (typeof payload.text === "string") {
-              thinkingBuffer += payload.text;
-            }
-          } else if (chunk.type === "tool-call") {
-            // Flush thinking buffer before logging tool call
-            if (thinkingBuffer.trim()) {
-              await input.appendLog(`💭 Thinking: ${thinkingBuffer.trim()}`);
-              thinkingBuffer = "";
-            }
-            const payload = chunk.payload as ToolCallPayload;
-            const argsStr = payload.args
-              ? JSON.stringify(payload.args).slice(0, 200)
-              : "";
-            await input.appendLog(
-              `🔧 Tool: ${payload.toolName}${argsStr ? `(${argsStr}${argsStr.length >= 200 ? "..." : ""})` : "()"}`,
-            );
+          // Log structured activity to job logs (thinking, tool calls, results)
+          if (chunk.type === "tool-call") {
+            toolCallCount += 1;
           } else if (chunk.type === "tool-result") {
             const payload = chunk.payload as ToolResultPayload;
-            const resultStr =
-              typeof payload.result === "string"
-                ? payload.result.slice(0, 300)
-                : JSON.stringify(payload.result).slice(0, 300);
-            await input.appendLog(
-              `✅ Result: ${resultStr}${resultStr.length >= 300 ? "..." : ""}`,
-            );
-          } else if (chunk.type === "tool-error") {
-            const payload = chunk.payload as ErrorPayload;
-            await input.appendLog(
-              `❌ Error: ${typeof payload.error === "string" ? payload.error : JSON.stringify(payload.error)}`,
-            );
-          } else if (chunk.type === "text-delta") {
-            // Flush thinking buffer when text starts (thinking is done)
-            if (thinkingBuffer.trim()) {
-              await input.appendLog(`💭 Thinking: ${thinkingBuffer.trim()}`);
-              thinkingBuffer = "";
+            const resultRecord =
+              payload.result != null && typeof payload.result === "object"
+                ? (payload.result as Record<string, unknown>)
+                : null;
+            if (resultRecord?.__orphan === true) {
+              orphanToolCount += 1;
             }
           }
-        }
 
-        // Broadcast sub-agent activity to MiniChatCard (thinking, tool calls, results)
-        if (input.delegationId) {
-          const { broadcast } = await import("../websocket/index.js");
-          broadcast({
-            type: "subagent-chat:activity",
-            data: {
-              delegationId: input.delegationId,
-              chunk: {
-                type: chunk.type,
-                payload: chunk.payload,
-                timestamp: chunk.timestamp,
+          if (input.appendLog) {
+            if (chunk.type === "reasoning-delta") {
+              const payload = chunk.payload as ReasoningDeltaPayload;
+              if (typeof payload.text === "string") {
+                thinkingBuffer += payload.text;
+              }
+            } else if (chunk.type === "tool-call") {
+              // Flush thinking buffer before logging tool call
+              if (thinkingBuffer.trim()) {
+                await input.appendLog(`💭 Thinking: ${thinkingBuffer.trim()}`);
+                thinkingBuffer = "";
+              }
+              const payload = chunk.payload as ToolCallPayload;
+              const argsStr = payload.args
+                ? JSON.stringify(payload.args).slice(0, 200)
+                : "";
+              await input.appendLog(
+                `🔧 Tool: ${payload.toolName}${argsStr ? `(${argsStr}${argsStr.length >= 200 ? "..." : ""})` : "()"}`,
+              );
+            } else if (chunk.type === "tool-result") {
+              const payload = chunk.payload as ToolResultPayload;
+              const resultStr =
+                typeof payload.result === "string"
+                  ? payload.result.slice(0, 300)
+                  : JSON.stringify(payload.result).slice(0, 300);
+              await input.appendLog(
+                `✅ Result: ${resultStr}${resultStr.length >= 300 ? "..." : ""}`,
+              );
+            } else if (chunk.type === "tool-error") {
+              const payload = chunk.payload as ErrorPayload;
+              await input.appendLog(
+                `❌ Error: ${typeof payload.error === "string" ? payload.error : JSON.stringify(payload.error)}`,
+              );
+            } else if (chunk.type === "text-delta") {
+              // Flush thinking buffer when text starts (thinking is done)
+              if (thinkingBuffer.trim()) {
+                await input.appendLog(`💭 Thinking: ${thinkingBuffer.trim()}`);
+                thinkingBuffer = "";
+              }
+            }
+          }
+
+          // Broadcast sub-agent activity to MiniChatCard (thinking, tool calls, results)
+          if (input.delegationId) {
+            const { broadcast } = await import("../websocket/index.js");
+            broadcast({
+              type: "subagent-chat:activity",
+              data: {
+                delegationId: input.delegationId,
+                chunk: {
+                  type: chunk.type,
+                  payload: chunk.payload,
+                  timestamp: chunk.timestamp,
+                },
               },
-            },
-          });
-        }
+            });
+          }
 
-        if (chunk.type !== "text-delta") {
-          continue;
-        }
-        const payload = chunk.payload as TextDeltaPayload;
-        if (typeof payload.text === "string") {
-          text += payload.text;
-        }
+          if (chunk.type !== "text-delta") {
+            continue;
+          }
+          const payload = chunk.payload as TextDeltaPayload;
+          if (typeof payload.text === "string") {
+            text += payload.text;
+          }
         }
 
         // Flush any remaining thinking buffer at end of stream
@@ -4031,122 +4182,122 @@ ${last15.substring(0, 8_000)}`;
 
       // Retry with API key if OAuth rate limit was hit
       if (retryWithApiKey && authType === "oauth") {
-      // Try to get API key
-      const authProvider = provider === "openai-codex" ? "openai" : provider;
-      const keyName =
-        authProvider === "openai" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
-      const keys = await getApiKeys([keyName]);
+        // Try to get API key
+        const authProvider = provider === "openai-codex" ? "openai" : provider;
+        const keyName =
+          authProvider === "openai" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
+        const keys = await getApiKeys([keyName]);
 
-      if (!keys[keyName]) {
-        throw new Error(
-          `OAuth rate limit reached and no API key available for ${provider}. ` +
-            `Add an API key in Settings or wait for rate limit to reset.`,
-        );
-      }
-
-      console.log(
-        `[AgentService] Retrying with API key for ${provider} (OAuth rate limited)`,
-      );
-
-      // Retry with API key
-      const apiKeyConfig: AgentConfigInternal = {
-        ...config,
-        apiKey: keys[keyName],
-        authType: "apiKey",
-      };
-
-      // Create new chatId for retry to avoid session cache
-      retryChatId = `${chatId}-retry`;
-      thinkingBuffer = ""; // Reset thinking buffer for retry
-
-      for await (const chunk of this.streamAgent(
-        retryChatId,
-        input.prompt,
-        apiKeyConfig,
-        {
-          allowedToolIds: input.allowedToolIds,
-          maxSteps: input.maxTurns,
-        },
-      )) {
-        if (chunk.type === "error") {
-          const errMsg =
-            (chunk.payload as { error?: string })?.error ?? "Model API error";
+        if (!keys[keyName]) {
           throw new Error(
-            `Agent job model error (${provider}/${model}) after API key fallback: ${errMsg}`,
+            `OAuth rate limit reached and no API key available for ${provider}. ` +
+              `Add an API key in Settings or wait for rate limit to reset.`,
           );
         }
 
-        // Log structured activity to job logs (same as main path)
-        if (input.appendLog) {
-          if (chunk.type === "reasoning-delta") {
-            const payload = chunk.payload as ReasoningDeltaPayload;
-            if (typeof payload.text === "string") {
-              thinkingBuffer += payload.text;
-            }
-          } else if (chunk.type === "tool-call") {
-            if (thinkingBuffer.trim()) {
-              await input.appendLog(`💭 Thinking: ${thinkingBuffer.trim()}`);
-              thinkingBuffer = "";
-            }
-            const payload = chunk.payload as ToolCallPayload;
-            const argsStr = payload.args
-              ? JSON.stringify(payload.args).slice(0, 200)
-              : "";
-            await input.appendLog(
-              `🔧 Tool: ${payload.toolName}${argsStr ? `(${argsStr}${argsStr.length >= 200 ? "..." : ""})` : "()"}`,
+        console.log(
+          `[AgentService] Retrying with API key for ${provider} (OAuth rate limited)`,
+        );
+
+        // Retry with API key
+        const apiKeyConfig: AgentConfigInternal = {
+          ...config,
+          apiKey: keys[keyName],
+          authType: "apiKey",
+        };
+
+        // Create new chatId for retry to avoid session cache
+        retryChatId = `${chatId}-retry`;
+        thinkingBuffer = ""; // Reset thinking buffer for retry
+
+        for await (const chunk of this.streamAgent(
+          retryChatId,
+          input.prompt,
+          apiKeyConfig,
+          {
+            allowedToolIds: input.allowedToolIds,
+            maxSteps: input.maxTurns,
+          },
+        )) {
+          if (chunk.type === "error") {
+            const errMsg =
+              (chunk.payload as { error?: string })?.error ?? "Model API error";
+            throw new Error(
+              `Agent job model error (${provider}/${model}) after API key fallback: ${errMsg}`,
             );
-          } else if (chunk.type === "tool-result") {
-            const payload = chunk.payload as ToolResultPayload;
-            const resultStr =
-              typeof payload.result === "string"
-                ? payload.result.slice(0, 300)
-                : JSON.stringify(payload.result).slice(0, 300);
-            await input.appendLog(
-              `✅ Result: ${resultStr}${resultStr.length >= 300 ? "..." : ""}`,
-            );
-          } else if (chunk.type === "tool-error") {
-            const payload = chunk.payload as ErrorPayload;
-            await input.appendLog(
-              `❌ Error: ${typeof payload.error === "string" ? payload.error : JSON.stringify(payload.error)}`,
-            );
-          } else if (chunk.type === "text-delta") {
-            if (thinkingBuffer.trim()) {
-              await input.appendLog(`💭 Thinking: ${thinkingBuffer.trim()}`);
-              thinkingBuffer = "";
+          }
+
+          // Log structured activity to job logs (same as main path)
+          if (input.appendLog) {
+            if (chunk.type === "reasoning-delta") {
+              const payload = chunk.payload as ReasoningDeltaPayload;
+              if (typeof payload.text === "string") {
+                thinkingBuffer += payload.text;
+              }
+            } else if (chunk.type === "tool-call") {
+              if (thinkingBuffer.trim()) {
+                await input.appendLog(`💭 Thinking: ${thinkingBuffer.trim()}`);
+                thinkingBuffer = "";
+              }
+              const payload = chunk.payload as ToolCallPayload;
+              const argsStr = payload.args
+                ? JSON.stringify(payload.args).slice(0, 200)
+                : "";
+              await input.appendLog(
+                `🔧 Tool: ${payload.toolName}${argsStr ? `(${argsStr}${argsStr.length >= 200 ? "..." : ""})` : "()"}`,
+              );
+            } else if (chunk.type === "tool-result") {
+              const payload = chunk.payload as ToolResultPayload;
+              const resultStr =
+                typeof payload.result === "string"
+                  ? payload.result.slice(0, 300)
+                  : JSON.stringify(payload.result).slice(0, 300);
+              await input.appendLog(
+                `✅ Result: ${resultStr}${resultStr.length >= 300 ? "..." : ""}`,
+              );
+            } else if (chunk.type === "tool-error") {
+              const payload = chunk.payload as ErrorPayload;
+              await input.appendLog(
+                `❌ Error: ${typeof payload.error === "string" ? payload.error : JSON.stringify(payload.error)}`,
+              );
+            } else if (chunk.type === "text-delta") {
+              if (thinkingBuffer.trim()) {
+                await input.appendLog(`💭 Thinking: ${thinkingBuffer.trim()}`);
+                thinkingBuffer = "";
+              }
             }
+          }
+
+          // Broadcast sub-agent activity to MiniChatCard (same as main path)
+          if (input.delegationId) {
+            const { broadcast } = await import("../websocket/index.js");
+            broadcast({
+              type: "subagent-chat:activity",
+              data: {
+                delegationId: input.delegationId,
+                chunk: {
+                  type: chunk.type,
+                  payload: chunk.payload,
+                  timestamp: chunk.timestamp,
+                },
+              },
+            });
+          }
+
+          if (chunk.type !== "text-delta") {
+            continue;
+          }
+          const payload = chunk.payload as TextDeltaPayload;
+          if (typeof payload.text === "string") {
+            text += payload.text;
           }
         }
 
-        // Broadcast sub-agent activity to MiniChatCard (same as main path)
-        if (input.delegationId) {
-          const { broadcast } = await import("../websocket/index.js");
-          broadcast({
-            type: "subagent-chat:activity",
-            data: {
-              delegationId: input.delegationId,
-              chunk: {
-                type: chunk.type,
-                payload: chunk.payload,
-                timestamp: chunk.timestamp,
-              },
-            },
-          });
+        // Flush any remaining thinking buffer at end of retry stream
+        if (input.appendLog && thinkingBuffer.trim()) {
+          await input.appendLog(`💭 Thinking: ${thinkingBuffer.trim()}`);
+          thinkingBuffer = "";
         }
-
-        if (chunk.type !== "text-delta") {
-          continue;
-        }
-        const payload = chunk.payload as TextDeltaPayload;
-        if (typeof payload.text === "string") {
-          text += payload.text;
-        }
-      }
-
-      // Flush any remaining thinking buffer at end of retry stream
-      if (input.appendLog && thinkingBuffer.trim()) {
-        await input.appendLog(`💭 Thinking: ${thinkingBuffer.trim()}`);
-        thinkingBuffer = "";
-      }
       }
 
       const trimmed = text.trim();
@@ -4264,10 +4415,15 @@ ${last15.substring(0, 8_000)}`;
     });
 
     let thinkingBuffer = "";
-    for await (const chunk of this.streamAgent(chatId, input.userMessage, config, {
-      allowedToolIds: input.allowedToolIds,
-      maxSteps: input.maxTurns,
-    })) {
+    for await (const chunk of this.streamAgent(
+      chatId,
+      input.userMessage,
+      config,
+      {
+        allowedToolIds: input.allowedToolIds,
+        maxSteps: input.maxTurns,
+      },
+    )) {
       if (input.appendLog) {
         if (chunk.type === "reasoning-delta") {
           const payload = chunk.payload as ReasoningDeltaPayload;
@@ -4335,13 +4491,16 @@ ${last15.substring(0, 8_000)}`;
     // Resolve default provider and model based on user's available authentication
     let provider = input.provider;
     let modelId = input.model;
-    
+
     if (!provider || !modelId) {
-      const { getDefaultProviderAndModel } = await import("../utils/defaultProvider.js");
+      const { getDefaultProviderAndModel } =
+        await import("../utils/defaultProvider.js");
       const defaults = await getDefaultProviderAndModel();
       provider = provider ?? defaults.provider;
       modelId = modelId ?? defaults.model;
-      console.log(`[AgentService] Using default provider/model: ${provider}/${modelId}`);
+      console.log(
+        `[AgentService] Using default provider/model: ${provider}/${modelId}`,
+      );
     }
 
     const defaultModelByProvider: Record<Provider, string> = {
@@ -4401,9 +4560,11 @@ ${last15.substring(0, 8_000)}`;
     // If auth check failed, fall back to default provider
     if (authCheckFailed) {
       // Try smart fallback based on original model capabilities
-      const { getBestFallbackModel } = await import("../utils/smartFallback.js");
-      const { getAvailableProviders } = await import("../utils/defaultProvider.js");
-      
+      const { getBestFallbackModel } =
+        await import("../utils/smartFallback.js");
+      const { getAvailableProviders } =
+        await import("../utils/defaultProvider.js");
+
       const available = await getAvailableProviders();
       const fallback = await getBestFallbackModel(
         originalProvider,
@@ -4419,7 +4580,8 @@ ${last15.substring(0, 8_000)}`;
         );
       } else {
         // No smart fallback available, use basic default
-        const { getDefaultProviderAndModel } = await import("../utils/defaultProvider.js");
+        const { getDefaultProviderAndModel } =
+          await import("../utils/defaultProvider.js");
         const defaults = await getDefaultProviderAndModel();
         provider = defaults.provider;
         modelId = defaults.model;
@@ -4442,7 +4604,9 @@ ${last15.substring(0, 8_000)}`;
         const keys = await getApiKeys(["GOOGLE_API_KEY"]);
         apiKey = keys.GOOGLE_API_KEY;
         if (!apiKey) {
-          throw new Error(`Missing API key for fallback provider: GOOGLE_API_KEY`);
+          throw new Error(
+            `Missing API key for fallback provider: GOOGLE_API_KEY`,
+          );
         }
       } else if (provider === "ollama") {
         // Ollama doesn't need auth
@@ -4668,8 +4832,11 @@ ${last15.substring(0, 8_000)}`;
   ): Promise<LanguageModel> {
     // Route through Papr proxy if configured
     if (options?.usePaprProxy && options?.paprApiKey) {
-      const { createProxyModel } = await import("../utils/paprProxyProvider.js");
-      console.log(`[AgentService] Using Papr AI proxy for ${provider}/${modelId}`);
+      const { createProxyModel } =
+        await import("../utils/paprProxyProvider.js");
+      console.log(
+        `[AgentService] Using Papr AI proxy for ${provider}/${modelId}`,
+      );
       return createProxyModel(provider, modelId, options.paprApiKey);
     }
 
@@ -4721,7 +4888,8 @@ ${last15.substring(0, 8_000)}`;
         return zai.chat(normalizeZaiModelId(modelId)) as LanguageModel;
       }
       case "groq": {
-        const { createGroqChatModel } = await import("../utils/groqProvider.js");
+        const { createGroqChatModel } =
+          await import("../utils/groqProvider.js");
         const groqApiKey = process.env.GROQ_API_KEY;
         if (!groqApiKey) {
           throw new Error(
@@ -4734,14 +4902,16 @@ ${last15.substring(0, 8_000)}`;
         });
       }
       case "moonshot": {
-        const { createMoonshotChatModel } = await import("../utils/moonshotProvider.js");
+        const { createMoonshotChatModel } =
+          await import("../utils/moonshotProvider.js");
         const moonshotApiKey = process.env.MOONSHOT_API_KEY;
         if (!moonshotApiKey) {
           throw new Error(
             "Moonshot direct API requires MOONSHOT_API_KEY. Sign in with Papr to use Kimi via proxy.",
           );
         }
-        const { normalizeMoonshotModelId } = await import("../utils/moonshotModel.js");
+        const { normalizeMoonshotModelId } =
+          await import("../utils/moonshotModel.js");
         return createMoonshotChatModel(normalizeMoonshotModelId(modelId), {
           apiKey: moonshotApiKey,
         });
@@ -5018,13 +5188,15 @@ ${last15.substring(0, 8_000)}`;
 
   /**
    * Build native web search tools for supported providers (AI SDK format)
-   * 
+   *
    * Providers with native search:
    * - Google: google.tools.googleSearch({})
    * - OpenAI: openai.tools.webSearch({ maxUses: 10 })
    * - Anthropic: anthropic.tools.webSearch_20260209({ maxUses: 10 })
    */
-  private async buildNativeSearchTools(provider: Provider): Promise<Record<string, any>> {
+  private async buildNativeSearchTools(
+    provider: Provider,
+  ): Promise<Record<string, any>> {
     const tools: Record<string, any> = {};
 
     switch (provider) {
@@ -5040,10 +5212,15 @@ ${last15.substring(0, 8_000)}`;
             tools.google_search = google.tools.googleSearch({});
             console.log("[AgentService] ✅ Enabled Google Search for Gemini");
           } else {
-            console.warn("[AgentService] ⚠️  Google Search not available in this SDK version");
+            console.warn(
+              "[AgentService] ⚠️  Google Search not available in this SDK version",
+            );
           }
         } catch (error) {
-          console.warn("[AgentService] ⚠️  Failed to load Google Search tool:", (error as Error).message);
+          console.warn(
+            "[AgentService] ⚠️  Failed to load Google Search tool:",
+            (error as Error).message,
+          );
         }
         break;
 
@@ -5054,46 +5231,63 @@ ${last15.substring(0, 8_000)}`;
           if (openai.tools?.webSearch) {
             const webSearchTool = openai.tools.webSearch({
               externalWebAccess: true, // Enable live web access
-              searchContextSize: 'high', // Use high context for search results
+              searchContextSize: "high", // Use high context for search results
             });
             // Check if tool has ID property and sanitize it if needed
             // OpenAI tools may or may not expose 'id', use key name as fallback
-            const hasId = webSearchTool && typeof (webSearchTool as any).id === 'string';
-            const toolId = hasId && (webSearchTool as any).id.includes('.')
-              ? (webSearchTool as any).id.replace(/\./g, '_')
-              : 'web_search';
-            
+            const hasId =
+              webSearchTool && typeof (webSearchTool as any).id === "string";
+            const toolId =
+              hasId && (webSearchTool as any).id.includes(".")
+                ? (webSearchTool as any).id.replace(/\./g, "_")
+                : "web_search";
+
             // Override ID if it exists and has dots
-            if (hasId && (webSearchTool as any).id.includes('.')) {
+            if (hasId && (webSearchTool as any).id.includes(".")) {
               tools.web_search = {
                 ...webSearchTool,
                 id: toolId,
               };
-              console.log("[AgentService] ✅ Enabled OpenAI web search (sanitized tool ID: " + toolId + ")");
+              console.log(
+                "[AgentService] ✅ Enabled OpenAI web search (sanitized tool ID: " +
+                  toolId +
+                  ")",
+              );
             } else {
               tools.web_search = webSearchTool;
               console.log("[AgentService] ✅ Enabled OpenAI web search");
             }
           } else {
-            console.warn("[AgentService] ⚠️  OpenAI web search not available in this SDK version");
+            console.warn(
+              "[AgentService] ⚠️  OpenAI web search not available in this SDK version",
+            );
           }
         } catch (error) {
-          console.warn("[AgentService] ⚠️  Failed to load OpenAI web search tool:", (error as Error).message);
+          console.warn(
+            "[AgentService] ⚠️  Failed to load OpenAI web search tool:",
+            (error as Error).message,
+          );
         }
         break;
 
       case "anthropic":
         // Anthropic: web_search disabled for now due to compatibility issues
-        console.log("[AgentService] ℹ️  Anthropic: Web search disabled (use browser tools instead)");
+        console.log(
+          "[AgentService] ℹ️  Anthropic: Web search disabled (use browser tools instead)",
+        );
         break;
 
       case "ollama":
         // Ollama: No native search (local models)
-        console.log("[AgentService] ℹ️  Ollama: No native search (use browser tools instead)");
+        console.log(
+          "[AgentService] ℹ️  Ollama: No native search (use browser tools instead)",
+        );
         break;
 
       default:
-        console.log(`[AgentService] ℹ️  Provider ${provider}: No native search support`);
+        console.log(
+          `[AgentService] ℹ️  Provider ${provider}: No native search support`,
+        );
     }
 
     return tools;
@@ -5101,16 +5295,20 @@ ${last15.substring(0, 8_000)}`;
 
   /**
    * Build native web search tools for pi-ai providers (OAuth routes)
-   * 
+   *
    * Same as buildNativeSearchTools but returns pi-ai compatible format
    */
-  private buildNativeSearchToolsForPiAi(provider: string): Array<{ type: string; name?: string; max_uses?: number }> {
+  private buildNativeSearchToolsForPiAi(
+    provider: string,
+  ): Array<{ type: string; name?: string; max_uses?: number }> {
     const tools: Array<{ type: string; name?: string; max_uses?: number }> = [];
 
     switch (provider) {
       case "anthropic":
         // Anthropic: web_search disabled for now due to compatibility issues
-        console.log("[AgentService] ℹ️  Anthropic OAuth: Web search disabled (use browser tools instead)");
+        console.log(
+          "[AgentService] ℹ️  Anthropic OAuth: Web search disabled (use browser tools instead)",
+        );
         break;
 
       case "openai-codex":
@@ -5121,11 +5319,15 @@ ${last15.substring(0, 8_000)}`;
           name: "web_search",
           max_uses: 10,
         });
-        console.log("[AgentService] ⚠️  Added OpenAI Codex web_search via pi-ai (experimental)");
+        console.log(
+          "[AgentService] ⚠️  Added OpenAI Codex web_search via pi-ai (experimental)",
+        );
         break;
 
       default:
-        console.log(`[AgentService] ℹ️  Provider ${provider}: No native search via pi-ai`);
+        console.log(
+          `[AgentService] ℹ️  Provider ${provider}: No native search via pi-ai`,
+        );
     }
 
     return tools;

--- a/src/gateway/services/AgentStreamRegistry.ts
+++ b/src/gateway/services/AgentStreamRegistry.ts
@@ -344,6 +344,11 @@ export class AgentStreamRegistry {
     const agentService = getAgentService();
     const { chatId, requestId } = entry;
 
+    // The last error the model stream actually explained. Kept so a trailing
+    // NoOutputGeneratedError cannot replace it with a description of its own
+    // side effect.
+    let reportedModelError: string | undefined;
+
     try {
       getStreamProfiler(chatId)?.mark("registry.runStream.start");
 
@@ -365,6 +370,13 @@ export class AgentStreamRegistry {
           },
         )) {
           if (entry.cancelled) break;
+          if (chunk.type === "error") {
+            const reported = (chunk.payload as { error?: unknown } | undefined)
+              ?.error;
+            if (typeof reported === "string" && reported.trim().length > 0) {
+              reportedModelError = reported;
+            }
+          }
           this.bufferChunk(entry, chunk);
           this.broadcastChunk(entry, chunk);
         }
@@ -410,16 +422,35 @@ export class AgentStreamRegistry {
         `[AgentStreamRegistry] Stream complete for chat ${chatId} (${entry.chunks.length} chunks buffered)`,
       );
     } catch (streamError) {
-      console.error(
-        `[AgentStreamRegistry] Stream error for chat ${chatId}:`,
-        streamError,
+      const { isNoOutputGeneratedError } = await import(
+        "./agent/providerErrorMessage.js"
       );
+
+      // Prefer the error we already explained. NoOutputGeneratedError only
+      // tells us the stream produced no steps, which we can already see.
+      const preferReported =
+        reportedModelError !== undefined &&
+        isNoOutputGeneratedError(streamError);
+
+      if (preferReported) {
+        console.error(
+          `[AgentStreamRegistry] Stream error for chat ${chatId}: ` +
+            `reporting the model error instead of the trailing ` +
+            `NoOutputGeneratedError: ${reportedModelError}`,
+        );
+      } else {
+        console.error(
+          `[AgentStreamRegistry] Stream error for chat ${chatId}:`,
+          streamError,
+        );
+      }
 
       entry.status = "error";
       entry.errorData = {
         chatId,
-        error:
-          streamError instanceof Error
+        error: preferReported
+          ? (reportedModelError as string)
+          : streamError instanceof Error
             ? streamError.message
             : "Stream error",
       };

--- a/src/gateway/services/DocumentService.ts
+++ b/src/gateway/services/DocumentService.ts
@@ -10,6 +10,10 @@
  */
 
 import { promises as fs } from "fs";
+import {
+  documentMetaNeedsRewrite,
+  normalizeDocumentMeta,
+} from "./documentMetaNormalize.js";
 import { markdownPreviewText } from "../../core/utils/markdownPreview.js";
 import { getPaprDocumentsDir } from "../../core/utils/paprRoot.js";
 import { watch, type FSWatcher } from "fs";
@@ -96,14 +100,14 @@ export class DocumentService {
 
     await fs.mkdir(docsRoot, { recursive: true });
     await this.migrateLegacyIfNeeded();
-    const repaired = await this.reconcileMissingMetaFiles();
+    const repaired = await this.reconcileMetaFiles();
     this.initialized = true;
     this.initializedDocsRoot = docsRoot;
 
     const docIds = await this.listDocIds();
     console.log(
       `[DocumentService] Initialized with ${docIds.length} documents in ${docsRoot}` +
-        (repaired > 0 ? ` (${repaired} missing meta.json repaired)` : ""),
+        (repaired > 0 ? ` (${repaired} meta.json repaired)` : ""),
     );
   }
 
@@ -496,12 +500,21 @@ export class DocumentService {
   }
 
   private async readMeta(id: string): Promise<DocumentMeta | null> {
+    let parsed: unknown;
     try {
       const raw = await fs.readFile(this.metaPath(id), "utf-8");
-      return JSON.parse(raw) as DocumentMeta;
+      parsed = JSON.parse(raw);
     } catch {
       return this.repairMetaFromContent(id);
     }
+
+    // Normalize rather than cast: meta.json has several writers and is not
+    // guaranteed to hold every field. Casting used to mint records with
+    // `id: undefined`, which surfaced as a React key warning in the sidebar.
+    const meta = normalizeDocumentMeta(id, parsed, {
+      fallbackTitle: slugToDisplayTitle(id),
+    });
+    return meta ?? this.repairMetaFromContent(id);
   }
 
   /** Build meta.json when agents wrote content.md without going through createDocument(). */
@@ -538,17 +551,47 @@ export class DocumentService {
     return meta;
   }
 
-  private async reconcileMissingMetaFiles(): Promise<number> {
+  /**
+   * Heal meta.json files at startup: rebuild the ones that are missing, and
+   * rewrite the ones that exist but omit an id or type.
+   *
+   * `readMeta` already normalizes both cases for its callers, so this is not
+   * what keeps the app correct — it is what stops every read from re-deriving
+   * the same fields forever, and makes the file on disk say what the app
+   * believes.
+   */
+  private async reconcileMetaFiles(): Promise<number> {
     const ids = await this.listDocIds();
     let repaired = 0;
 
     for (const id of ids) {
+      let raw: string;
       try {
-        await fs.access(this.metaPath(id));
+        raw = await fs.readFile(this.metaPath(id), "utf-8");
       } catch {
         const meta = await this.repairMetaFromContent(id);
         if (meta) repaired++;
+        continue;
       }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        const meta = await this.repairMetaFromContent(id);
+        if (meta) repaired++;
+        continue;
+      }
+
+      if (!documentMetaNeedsRewrite(id, parsed)) continue;
+
+      const meta = normalizeDocumentMeta(id, parsed, {
+        fallbackTitle: slugToDisplayTitle(id),
+      });
+      if (!meta) continue;
+
+      await this.writeMeta(id, meta);
+      repaired++;
     }
 
     return repaired;

--- a/src/gateway/services/KnowledgeGraphWikiService.ts
+++ b/src/gateway/services/KnowledgeGraphWikiService.ts
@@ -474,6 +474,16 @@ export interface WikiRail {
   items: WikiNode[];
 }
 
+/** Mirrors `WikiRelatedMemory` in `ui/types/wiki.ts`, which consumes this. */
+export interface WikiRelatedMemory {
+  id: string;
+  content: string;
+  category: string;
+  source: string;
+  createdAt: string;
+  chatId: string;
+}
+
 export interface WikiHomeResult {
   featured: WikiNode | null;
   rails: WikiRail[];
@@ -1448,7 +1458,9 @@ export async function fetchWikiEntity(
   };
 }
 
-async function _fetchRelatedMemories(node: WikiNode): Promise<any[]> {
+async function _fetchRelatedMemories(
+  node: WikiNode,
+): Promise<WikiRelatedMemory[]> {
   try {
     const client = await getPaprClient();
     const query = [node.label, node.description].filter(Boolean).join(" ");
@@ -1461,20 +1473,39 @@ async function _fetchRelatedMemories(node: WikiNode): Promise<any[]> {
       enable_agentic_graph: false,
     });
     const { memories } = parseSearchPayload(response);
-    return memories
-      .map((m) => ({
-        id: asString(m.id),
-        content: asString(m.content),
-        category: asString(m.category),
-        source: asString(m.source),
-        createdAt: asString(m.created_at),
-        chatId: asString(m.chat_id),
-      }))
-      .filter((m) => m.id && m.content);
+    return toRelatedMemories(memories);
   } catch (e) {
     console.warn("[Wiki] Failed to fetch related memories:", e);
     return [];
   }
+}
+
+/**
+ * Map search hits to related memories, keeping the first hit per id.
+ *
+ * A memory can match a query on more than one chunk, so search returns it once
+ * per hit. Consumers key on the id — the UI as a React key, and its "which one
+ * is open" lookup as a find-by-id — and both need the id to identify exactly
+ * one memory. Hits stay in search order, so the strongest match still leads.
+ */
+export function toRelatedMemories(
+  memories: ReadonlyArray<Record<string, unknown>>,
+): WikiRelatedMemory[] {
+  const byId = new Map<string, WikiRelatedMemory>();
+  for (const m of memories) {
+    const id = asString(m.id);
+    const content = asString(m.content);
+    if (!id || !content || byId.has(id)) continue;
+    byId.set(id, {
+      id,
+      content,
+      category: asString(m.category),
+      source: asString(m.source),
+      createdAt: asString(m.created_at),
+      chatId: asString(m.chat_id),
+    });
+  }
+  return [...byId.values()];
 }
 
 async function _fetchGraphConnectedEntities(

--- a/src/gateway/services/agent/contextBudget.ts
+++ b/src/gateway/services/agent/contextBudget.ts
@@ -30,6 +30,33 @@ export function resolveModelContextWindow(
   return PROVIDER_DEFAULT_CONTEXT[provider] ?? 128_000;
 }
 
+/**
+ * Smallest window we will budget against, whatever the user asks for.
+ *
+ * A turn carries ~86K of tool schemas before any conversation, so a cap below
+ * this would leave no room for the history it is supposed to be budgeting and
+ * every turn would trim to the 8K floor.
+ */
+export const MIN_CONTEXT_LIMIT = 128_000;
+
+/**
+ * Effective window: the model's own, narrowed by the user's choice.
+ *
+ * A cap can only ever shrink the window — asking for 1M on a 200K model does
+ * not widen it — and cannot go below {@link MIN_CONTEXT_LIMIT}.
+ */
+export function resolveEffectiveContextWindow(
+  provider: Provider,
+  modelId: string,
+  contextLimit?: number,
+): number {
+  const modelWindow = resolveModelContextWindow(provider, modelId);
+  if (!contextLimit || !Number.isFinite(contextLimit) || contextLimit <= 0) {
+    return modelWindow;
+  }
+  return Math.min(modelWindow, Math.max(contextLimit, MIN_CONTEXT_LIMIT));
+}
+
 /** Fraction of context window available for message history (rest: tools + output). */
 const HISTORY_BUDGET_RATIO = 0.85;
 
@@ -80,10 +107,13 @@ export function computeHistoryTokenBudget(params: {
   modelId: string;
   toolTokenEstimate: number;
   maxOutputTokens?: number;
+  /** User-chosen cap; narrows the model's window, never widens it. */
+  contextLimit?: number;
 }): number {
-  const contextWindow = resolveModelContextWindow(
+  const contextWindow = resolveEffectiveContextWindow(
     params.provider,
     params.modelId,
+    params.contextLimit,
   );
   const outputReserve = params.maxOutputTokens ?? DEFAULT_OUTPUT_RESERVE;
   const budget = Math.floor(

--- a/src/gateway/services/agent/providerErrorMessage.ts
+++ b/src/gateway/services/agent/providerErrorMessage.ts
@@ -1,0 +1,215 @@
+/**
+ * Recovering the provider's own error message.
+ *
+ * The AI SDK's `APICallError` carries the provider's response in two places
+ * (`responseBody`, the raw JSON string, and `data`, the parsed form) while
+ * leaving `message` an empty string for whole classes of error. Formatting on
+ * `message` alone therefore produced "API error (400): " — a status code and
+ * nothing else — while the response body held the one sentence that told the
+ * user what had happened and when it would stop.
+ *
+ * So read the body first and fall back to `message`, never the other way
+ * round: the body is the provider speaking about this specific request, and
+ * `message` is the SDK's summary of it.
+ */
+
+export interface ProviderErrorPayload {
+  /** Provider's machine-readable error type, e.g. "invalid_request_error". */
+  type?: string;
+  /** Provider's human-readable sentence. */
+  message?: string;
+}
+
+function readPayloadShape(value: unknown): ProviderErrorPayload | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const error = (value as Record<string, unknown>).error;
+  if (typeof error !== "object" || error === null) return undefined;
+
+  const shape = error as Record<string, unknown>;
+  const type = typeof shape.type === "string" ? shape.type : undefined;
+  const message =
+    typeof shape.message === "string" && shape.message.trim().length > 0
+      ? shape.message
+      : undefined;
+
+  if (!type && !message) return undefined;
+  return { ...(type ? { type } : {}), ...(message ? { message } : {}) };
+}
+
+/**
+ * Pull the provider's error type and message out of an SDK error.
+ *
+ * Prefers `data` (already parsed) and falls back to parsing `responseBody`.
+ */
+export function extractProviderErrorPayload(
+  error: unknown,
+): ProviderErrorPayload | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const errorObj = error as Record<string, unknown>;
+
+  const fromData = readPayloadShape(errorObj.data);
+  if (fromData) return fromData;
+
+  if (typeof errorObj.responseBody === "string") {
+    try {
+      return readPayloadShape(JSON.parse(errorObj.responseBody));
+    } catch {
+      // Not JSON — nothing to recover.
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * A spend cap is not a rate limit.
+ *
+ * Anthropic reports an exhausted usage limit as `400 invalid_request_error`,
+ * not `429`, so the rate-limit branch never sees it and "wait a moment and try
+ * again" would be wrong advice — the limit resets on a date, and waiting will
+ * not help. It is not `402` either: the account has credit, someone has capped
+ * how much of it this workspace may spend. That distinction decides where the
+ * user has to go, so it is worth detecting on its own.
+ */
+export function isUsageLimitError(payload: ProviderErrorPayload): boolean {
+  const message = payload.message?.toLowerCase();
+  if (!message) return false;
+
+  // Deliberately not matching "credit balance too low": that is a 402 with its
+  // own established message telling the user to add credits, which is different
+  // advice from raising a cap.
+  return (
+    message.includes("usage limit") ||
+    message.includes("spend limit") ||
+    message.includes("spending limit") ||
+    message.includes("quota")
+  );
+}
+
+/**
+ * Which provider actually served this request.
+ *
+ * Taken from the request URL rather than threaded down from config: the URL is
+ * what the call really went to, and it is already on the error.
+ */
+export function providerFromRequestUrl(
+  url: string | undefined,
+): string | undefined {
+  if (!url) return undefined;
+
+  if (
+    url.includes("api.anthropic.com") ||
+    url.includes("claude.com") ||
+    url.includes("claude.ai")
+  ) {
+    return "anthropic";
+  }
+  if (url.includes("openai.com")) return "openai";
+  if (
+    url.includes("generativelanguage.googleapis.com") ||
+    url.includes("aistudio.google")
+  ) {
+    return "google";
+  }
+
+  return undefined;
+}
+
+/** "2026-10-01 at 00:00 UTC" out of the provider's sentence, when present. */
+function extractRegainDate(message: string): string | undefined {
+  const match = message.match(
+    /regain access on ([0-9]{4}-[0-9]{2}-[0-9]{2}(?: at [^.]*)?)/i,
+  );
+  return match?.[1]?.trim();
+}
+
+/**
+ * Where to go to fix a limit, per provider.
+ *
+ * Only providers whose console we can name confidently get a link; the rest get
+ * the provider's own sentence, which is still far better than a bare status.
+ */
+function limitFixHint(provider: string | undefined): string | undefined {
+  switch (provider) {
+    case "anthropic":
+      return "Raise or remove the cap in the Anthropic Console under Settings → Limits (https://console.anthropic.com/settings/limits).";
+    case "openai":
+      return "Raise or remove the cap in the OpenAI dashboard under Settings → Limits (https://platform.openai.com/settings/organization/limits).";
+    case "google":
+      return "Review your quota in Google AI Studio (https://aistudio.google.com/app/apikey).";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Turn a provider limit error into something the user can act on.
+ *
+ * Returns null when this is not a limit error, so callers keep their existing
+ * handling for everything else.
+ */
+export function describeUsageLimitError(
+  payload: ProviderErrorPayload,
+  provider?: string,
+): string | null {
+  if (!isUsageLimitError(payload) || !payload.message) return null;
+
+  const parts = ["You have reached your API usage limit for this provider."];
+
+  const regainDate = extractRegainDate(payload.message);
+  if (regainDate) {
+    parts.push(`Access returns on ${regainDate}.`);
+  }
+
+  const hint = limitFixHint(provider);
+  if (hint) {
+    parts.push(hint);
+  }
+
+  parts.push(
+    "You can also switch to a different model in the composer to keep working now.",
+  );
+
+  return parts.join(" ");
+}
+
+/**
+ * The AI SDK's `NoOutputGeneratedError`, which reports a consequence.
+ *
+ * It is raised in `streamText`'s flush when no step was recorded — the SDK's
+ * own comment there reads "no steps recorded (e.g. in error scenario)". So it
+ * is what a failed request looks like from the outside, never the reason for
+ * one, and it arrives *after* the real error has already been reported. Left
+ * alone it overwrites that error, which is how a response explaining an
+ * exhausted usage limit reached the user as "No output generated."
+ */
+export function isNoOutputGeneratedError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const errorObj = error as Record<string, unknown>;
+
+  const name = typeof errorObj.name === "string" ? errorObj.name : "";
+  if (
+    name === "AI_NoOutputGeneratedError" ||
+    name === "NoOutputGeneratedError"
+  ) {
+    return true;
+  }
+
+  const message =
+    typeof errorObj.message === "string" ? errorObj.message.toLowerCase() : "";
+  return message.startsWith("no output generated");
+}
+
+/**
+ * Format a provider error payload as a fallback message.
+ *
+ * Used when no specialised branch claims the error but the provider still told
+ * us something useful.
+ */
+export function formatProviderErrorPayload(
+  payload: ProviderErrorPayload,
+  statusCode?: number,
+): string | undefined {
+  if (!payload.message) return undefined;
+  return `API error${statusCode ? ` (${statusCode})` : ""}: ${payload.message}`;
+}

--- a/src/gateway/services/agent/streamOrchestrator.ts
+++ b/src/gateway/services/agent/streamOrchestrator.ts
@@ -1,6 +1,12 @@
 import { sanitizeToolOutput } from "../../../core/tools/index.js";
 import { isFailedToolResult } from "../../../core/utils/interruptedToolResult.js";
 import {
+  describeUsageLimitError,
+  extractProviderErrorPayload,
+  formatProviderErrorPayload,
+  providerFromRequestUrl,
+} from "./providerErrorMessage.js";
+import {
   createChatStreamChunk,
   parseToolCallChunk,
   parseToolErrorChunk,
@@ -175,30 +181,23 @@ function extractFromRetryError(error: Record<string, unknown>): string | null {
   const err = underlying as Record<string, unknown>;
   const statusCode = err.statusCode as number | undefined;
   const message = typeof err.message === "string" ? err.message : undefined;
-  const responseBody = typeof err.responseBody === "string" ? err.responseBody : undefined;
-
-  // Try to extract Anthropic's error type from response body (e.g. "overloaded_error")
-  let apiErrorType: string | undefined;
-  if (responseBody) {
-    try {
-      const body = JSON.parse(responseBody) as Record<string, unknown>;
-      const bodyError = body.error as Record<string, unknown> | undefined;
-      if (bodyError && typeof bodyError.type === "string") {
-        apiErrorType = bodyError.type;
-      }
-      if (bodyError && typeof bodyError.message === "string" && !message) {
-        return `API error${statusCode ? ` (${statusCode})` : ""}: ${bodyError.message}`;
-      }
-    } catch {
-      // Response body not JSON
-    }
-  }
+  const payload = extractProviderErrorPayload(err);
+  const apiErrorType = payload?.type;
 
   if (statusCode === 529 || apiErrorType === "overloaded_error") {
     return "Claude servers are temporarily overloaded. Please wait a moment and try again, or switch to a different model.";
   }
   if (statusCode === 429) {
     return "Rate limit exceeded. Please wait a moment and try again.";
+  }
+  // Checked after 429 so a transient rate limit keeps its "try again" advice;
+  // a spend cap arrives as 400 and so reaches this branch instead.
+  if (payload) {
+    const limitMessage = describeUsageLimitError(
+      payload,
+      providerFromRequestUrl(extractRequestUrl(err)),
+    );
+    if (limitMessage) return limitMessage;
   }
   if (statusCode === 401) {
     return "Invalid API key. Please check your Anthropic API key in Settings.";
@@ -212,6 +211,12 @@ function extractFromRetryError(error: Record<string, unknown>): string | null {
   if (statusCode && statusCode >= 500) {
     return `Anthropic server error (${statusCode}). Please try again in a moment.`;
   }
+  // Provider body before SDK message: the body describes this request, and the
+  // SDK leaves `message` empty for whole classes of error.
+  const fromPayload = payload
+    ? formatProviderErrorPayload(payload, statusCode)
+    : undefined;
+  if (fromPayload) return fromPayload;
   if (message) {
     return `API error${statusCode ? ` (${statusCode})` : ""}: ${message}`;
   }
@@ -328,15 +333,30 @@ function extractErrorMessage(error: unknown): string {
     if (typeof errorObj.statusCode === "number" && typeof errorObj.url === "string") {
       const statusCode = errorObj.statusCode as number;
       const message = typeof errorObj.message === "string" ? errorObj.message : "";
+      // The provider's own payload, which this branch used to skip entirely —
+      // hence "API error (400): " with nothing after the colon on a response
+      // whose body explained the problem in full.
+      const payload = extractProviderErrorPayload(errorObj);
       if (statusCode === 529) {
         return "Claude servers are temporarily overloaded. Please wait a moment and try again.";
       }
       if (statusCode === 429) {
         return "Rate limit exceeded. Please wait a moment and try again.";
       }
+      if (payload) {
+        const limitMessage = describeUsageLimitError(
+          payload,
+          providerFromRequestUrl(errorObj.url as string),
+        );
+        if (limitMessage) return limitMessage;
+      }
       if (statusCode === 401) {
         return "Invalid API key. Please check your API key in Settings.";
       }
+      const fromPayload = payload
+        ? formatProviderErrorPayload(payload, statusCode)
+        : undefined;
+      if (fromPayload) return fromPayload;
       return `API error (${statusCode}): ${message}`;
     }
 

--- a/src/gateway/services/documentMetaNormalize.ts
+++ b/src/gateway/services/documentMetaNormalize.ts
@@ -1,0 +1,94 @@
+/**
+ * Normalization for document metadata read off disk.
+ *
+ * `meta.json` is written by this app, by the legacy `documents.json` migration,
+ * and by agents editing files directly, so what comes back is not guaranteed to
+ * match `DocumentMeta`. Reading it with `JSON.parse(raw) as DocumentMeta`
+ * asserts that shape rather than checking it, and the assertion is not true of
+ * the files actually on disk: seeded documents carry a title and nothing else.
+ *
+ * The cost of that cast landed a long way from here. A document with no `id`
+ * became a favourite with `id: undefined`, which the sidebar used as a React
+ * list key — so the visible symptom was a key warning in `FavoritesList`, four
+ * layers away from the parse that invented the missing field.
+ *
+ * The directory name is the authoritative id: every path helper derives from it
+ * (`docDir`, `contentPath`, `metaPath`) and every lookup goes through it, so a
+ * document is reachable under that name whatever `meta.json` claims. It
+ * therefore wins outright rather than merely filling a gap.
+ */
+
+import type { DocumentMeta } from "./DocumentService.js";
+
+/** A string field, or undefined when absent/blank/wrong type. */
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : value;
+}
+
+/**
+ * Coerce a parsed `meta.json` into a complete `DocumentMeta`.
+ *
+ * Returns null only when the file holds something that is not an object at all,
+ * which is corruption rather than an incomplete record — the caller rebuilds
+ * from `content.md` in that case.
+ */
+export function normalizeDocumentMeta(
+  id: string,
+  parsed: unknown,
+  options: { fallbackTitle: string; fallbackTimestamp?: string },
+): DocumentMeta | null {
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const raw = parsed as Record<string, unknown>;
+  const createdAt =
+    readString(raw.createdAt) ??
+    options.fallbackTimestamp ??
+    new Date().toISOString();
+
+  const meta: DocumentMeta = {
+    // Directory name wins — see the note above.
+    id,
+    title: readString(raw.title) ?? options.fallbackTitle,
+    // The only legal value, and absent from pre-migration files. Consumers
+    // branch on it to pick an icon and a route, so a missing one is not benign.
+    type: "document",
+    createdAt,
+    updatedAt: readString(raw.updatedAt) ?? createdAt,
+    tags: Array.isArray(raw.tags)
+      ? raw.tags.filter((tag): tag is string => typeof tag === "string")
+      : [],
+    favorite: raw.favorite === true,
+    preview: readString(raw.preview) ?? "",
+    wordCount:
+      typeof raw.wordCount === "number" && Number.isFinite(raw.wordCount)
+        ? raw.wordCount
+        : 0,
+  };
+
+  const createdByAgentId = readString(raw.createdByAgentId);
+  if (createdByAgentId) meta.createdByAgentId = createdByAgentId;
+  const createdByAgentName = readString(raw.createdByAgentName);
+  if (createdByAgentName) meta.createdByAgentName = createdByAgentName;
+
+  return meta;
+}
+
+/**
+ * Whether the stored file disagrees with the record consumers will be handed,
+ * and so is worth rewriting once at startup.
+ *
+ * Only the two load-bearing invariants count. Cosmetic gaps that normalization
+ * fills with an equivalent value are left alone, so this does not rewrite every
+ * document on every launch.
+ */
+export function documentMetaNeedsRewrite(id: string, parsed: unknown): boolean {
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return false;
+  }
+  const raw = parsed as Record<string, unknown>;
+  return raw.id !== id || raw.type !== "document";
+}

--- a/src/gateway/services/jobs/registryDbSchemaReader.ts
+++ b/src/gateway/services/jobs/registryDbSchemaReader.ts
@@ -11,6 +11,9 @@ import Database from "better-sqlite3";
 import type { AppDataSource } from "../appDataSources.js";
 import type { DatabaseSyncMode } from "../tursoReplica/tursoReplicaTypes.js";
 import { isReplicaManagedDbPath } from "../tursoReplica/tursoReplicaFileGuard.js";
+// One definition, shared: this file's local copy was the only correct one, and
+// keeping it local let the other copy stay too narrow to match engine errors.
+import { isSqliteBusyError } from "../tursoReplica/tursoReplicaErrors.js";
 import { isTursoReplicaSyncFeatureEnabled } from "../../utils/tursoReplicaEnabled.js";
 
 export interface RegistryDbSchemaReadInput {
@@ -34,14 +37,6 @@ export interface RegistryDbSchemaSnapshot {
 export type RegistryDbSchemaReadResult =
   | { ok: true; schema: RegistryDbSchemaSnapshot }
   | { ok: false; code: RegistryDbSchemaReadErrorCode; message: string };
-
-function isSqliteBusyError(error: unknown): boolean {
-  const err = error as { code?: string; message?: string };
-  return (
-    err.code === "SQLITE_BUSY" ||
-    /database is locked/i.test(err.message ?? "")
-  );
-}
 
 function isSqliteNotDbError(error: unknown): boolean {
   const err = error as { code?: string; message?: string };

--- a/src/gateway/services/providers/PiCodexStreamWithToolLoop.ts
+++ b/src/gateway/services/providers/PiCodexStreamWithToolLoop.ts
@@ -58,7 +58,9 @@ import {
 import {
   MAX_PROVIDER_RATE_LIMIT_RETRIES,
   computeRateLimitBackoffMs,
+  createProviderQuotaExhaustedError,
   createRateLimitExhaustedError,
+  detectProviderQuotaExhaustion,
   isRetryableProviderCapacityError,
   sleepMs,
 } from "../../utils/providerRateLimitRetry.js";
@@ -66,8 +68,33 @@ import {
  * Truncate tool call ID to 64 characters (OpenAI's maximum length requirement).
  * IDs from various APIs may exceed this limit, causing validation errors.
  */
-function yieldRateLimitExhausted(): { type: "error"; error: ReturnType<typeof createRateLimitExhaustedError> } {
-  return { type: "error", error: createRateLimitExhaustedError() };
+function yieldRateLimitExhausted(error?: unknown): {
+  type: "error";
+  error: ReturnType<typeof createRateLimitExhaustedError>;
+} {
+  return { type: "error", error: createRateLimitExhaustedError(error) };
+}
+
+/**
+ * A refusal that waiting cannot fix, described so the user knows where to go.
+ *
+ * Returns null when the failure is ordinary capacity pressure, leaving the
+ * retry-then-Resume path in charge. Checked before the retry branch at every
+ * site that can raise one, so a spent month never spends three attempts
+ * discovering it is still spent.
+ */
+function quotaExhaustedChunk(error: unknown): {
+  type: "error";
+  error: ReturnType<typeof createProviderQuotaExhaustedError>;
+} | null {
+  const detail = detectProviderQuotaExhaustion(error);
+  if (!detail) return null;
+  console.warn(
+    `[PiCodexToolLoop] Provider quota exhausted (${detail.remedy})` +
+      (detail.resetsAt ? `, resets ${detail.resetsAt.toISOString()}` : "") +
+      " — not retrying",
+  );
+  return { type: "error", error: createProviderQuotaExhaustedError(detail) };
 }
 
 function truncateToolCallId(id: string): string {
@@ -612,12 +639,18 @@ export async function* createPiCodexStreamWithToolLoop(
         try {
           piStream = streamSimple(piModel, context, streamOptions);
         } catch (err) {
+          const quotaChunk = quotaExhaustedChunk(err);
+          if (quotaChunk) {
+            yield quotaChunk;
+            emitTurnEnd("rate_limit_exhausted");
+            return;
+          }
           if (isRetryableProviderCapacityError(err)) {
             if (rateLimitAttempt < MAX_PROVIDER_RATE_LIMIT_RETRIES) {
               capacityError = err;
               shouldRetryCapacity = true;
             } else {
-              yield yieldRateLimitExhausted();
+              yield yieldRateLimitExhausted(err);
               emitTurnEnd("rate_limit_exhausted");
               return;
             }
@@ -655,13 +688,19 @@ export async function* createPiCodexStreamWithToolLoop(
             if (event.type === "error") {
               const apiError =
                 (event as { error?: unknown }).error ?? event;
+              const quotaChunk = quotaExhaustedChunk(apiError);
+              if (quotaChunk) {
+                yield quotaChunk;
+                emitTurnEnd("rate_limit_exhausted");
+                return;
+              }
               if (isRetryableProviderCapacityError(apiError)) {
                 if (rateLimitAttempt < MAX_PROVIDER_RATE_LIMIT_RETRIES) {
                   capacityError = apiError;
                   shouldRetryCapacity = true;
                   break;
                 }
-                yield yieldRateLimitExhausted();
+                yield yieldRateLimitExhausted(apiError);
                 emitTurnEnd("rate_limit_exhausted");
                 return;
               }
@@ -746,13 +785,19 @@ export async function* createPiCodexStreamWithToolLoop(
 
             const chunk = adaptPiStreamToAISDKEvent(event);
             if (chunk?.type === "error") {
+              const quotaChunk = quotaExhaustedChunk(chunk.error);
+              if (quotaChunk) {
+                yield quotaChunk;
+                emitTurnEnd("rate_limit_exhausted");
+                return;
+              }
               if (isRetryableProviderCapacityError(chunk.error)) {
                 if (rateLimitAttempt < MAX_PROVIDER_RATE_LIMIT_RETRIES) {
                   capacityError = chunk.error;
                   shouldRetryCapacity = true;
                   break;
                 }
-                yield yieldRateLimitExhausted();
+                yield yieldRateLimitExhausted(chunk.error);
                 emitTurnEnd("rate_limit_exhausted");
                 return;
               }
@@ -773,12 +818,18 @@ export async function* createPiCodexStreamWithToolLoop(
           }
         }
       } catch (err) {
+        const quotaChunk = quotaExhaustedChunk(err);
+        if (quotaChunk) {
+          yield quotaChunk;
+          emitTurnEnd("rate_limit_exhausted");
+          return;
+        }
         if (isRetryableProviderCapacityError(err)) {
           if (rateLimitAttempt < MAX_PROVIDER_RATE_LIMIT_RETRIES) {
             capacityError = err;
             shouldRetryCapacity = true;
           } else {
-            yield yieldRateLimitExhausted();
+            yield yieldRateLimitExhausted(err);
             emitTurnEnd("rate_limit_exhausted");
             return;
           }

--- a/src/gateway/services/providers/piAiAnthropicAdaptiveThinking.ts
+++ b/src/gateway/services/providers/piAiAnthropicAdaptiveThinking.ts
@@ -27,8 +27,15 @@ interface AnthropicThinkingConfig {
   display?: "summarized";
 }
 
+interface AnthropicDisabledThinking {
+  type: "disabled";
+}
+
 interface AnthropicMessagesParams {
-  thinking?: AnthropicThinkingConfig | { type: string; budget_tokens?: number };
+  thinking?:
+    | AnthropicThinkingConfig
+    | AnthropicDisabledThinking
+    | { type: string; budget_tokens?: number };
   output_config?: { effort?: AnthropicAdaptiveEffort; [key: string]: unknown };
   [key: string]: unknown;
 }
@@ -95,10 +102,30 @@ export function mapPiAiReasoningToAnthropicEffort(
 export function buildAdaptiveThinkingOnPayload(
   modelId: string,
   reasoningLevel: PiAiReasoningLevel,
+  thinkingEnabled = true,
 ): PiAiAnthropicStreamOptions["onPayload"] {
   const effort = mapPiAiReasoningToAnthropicEffort(reasoningLevel, modelId);
 
   return (params) => {
+    if (!thinkingEnabled) {
+      // The user turned reasoning off. Drop effort as well as the thinking
+      // block — an effort on a disabled thinking config is a contradiction the
+      // API would have to resolve for us.
+      const { output_config: existing, ...rest } = params;
+      const remaining =
+        existing && typeof existing === "object"
+          ? (({ effort: _dropped, ...others }) => others)(existing)
+          : undefined;
+
+      return {
+        ...rest,
+        ...(remaining && Object.keys(remaining).length > 0
+          ? { output_config: remaining }
+          : {}),
+        thinking: { type: "disabled" },
+      };
+    }
+
     const existingOutputConfig =
       params.output_config && typeof params.output_config === "object"
         ? params.output_config
@@ -122,6 +149,7 @@ export function augmentPiAiAnthropicStreamOptions(
   modelId: string,
   reasoningLevel: PiAiReasoningLevel,
   base: PiAiAnthropicStreamOptions,
+  thinkingEnabled = true,
 ): PiAiAnthropicStreamOptions {
   const isOAuth = base.apiKey.includes("sk-ant-oat");
   const headers = isOAuth
@@ -131,18 +159,26 @@ export function augmentPiAiAnthropicStreamOptions(
       }
     : base.headers;
 
-  if (!requiresPiAiAdaptiveThinkingOverride(modelId)) {
+  // A disabled-thinking request still needs patching even on models that do not
+  // otherwise need the adaptive override, or the off switch does nothing here.
+  if (thinkingEnabled && !requiresPiAiAdaptiveThinkingOverride(modelId)) {
     return headers === base.headers ? base : { ...base, headers };
   }
 
   console.log(
-    `[AgentService] Applying adaptive thinking override for ${modelId} ` +
-      `(effort=${mapPiAiReasoningToAnthropicEffort(reasoningLevel, modelId)}, display=summarized)`,
+    thinkingEnabled
+      ? `[AgentService] Applying adaptive thinking override for ${modelId} ` +
+          `(effort=${mapPiAiReasoningToAnthropicEffort(reasoningLevel, modelId)}, display=summarized)`
+      : `[AgentService] Thinking disabled by user for ${modelId}`,
   );
 
   return {
     ...base,
     headers,
-    onPayload: buildAdaptiveThinkingOnPayload(modelId, reasoningLevel),
+    onPayload: buildAdaptiveThinkingOnPayload(
+      modelId,
+      reasoningLevel,
+      thinkingEnabled,
+    ),
   };
 }

--- a/src/gateway/services/tursoPushScheduler.ts
+++ b/src/gateway/services/tursoPushScheduler.ts
@@ -127,6 +127,18 @@ const queuedJobIds = new Set<string>();
 /** Jobs currently executing pushJob — still pending from max-wait's perspective. */
 const pushInFlightSyncKeys = new Set<string>();
 const pushFailureBackoffUntilMs = new Map<string, number>();
+/**
+ * Consecutive follow-up pushes that shipped nothing while the dirty check kept
+ * saying there was work. The two answers come from different evidence — the
+ * push asks the sync log whether anything is unshipped, the dirty check also
+ * asks whether the remote is missing local tables — so they can disagree
+ * permanently. Re-running immediately cannot break that tie: nothing about the
+ * state changed between the two calls, so the next round returns the same pair
+ * of answers. Counting them is what turns an unbounded spin into a backoff.
+ */
+const noProgressFollowUps = new Map<string, number>();
+/** Allows for a genuine write landing mid-push before treating it as a stall. */
+const MAX_NO_PROGRESS_FOLLOW_UPS = 2;
 const lastMaxWaitLogAtMs = new Map<string, number>();
 let queueProcessing = false;
 let rateLimitUntilMs = 0;
@@ -211,6 +223,7 @@ function clearDirtyTracking(syncKey: string): void {
   firstDirtyAtMs.delete(syncKey);
   lastMaxWaitLogAtMs.delete(syncKey);
   pushFailureBackoffUntilMs.delete(syncKey);
+  noProgressFollowUps.delete(syncKey);
 }
 
 function pushFailureBackoffMs(): number {
@@ -314,17 +327,51 @@ async function finishTursoPushTracking(
   linked: TursoLinkedSource,
   schedulerKey: string,
   resolvedSyncKey: string,
+  shippedWork: boolean,
 ): Promise<void> {
   const stillDirty = await bridge.linkedSourceNeedsPush(linked);
-  if (stillDirty) {
+  if (!stillDirty) {
+    clearDirtyTracking(schedulerKey);
+    return;
+  }
+
+  // Still dirty after a push that actually shipped rows means the backlog is
+  // draining, so keep going at full speed.
+  if (shippedWork) {
     noteDirty(schedulerKey);
+    noProgressFollowUps.delete(schedulerKey);
     enqueueTursoPush(schedulerKey, true);
     console.log(
       `[TursoPushScheduler] Backlog remains for ${resolvedSyncKey} — queued follow-up push`,
     );
     return;
   }
-  clearDirtyTracking(schedulerKey);
+
+  // Shipped nothing and still dirty. Re-queuing at the front with no delay is
+  // what turned this into a hot loop: the push reports the log has nothing
+  // unshipped, the dirty check reports the remote is missing tables, and
+  // neither answer moves. Allow a couple of rounds for a write that genuinely
+  // landed mid-push, then back off so the tie costs a retry a minute rather
+  // than a core.
+  const attempts = (noProgressFollowUps.get(schedulerKey) ?? 0) + 1;
+  noProgressFollowUps.set(schedulerKey, attempts);
+
+  if (attempts > MAX_NO_PROGRESS_FOLLOW_UPS) {
+    notePushFailureBackoff(schedulerKey);
+    console.warn(
+      `[TursoPushScheduler] ${resolvedSyncKey} still reports pending work after ` +
+        `${attempts} pushes that shipped nothing — backing off for ` +
+        `${pushFailureBackoffMs()}ms. The sync log and the dirty check disagree; ` +
+        `the remote is likely missing tables the log considers already shipped.`,
+    );
+    return;
+  }
+
+  noteDirty(schedulerKey);
+  enqueueTursoPush(schedulerKey, true);
+  console.log(
+    `[TursoPushScheduler] Backlog remains for ${resolvedSyncKey} — queued follow-up push`,
+  );
 }
 
 async function executePushForJob(
@@ -385,6 +432,7 @@ async function executePushForJob(
         linked,
         syncKey,
         resolvedSyncKey,
+        true,
       );
       const skipped =
         pushResult.skippedTables && pushResult.skippedTables.length > 0
@@ -406,6 +454,7 @@ async function executePushForJob(
         linked,
         syncKey,
         resolvedSyncKey,
+        false,
       );
       return;
     }
@@ -688,6 +737,12 @@ async function enqueueDirtyLinkedJobs(
     }
     const syncKey = linkedSourceSyncKey(source);
     if (!(await bridge.linkedSourceNeedsPush(source))) {
+      continue;
+    }
+    // A source that keeps reporting dirty is exactly the one a backoff exists
+    // to hold off, so honour it here directly rather than relying on max-wait
+    // having elapsed for flushIfMaxWaitElapsed to reach its own check.
+    if (trigger !== "manual" && isInPushFailureBackoff(syncKey)) {
       continue;
     }
     logTursoSchedule(syncKey, trigger, "dirty linked source");

--- a/src/gateway/services/tursoReplica/TursoReplicaService.ts
+++ b/src/gateway/services/tursoReplica/TursoReplicaService.ts
@@ -58,6 +58,7 @@ import {
   resetReplicaSidecars,
 } from "./tursoReplicaSidecarWedge.js";
 import { isTursoHostNotReadyError } from "./tursoReplicaErrors.js";
+import { retryWhileReplicaBusy } from "./replicaBusyRetry.js";
 import {
   noteReplicaReadPathFailure,
   scheduleReplicaBackgroundWedgeRecovery,
@@ -390,7 +391,10 @@ export class TursoReplicaService {
       };
 
       try {
-        return await executeRead(options.pullBeforeRead === true);
+        return await retryWhileReplicaBusy(
+          () => executeRead(options.pullBeforeRead === true),
+          `read ${options.tursoDatabase}`,
+        );
       } catch (error) {
         const message = (error as Error).message;
         if (!isReplicaReadTransportError(message)) {
@@ -457,7 +461,10 @@ export class TursoReplicaService {
       };
 
       try {
-        return await executeSchema(options?.pullBeforeRead === true);
+        return await retryWhileReplicaBusy(
+          () => executeSchema(options?.pullBeforeRead === true),
+          `schema ${tursoDatabase}`,
+        );
       } catch (error) {
         const message = (error as Error).message;
         if (!isReplicaReadTransportError(message)) {

--- a/src/gateway/services/tursoReplica/cutover/retiredCutoverBlocks.ts
+++ b/src/gateway/services/tursoReplica/cutover/retiredCutoverBlocks.ts
@@ -1,0 +1,43 @@
+/**
+ * Cutover blocks that record a failure the code can no longer produce.
+ *
+ * `blockCutover` writes why an attempt failed, and nothing re-examines that
+ * verdict: `classifyRecordForReplicaCutover` buckets a blocked record as
+ * "blocked" and returns before reaching any real check, and the automatic
+ * cutover pass does not pass `forceRetry`. Only an explicit user action
+ * ("Upload now", `repair_cloud_sync`) clears it.
+ *
+ * That is correct while the cause still exists and wrong the moment a fix
+ * makes it impossible — the block outlives the bug that wrote it and pins the
+ * database to the legacy sync path indefinitely. Fixing the cause does not
+ * retract the blocks the cause already caused, so they have to be retired
+ * explicitly.
+ */
+
+const SCHEMA_DRIFT_HEAL_PREFIX = "__schema_drift_heal__";
+
+/** `Migration SQL missing for <id>` — the id is what decides if it is retired. */
+const MISSING_MIGRATION_SQL = /Migration SQL missing for (\S+)/;
+
+/**
+ * True when the reason names a failure the current code cannot reach.
+ *
+ * Today that is one case: `replayMigration` used to throw `Migration SQL
+ * missing` for a synthetic `__schema_drift_heal__*` id whose manifest entry
+ * had been pruned or written on another device. Those ids never have a .sql
+ * file by design, and their ops were already applied remotely when the heal
+ * shipped, so `jobMigrationTursoSync` now treats them as a no-op. A block
+ * citing one is a fossil of the old behaviour.
+ *
+ * Deliberately narrow: it matches the drift-heal id specifically, so a genuine
+ * missing migration — where the SQL really is needed and really is gone —
+ * stays blocked.
+ */
+export function isRetiredCutoverBlockReason(
+  reason: string | undefined,
+): boolean {
+  if (!reason) return false;
+  const match = MISSING_MIGRATION_SQL.exec(reason);
+  if (!match?.[1]) return false;
+  return match[1].startsWith(SCHEMA_DRIFT_HEAL_PREFIX);
+}

--- a/src/gateway/services/tursoReplica/cutover/tursoReplicaCutoverMigrationAuthority.ts
+++ b/src/gateway/services/tursoReplica/cutover/tursoReplicaCutoverMigrationAuthority.ts
@@ -19,10 +19,19 @@ import {
   readRemoteTursoMigrationIds,
 } from "../tursoReplicaMigrationConflict.js";
 import { isReplicaManagedDbPath } from "../tursoReplicaFileGuard.js";
+import { isReplicaBusyError } from "../tursoReplicaErrors.js";
 import { applyReplicaRegistryDatabaseMigrations } from "../tursoReplicaRegistryMigrations.js";
 import type { CutoverClassification, CutoverSnapshot } from "./tursoReplicaCutoverTypes.js";
 import { preReplicaBackupPath } from "./tursoReplicaCutoverBackup.js";
 import type { AppDataSource } from "../../appDataSources.js";
+
+/** Rounds of re-attempt for databases that were merely locked, not broken. */
+const BUSY_RETRY_ROUNDS = 2;
+const BUSY_RETRY_DELAY_MS = 30_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 function readMigrationIdsFromSqlite(dbPath: string): string[] {
   if (!fs.existsSync(dbPath)) {
@@ -266,18 +275,39 @@ export async function repairAllReplicaMigrationAuthorityOnStartup(): Promise<num
   const records = registry.listActive().filter((record) => record.syncMode === "replica");
 
   let repaired = 0;
-  for (const record of records) {
-    try {
-      const result = await repairReplicaMigrationAuthorityAfterCutover(record);
-      if (result.ledgerInferred.length > 0 || result.migrationsApplied.length > 0) {
-        repaired += 1;
-      }
-    } catch (error) {
-      console.warn(
-        `[TursoReplicaCutover] Startup migration repair failed for ${record.dbId}: ` +
-          `${(error as Error).message.slice(0, 160)}`,
+  // A lock means "someone is mid-flight", not "this database is broken".
+  // Abandoning on the first SQLITE_BUSY left the drift this function exists to
+  // heal in place for the whole session, so the next launch re-logged the same
+  // "missing on the replica handle" warning for the same databases, forever.
+  let pending = records;
+  for (let round = 0; round <= BUSY_RETRY_ROUNDS && pending.length > 0; round++) {
+    if (round > 0) {
+      console.log(
+        `[TursoReplicaCutover] ${pending.length} database(s) locked — ` +
+          `retrying migration repair in ${BUSY_RETRY_DELAY_MS}ms`,
       );
+      await sleep(BUSY_RETRY_DELAY_MS);
     }
+
+    const stillLocked: DatabaseRecord[] = [];
+    for (const record of pending) {
+      try {
+        const result = await repairReplicaMigrationAuthorityAfterCutover(record);
+        if (result.ledgerInferred.length > 0 || result.migrationsApplied.length > 0) {
+          repaired += 1;
+        }
+      } catch (error) {
+        if (isReplicaBusyError(error) && round < BUSY_RETRY_ROUNDS) {
+          stillLocked.push(record);
+          continue;
+        }
+        console.warn(
+          `[TursoReplicaCutover] Startup migration repair failed for ${record.dbId}: ` +
+            `${(error as Error).message.slice(0, 160)}`,
+        );
+      }
+    }
+    pending = stillLocked;
   }
 
   if (repaired > 0) {

--- a/src/gateway/services/tursoReplica/cutover/tursoReplicaCutoverOrchestrator.ts
+++ b/src/gateway/services/tursoReplica/cutover/tursoReplicaCutoverOrchestrator.ts
@@ -20,6 +20,7 @@ import {
   pushLocalLegacyFileToTursoPrimary,
 } from "../tursoReplicaProvision.js";
 import { classifyRecordForReplicaCutover } from "./tursoReplicaCutoverClassify.js";
+import { isRetiredCutoverBlockReason } from "./retiredCutoverBlocks.js";
 import {
   backupLocalDbPreReplica,
   restoreLocalDbFromPreReplicaBackup,
@@ -213,7 +214,23 @@ export async function runCutoverForRecord(
 ): Promise<CutoverRunResult> {
   const dryRun = options?.dryRun === true;
 
-  if (options?.forceRetry && record.cutoverBlocked) {
+  // A retired reason names a failure the current code cannot produce, so the
+  // block is a fossil rather than a live verdict. Clearing it here — not only
+  // under forceRetry — is what lets the automatic pass reconsider a database
+  // that would otherwise stay on the legacy path until someone clicked
+  // "Upload now", with no symptom pointing at why.
+  const blockRetired =
+    record.cutoverBlocked === true &&
+    isRetiredCutoverBlockReason(record.cutoverBlockReason);
+
+  if (blockRetired) {
+    console.warn(
+      `[TursoReplicaCutover] Clearing retired cutover block for ${record.dbId}: ` +
+        `${record.cutoverBlockReason} — this failure mode no longer exists, retrying cutover.`,
+    );
+  }
+
+  if ((options?.forceRetry || blockRetired) && record.cutoverBlocked) {
     const registry = getDatabaseRegistryService();
     await registry.updateReplicaPushState(record.dbId, {
       cutoverBlocked: false,

--- a/src/gateway/services/tursoReplica/replicaBusyRetry.ts
+++ b/src/gateway/services/tursoReplica/replicaBusyRetry.ts
@@ -1,0 +1,62 @@
+/**
+ * The `busy_timeout` the replica engine does not have.
+ *
+ * Every better-sqlite3 path in this codebase waits out a contended file — the
+ * mini-app read worker sets 3s, the CDC writer 5s. `@tursodatabase/sync` has no
+ * equivalent knob (`connectTursoReplica` passes none), so a replica read that
+ * lands while a push or migration holds the file fails on the first attempt and
+ * the raw "database is locked" travels all the way to the mini-app UI.
+ *
+ * Waiting inside the caller's scheduler slot is intentional, and is what
+ * `busy_timeout` does too: it blocks the connection rather than yielding it.
+ * The budget stays well under REPLICA_OPERATION_TIMEOUT_MS so a contended read
+ * still resolves inside the operation timeout instead of trading one error for
+ * another.
+ */
+
+import { isReplicaBusyError } from "./tursoReplicaErrors.js";
+
+/** ~2.4s total, in the same range as the better-sqlite3 read path's 3s. */
+const BUSY_RETRY_DELAYS_MS = [150, 350, 700, 1200] as const;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `fn`, retrying only while it fails with a lock error.
+ *
+ * Any other failure propagates on the first attempt — retrying a schema or
+ * transport error would just delay the real report.
+ */
+export async function retryWhileReplicaBusy<T>(
+  fn: () => Promise<T>,
+  label: string,
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= BUSY_RETRY_DELAYS_MS.length; attempt++) {
+    if (attempt > 0) {
+      await sleep(BUSY_RETRY_DELAYS_MS[attempt - 1]);
+    }
+    try {
+      return await fn();
+    } catch (error) {
+      if (!isReplicaBusyError(error)) {
+        throw error;
+      }
+      lastError = error;
+    }
+  }
+
+  // Out of budget: the holder is not transient. Report the lock rather than
+  // masking it, so the caller's own recovery and the logs still see the truth.
+  console.warn(
+    `[TursoReplicaBusy] ${label} still locked after ` +
+      `${BUSY_RETRY_DELAYS_MS.length + 1} attempts — giving up`,
+  );
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+/** @internal test hook */
+export const BUSY_RETRY_ATTEMPTS = BUSY_RETRY_DELAYS_MS.length + 1;

--- a/src/gateway/services/tursoReplica/tursoReplicaErrors.ts
+++ b/src/gateway/services/tursoReplica/tursoReplicaErrors.ts
@@ -10,3 +10,39 @@ export function isTursoHostNotReadyError(error: unknown): boolean {
     msg.includes("not found")
   );
 }
+
+/**
+ * Contention, not damage: someone else holds the file right now.
+ *
+ * Deliberately separate from `isReplicaReadTransportError`. That classifier's
+ * recovery resets the sync sidecars, which is the right remedy for a wedged
+ * WAL and the wrong one here — a lock means the previous holder is mid-flight,
+ * so the fix is to wait, not to operate on its files. The engine sets no
+ * `busy_timeout` (see `connectTursoReplica`), so nothing waits unless we do.
+ */
+export function isReplicaBusyError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  const lower = msg.toLowerCase();
+  return (
+    lower.includes("database is locked") ||
+    lower.includes("database table is locked") ||
+    lower.includes("sqlite_busy")
+  );
+}
+
+/**
+ * Matches the message as well as the code, because only one of the two engines
+ * on these files sets a code. better-sqlite3 raises `code: "SQLITE_BUSY"`;
+ * `@tursodatabase/sync` surfaces a bare "database is locked". Checking the code
+ * alone meant every caller's "DB busy, defer and try later" branch quietly
+ * never ran for replica-backed databases, turning a wait into a hard failure.
+ */
+export function isSqliteBusyError(error: unknown): boolean {
+  const hasBusyCode =
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: string }).code === "SQLITE_BUSY";
+
+  return hasBusyCode || isReplicaBusyError(error);
+}

--- a/src/gateway/services/tursoSyncBridgeCore.ts
+++ b/src/gateway/services/tursoSyncBridgeCore.ts
@@ -879,14 +879,9 @@ const LOCAL_DB_BUSY_TIMEOUT_MS = 5_000;
 /** Paths where changelog infrastructure was installed this session (avoids DDL on every watcher event). */
 const changeLogReadyPaths = new Set<string>();
 
-export function isSqliteBusyError(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error as { code: string }).code === "SQLITE_BUSY"
-  );
-}
+// Re-exported so existing importers keep working; defined in the classifier
+// module, which is native-import-free and reachable from the sync worker.
+export { isSqliteBusyError } from "./tursoReplica/tursoReplicaErrors.js";
 
 /** @internal test hook */
 export function resetChangeLogReadyCacheForTests(): void {

--- a/src/gateway/utils/keyResolver.ts
+++ b/src/gateway/utils/keyResolver.ts
@@ -473,7 +473,9 @@ export async function getProviderAuth(
   provider: "openai" | "anthropic",
   ipcProcess: IpcProcessLike = process,
 ): Promise<
-  { type: "oauth"; token: string } | { type: "apiKey"; key: string } | null
+  | { type: "oauth"; token: string }
+  | { type: "apiKey"; key: string; oauthExpired?: boolean }
+  | null
 > {
   const keyName =
     provider === "openai" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
@@ -514,13 +516,35 @@ export async function getProviderAuth(
     }
   }
 
-  // Fall back to API key
+  // Fall back to API key.
+  //
+  // When an OAuth token exists but has expired, this is a downgrade rather
+  // than a plain fallback: it moves the request off the user's subscription
+  // and onto their platform API organisation, which bills separately and
+  // carries its own spend caps. Say so out loud. Doing it silently is how a
+  // subscription sitting at 11% usage produced "you have reached your usage
+  // limits" — the cap being reported belonged to an account the user had not
+  // chosen to spend from.
+  const oauthExpired = oauthTokenCache[provider] !== undefined;
+
   if (keys[keyName]) {
+    if (oauthExpired) {
+      console.warn(
+        `[KeyResolver] ${provider} OAuth token is expired — falling back to the ` +
+          `platform API key. Requests will bill the platform API account, not ` +
+          `the subscription. Reconnect ${provider} in Settings to go back to ` +
+          `the subscription.`
+      );
+    }
     console.log(
       `[KeyResolver] Using API key for ${provider} ` +
       `(length: ${keys[keyName].length}, prefix: ${keys[keyName].substring(0, 20)}...)`
     );
-    return { type: "apiKey", key: keys[keyName] };
+    return {
+      type: "apiKey",
+      key: keys[keyName],
+      ...(oauthExpired ? { oauthExpired: true } : {}),
+    };
   }
 
   console.log(`[KeyResolver] No authentication found for ${provider}`);
@@ -536,7 +560,9 @@ export async function getProviderAuthForModel(
   options: { modelId: string; modelProvider: string },
   ipcProcess: IpcProcessLike = process,
 ): Promise<
-  { type: "oauth"; token: string } | { type: "apiKey"; key: string } | null
+  | { type: "oauth"; token: string }
+  | { type: "apiKey"; key: string; oauthExpired?: boolean }
+  | null
 > {
   const { modelId, modelProvider } = options;
 

--- a/src/gateway/utils/providerRateLimitRetry.ts
+++ b/src/gateway/utils/providerRateLimitRetry.ts
@@ -5,16 +5,56 @@ export const MAX_PROVIDER_RATE_LIMIT_RETRIES = 2;
 
 export const RATE_LIMIT_EXHAUSTED_ERROR_CODE = "rate_limit_exhausted";
 
-export function createRateLimitExhaustedError(): {
+/**
+ * A limit that will not clear by waiting a moment, so Resume cannot fix it.
+ * Carries its own code because the UI's response has to differ: Resume is the
+ * right affordance for a burst limit and a false promise for a spent month.
+ */
+export const PROVIDER_QUOTA_EXHAUSTED_ERROR_CODE = "provider_quota_exhausted";
+
+/** Which knob the user has to turn to get working again. */
+export type QuotaRemedy =
+  | "subscription_quota"
+  | "api_spend_cap"
+  | "api_credits";
+
+export interface ProviderQuotaExhaustion {
+  remedy: QuotaRemedy;
+  /** The provider's own sentence, verbatim — it is the ground truth. */
+  providerMessage?: string;
+  /** When access returns, when the provider bothered to say. */
+  resetsAt?: Date;
+}
+
+export function createRateLimitExhaustedError(error?: unknown): {
   type: "stream_pause";
   code: typeof RATE_LIMIT_EXHAUSTED_ERROR_CODE;
   message: string;
 } {
+  // A burst limit really does clear on its own, so Resume is honest here. The
+  // provider's sentence is still worth passing along when it says something
+  // more specific than "429".
+  const detail = error ? extractProviderSentence(error) : undefined;
   return {
     type: "stream_pause",
     code: RATE_LIMIT_EXHAUSTED_ERROR_CODE,
-    message:
-      "The AI provider is rate limited. Tap Resume when ready to continue.",
+    message: detail
+      ? `The AI provider is rate limited. Tap Resume when ready to continue.\n\nProvider said: “${detail}”`
+      : "The AI provider is rate limited. Tap Resume when ready to continue.",
+  };
+}
+
+export function createProviderQuotaExhaustedError(
+  detail: ProviderQuotaExhaustion,
+): {
+  type: "stream_pause";
+  code: typeof PROVIDER_QUOTA_EXHAUSTED_ERROR_CODE;
+  message: string;
+} {
+  return {
+    type: "stream_pause",
+    code: PROVIDER_QUOTA_EXHAUSTED_ERROR_CODE,
+    message: describeQuotaExhaustion(detail),
   };
 }
 
@@ -39,6 +79,16 @@ function collectErrorStrings(error: unknown, depth = 0): string[] {
     }
     if (typeof record.responseBody === "string") {
       parts.push(record.responseBody);
+      // Anthropic's explanation lives in `error.message` inside this JSON, so
+      // the raw string alone is enough to match against but useless to quote.
+      try {
+        const parsed: unknown = JSON.parse(record.responseBody);
+        if (typeof parsed === "object" && parsed !== null) {
+          parts.push(...collectErrorStrings(parsed, depth + 1));
+        }
+      } catch {
+        // Not JSON; the raw string above is all there is.
+      }
     }
     if (typeof record.error === "object" && record.error !== null) {
       parts.push(...collectErrorStrings(record.error, depth + 1));
@@ -76,7 +126,171 @@ export function isProviderOverloadError(error: unknown): boolean {
   );
 }
 
+/**
+ * Phrases that mean the account is out of allowance, as opposed to going too
+ * fast. Anthropic returns both as HTTP 429 with `type: "rate_limit_error"`, so
+ * the status code cannot tell them apart — only the sentence can.
+ */
+const QUOTA_SIGNALS: ReadonlyArray<{ pattern: RegExp; remedy: QuotaRemedy }> = [
+  { pattern: /specified\s+api\s+usage\s+limits?/i, remedy: "api_spend_cap" },
+  { pattern: /will\s+regain\s+access\s+on/i, remedy: "api_spend_cap" },
+  {
+    pattern: /monthly\s+(?:spend|budget|usage)\s+limit/i,
+    remedy: "api_spend_cap",
+  },
+  { pattern: /credit\s+balance\s+is\s+too\s+low/i, remedy: "api_credits" },
+  { pattern: /insufficient\s+credits?/i, remedy: "api_credits" },
+  { pattern: /out\s+of\s+credits?/i, remedy: "api_credits" },
+  { pattern: /usage\s+limit\s+reached/i, remedy: "subscription_quota" },
+  {
+    pattern: /exceeded\s+your\s+account'?s?\s+usage\s+limit/i,
+    remedy: "subscription_quota",
+  },
+  {
+    pattern: /(?:weekly|plan|quota)\s+limit\s+reached/i,
+    remedy: "subscription_quota",
+  },
+];
+
+/**
+ * Markers of an ordinary burst ceiling. These take precedence, because the cost
+ * of the two mistakes is not symmetric: calling a burst limit "spent allowance"
+ * removes a retry that genuinely works, while the reverse merely wastes three
+ * attempts before saying something useful.
+ */
+const TRANSIENT_SIGNALS: ReadonlyArray<RegExp> = [
+  /per[-\s]?minute/i,
+  /per[-\s]?second/i,
+  /tokens?\s+per\s+(?:minute|second|hour|day)/i,
+  /requests?\s+per\s+(?:minute|second|hour|day)/i,
+  /concurrent/i,
+];
+
+function parseQuotaResetsAt(haystack: string): Date | undefined {
+  // Claude subscription limits arrive as `usage limit reached|<epoch>`.
+  const piped = haystack.match(
+    /usage\s+limit\s+reached\s*\|\s*(\d{9,13})/i,
+  );
+  if (piped) {
+    const raw = Number(piped[1]);
+    const ms = raw < 1e11 ? raw * 1000 : raw;
+    const date = new Date(ms);
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+
+  // Anchored to a reset word on purpose. An unanchored date scan would happily
+  // report an unrelated timestamp elsewhere in the payload as the reset time,
+  // and a confidently wrong date is worse than none.
+  const anchored = haystack.match(
+    /(?:resets?|regain\s+access(?:\s+on)?|available\s+again)\D{0,20}(\d{4}-\d{2}-\d{2})(?:T|\s+at\s+|\s+)?(\d{1,2}):(\d{2})?/i,
+  );
+  if (anchored) {
+    const [, day, hour, minute] = anchored;
+    const date = new Date(
+      `${day}T${hour.padStart(2, "0")}:${minute ?? "00"}:00Z`,
+    );
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+
+  const dateOnly = haystack.match(
+    /(?:resets?|regain\s+access(?:\s+on)?|available\s+again)\D{0,20}(\d{4}-\d{2}-\d{2})/i,
+  );
+  if (dateOnly) {
+    const date = new Date(`${dateOnly[1]}T00:00:00Z`);
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+
+  return undefined;
+}
+
+/** The longest sentence the provider gave us, which is usually the useful one. */
+function extractProviderSentence(error: unknown): string | undefined {
+  const candidates = collectErrorStrings(error)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 24 && /[a-z]{4}/i.test(part))
+    // Serialized bodies are noise next to the message they contain.
+    .filter((part) => !part.startsWith("{") && !part.startsWith("["));
+  if (candidates.length === 0) return undefined;
+  return candidates.sort((a, b) => b.length - a.length)[0];
+}
+
+/**
+ * Classify a provider refusal as spent allowance, or not.
+ *
+ * Returns null for anything that waiting could plausibly fix, which keeps the
+ * existing silent-retry path in charge of transient limits.
+ */
+export function detectProviderQuotaExhaustion(
+  error: unknown,
+): ProviderQuotaExhaustion | null {
+  const haystack = collectErrorStrings(error).join(" ");
+  if (!haystack.trim()) return null;
+
+  if (TRANSIENT_SIGNALS.some((pattern) => pattern.test(haystack))) return null;
+
+  const signal = QUOTA_SIGNALS.find(({ pattern }) => pattern.test(haystack));
+  if (!signal) return null;
+
+  return {
+    remedy: signal.remedy,
+    providerMessage: extractProviderSentence(error),
+    resetsAt: parseQuotaResetsAt(haystack),
+  };
+}
+
+function formatResetInstant(date: Date): string {
+  const formatted = new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC",
+  }).format(date);
+  return `${formatted} UTC`;
+}
+
+const REMEDY_COPY: Record<QuotaRemedy, { headline: string; action: string }> = {
+  subscription_quota: {
+    headline: "Your subscription's usage limit is reached",
+    action:
+      "Switch to a model that still has quota, or use an API key instead — Settings → AI Models.",
+  },
+  api_spend_cap: {
+    headline: "Your API spend limit is reached",
+    action:
+      "Raise or remove the cap in your provider's console, or switch to a subscription login — Settings → AI Models.",
+  },
+  api_credits: {
+    headline: "Your API credit balance is empty",
+    action:
+      "Add credits in your provider's billing settings, or switch to a subscription login — Settings → AI Models.",
+  },
+};
+
+export function describeQuotaExhaustion(
+  detail: ProviderQuotaExhaustion,
+): string {
+  const { headline, action } = REMEDY_COPY[detail.remedy];
+
+  // Naming the reset up front is the whole point: it is what tells the user
+  // whether to wait or to go change a setting.
+  const timing = detail.resetsAt
+    ? ` Access returns ${formatResetInstant(detail.resetsAt)}.`
+    : "";
+
+  const lines = [
+    `${headline} — retrying won't help until it resets.${timing}`,
+    action,
+  ];
+  if (detail.providerMessage) {
+    lines.push(`Provider said: “${detail.providerMessage}”`);
+  }
+  return lines.join("\n\n");
+}
+
 export function isRetryableProviderCapacityError(error: unknown): boolean {
+  // Spent allowance is not capacity pressure. Retrying it burns three attempts
+  // and a backoff to arrive at the same refusal, then offers Resume for a limit
+  // that may be weeks from clearing.
+  if (detectProviderQuotaExhaustion(error)) return false;
   return isProviderRateLimitError(error) || isProviderOverloadError(error);
 }
 

--- a/tests/chat-draft-store.test.ts
+++ b/tests/chat-draft-store.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Drafts must survive whatever kills the renderer.
+ *
+ * The regression these pin: unsent composer text lived only in an in-memory
+ * Zustand map, so a render-time throw took it with the app. Unlike messages,
+ * a draft exists nowhere else — there is no server copy to recover it from.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  MAX_DRAFT_CHARS,
+  MAX_REMEMBERED_DRAFTS,
+  forgetDraft,
+  readDraft,
+  renameDraft,
+  writeDraft,
+} from "../ui/utils/chatDraftStore";
+import {
+  sameSettings,
+  type ChatModelSettings,
+} from "../ui/utils/chatModelSettings";
+
+/** The backend project runs in node, which has no `window.localStorage`. */
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  key(index: number): string | null {
+    return [...this.store.keys()][index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+let storage: MemoryStorage;
+
+beforeEach(() => {
+  storage = new MemoryStorage();
+  (globalThis as { window?: unknown }).window = { localStorage: storage };
+});
+
+describe("chatDraftStore", () => {
+  it("returns a written draft", () => {
+    writeDraft("chat-a", "half a thought");
+    expect(readDraft("chat-a")).toBe("half a thought");
+  });
+
+  it("survives the in-memory store being emptied", () => {
+    // Nothing here touches React or Zustand — that is the point. A crash that
+    // wipes the store leaves this copy intact.
+    writeDraft("chat-a", "still here");
+    expect(readDraft("chat-a")).toBe("still here");
+  });
+
+  it("keeps drafts isolated per chat", () => {
+    writeDraft("chat-a", "for a");
+    writeDraft("chat-b", "for b");
+    expect(readDraft("chat-a")).toBe("for a");
+    expect(readDraft("chat-b")).toBe("for b");
+  });
+
+  it("returns empty string for a chat with no draft", () => {
+    expect(readDraft("never-typed-in")).toBe("");
+  });
+
+  it("returns empty string for an empty chat id", () => {
+    expect(readDraft("")).toBe("");
+  });
+
+  it("removes the entry when the draft is cleared, rather than storing ''", () => {
+    writeDraft("chat-a", "typed");
+    writeDraft("chat-a", "");
+    expect(readDraft("chat-a")).toBe("");
+    const raw = storage.getItem("paprwork_chat_drafts");
+    expect(raw).not.toContain("chat-a");
+  });
+
+  it("forgets a draft on demand", () => {
+    writeDraft("chat-a", "typed");
+    forgetDraft("chat-a");
+    expect(readDraft("chat-a")).toBe("");
+  });
+
+  it("caps one draft so a giant paste cannot eat the storage budget", () => {
+    writeDraft("chat-a", "x".repeat(MAX_DRAFT_CHARS + 5_000));
+    expect(readDraft("chat-a")).toHaveLength(MAX_DRAFT_CHARS);
+  });
+
+  it("evicts the oldest drafts past the cap", () => {
+    for (let i = 0; i < MAX_REMEMBERED_DRAFTS + 5; i++) {
+      writeDraft(`chat-${i}`, `draft ${i}`);
+    }
+    expect(readDraft("chat-0")).toBe("");
+    expect(readDraft("chat-4")).toBe("");
+    expect(readDraft(`chat-${MAX_REMEMBERED_DRAFTS + 4}`)).toBe(
+      `draft ${MAX_REMEMBERED_DRAFTS + 4}`,
+    );
+  });
+
+  it("refreshes position on re-write, so an active chat is evicted last", () => {
+    writeDraft("chat-old", "keep typing here");
+    for (let i = 0; i < MAX_REMEMBERED_DRAFTS - 1; i++) {
+      writeDraft(`filler-${i}`, `f${i}`);
+    }
+    // Touching it again moves it to the newest slot.
+    writeDraft("chat-old", "keep typing here, more");
+    for (let i = 0; i < 5; i++) {
+      writeDraft(`later-${i}`, `l${i}`);
+    }
+    expect(readDraft("chat-old")).toBe("keep typing here, more");
+  });
+
+  it("carries a draft across the temp -> permanent chat id rename", () => {
+    // Reachable: a user types a second message while the first is streaming,
+    // which is exactly when this rename fires.
+    writeDraft("temp-123", "second message");
+    renameDraft("temp-123", "real-uuid");
+    expect(readDraft("temp-123")).toBe("");
+    expect(readDraft("real-uuid")).toBe("second message");
+  });
+
+  it("does nothing on a rename with no draft to move", () => {
+    expect(() => renameDraft("temp-123", "real-uuid")).not.toThrow();
+    expect(readDraft("real-uuid")).toBe("");
+  });
+
+  it("keeps the newest draft when storage is over quota", () => {
+    // The draft being typed is the only one the user would notice losing, so
+    // an over-quota write retries with just that entry rather than giving up.
+    storage.setItem(
+      "paprwork_chat_drafts",
+      JSON.stringify({ "chat-old": "old draft" }),
+    );
+    const write = storage.setItem.bind(storage);
+    let calls = 0;
+    storage.setItem = (key: string, value: string) => {
+      calls += 1;
+      // Fail the full-map write; allow the trimmed retry.
+      if (calls === 1) {
+        throw new DOMException("quota", "QuotaExceededError");
+      }
+      write(key, value);
+    };
+
+    writeDraft("chat-new", "the one being typed");
+    expect(calls).toBe(2);
+    expect(readDraft("chat-new")).toBe("the one being typed");
+  });
+
+  it("degrades to a no-op when storage is unavailable entirely", () => {
+    (globalThis as { window?: unknown }).window = undefined;
+    expect(() => writeDraft("chat-a", "typed")).not.toThrow();
+    expect(readDraft("chat-a")).toBe("");
+  });
+
+  it("ignores a corrupt stored blob instead of throwing", () => {
+    storage.setItem("paprwork_chat_drafts", "not json{");
+    expect(readDraft("chat-a")).toBe("");
+    expect(() => writeDraft("chat-a", "typed")).not.toThrow();
+    expect(readDraft("chat-a")).toBe("typed");
+  });
+
+  it("drops non-string entries from a tampered blob", () => {
+    storage.setItem(
+      "paprwork_chat_drafts",
+      JSON.stringify({ "chat-a": 42, "chat-b": "real" }),
+    );
+    expect(readDraft("chat-a")).toBe("");
+    expect(readDraft("chat-b")).toBe("real");
+  });
+});
+
+describe("sameSettings", () => {
+  // Guards the render loop: `readChatSettings` builds a fresh object every
+  // call, so React state holding one cannot be compared by reference. Setting
+  // it from a re-read would always look like a change.
+  it("treats two independently-built equal objects as the same", () => {
+    const a: ChatModelSettings = { effort: "high", contextLimit: 200_000 };
+    const b: ChatModelSettings = { effort: "high", contextLimit: 200_000 };
+    expect(a).not.toBe(b);
+    expect(sameSettings(a, b)).toBe(true);
+  });
+
+  it("treats two empty objects as the same", () => {
+    expect(sameSettings({}, {})).toBe(true);
+  });
+
+  it("distinguishes unset from set", () => {
+    expect(sameSettings({}, { effort: "high" })).toBe(false);
+    expect(sameSettings({ thinking: false }, {})).toBe(false);
+  });
+
+  it("notices a change in each field", () => {
+    const base: ChatModelSettings = {
+      thinking: true,
+      effort: "high",
+      contextLimit: 200_000,
+      fast: false,
+    };
+    expect(sameSettings(base, { ...base, thinking: false })).toBe(false);
+    expect(sameSettings(base, { ...base, effort: "low" })).toBe(false);
+    expect(sameSettings(base, { ...base, contextLimit: 1_000_000 })).toBe(
+      false,
+    );
+    expect(sameSettings(base, { ...base, fast: true })).toBe(false);
+  });
+
+  it("does not confuse `false` with unset", () => {
+    // These mean different things: unset follows the model, false overrides it.
+    expect(sameSettings({ thinking: false }, {})).toBe(false);
+    expect(sameSettings({ fast: false }, {})).toBe(false);
+  });
+});

--- a/tests/claude-cli-credentials.test.ts
+++ b/tests/claude-cli-credentials.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import {
+  claudeCredentialsToTokenLifetime,
+  isUsableRefreshToken,
+  parseClaudeCliCredentials,
+} from "../src/core/services/claudeCliCredentials";
+
+const HOUR_SECONDS = 60 * 60;
+const YEAR_SECONDS = 365 * 24 * HOUR_SECONDS;
+const NOW = 1_700_000_000_000;
+
+/** The shape Claude Code writes to the keychain / ~/.claude/.credentials.json. */
+function claudeCodeRecord(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    claudeAiOauth: {
+      accessToken: "sk-ant-oat01-access",
+      refreshToken: "sk-ant-ort01-refresh",
+      expiresAt: NOW + 8 * HOUR_SECONDS * 1000,
+      scopes: ["user:inference"],
+      ...overrides,
+    },
+  });
+}
+
+describe("parseClaudeCliCredentials", () => {
+  it("keeps the refresh token and expiry, not just the access token", () => {
+    const parsed = parseClaudeCliCredentials(claudeCodeRecord());
+
+    expect(parsed).toEqual({
+      accessToken: "sk-ant-oat01-access",
+      refreshToken: "sk-ant-ort01-refresh",
+      expiresAt: NOW + 8 * HOUR_SECONDS * 1000,
+    });
+  });
+
+  it("reads a bare oauth record without the claudeAiOauth wrapper", () => {
+    const parsed = parseClaudeCliCredentials(
+      JSON.stringify({
+        accessToken: "sk-ant-oat01-access",
+        refreshToken: "sk-ant-ort01-refresh",
+        expiresAt: NOW,
+      }),
+    );
+
+    expect(parsed?.refreshToken).toBe("sk-ant-ort01-refresh");
+  });
+
+  it("reports a token with no companion fields rather than inventing them", () => {
+    const parsed = parseClaudeCliCredentials(
+      JSON.stringify({ claudeAiOauth: { accessToken: "sk-ant-oat01-access" } }),
+    );
+
+    expect(parsed).toEqual({ accessToken: "sk-ant-oat01-access" });
+    expect(parsed?.expiresAt).toBeUndefined();
+  });
+
+  it("returns null for unusable input instead of throwing", () => {
+    expect(parseClaudeCliCredentials("not json")).toBeNull();
+    expect(parseClaudeCliCredentials("")).toBeNull();
+    expect(parseClaudeCliCredentials(JSON.stringify({ other: 1 }))).toBeNull();
+    expect(
+      parseClaudeCliCredentials(JSON.stringify({ claudeAiOauth: {} })),
+    ).toBeNull();
+  });
+});
+
+describe("isUsableRefreshToken", () => {
+  it("accepts a genuine refresh token", () => {
+    expect(
+      isUsableRefreshToken("sk-ant-ort01-refresh", "sk-ant-oat01-access"),
+    ).toBe(true);
+  });
+
+  it("rejects the access token echoed into the refresh slot", () => {
+    // The exact record older builds stored, and the reason its refresh
+    // attempts could only ever fail.
+    expect(
+      isUsableRefreshToken("sk-ant-oat01-access", "sk-ant-oat01-access"),
+    ).toBe(false);
+  });
+
+  it("rejects any access token in the refresh slot, even a different one", () => {
+    expect(
+      isUsableRefreshToken("sk-ant-oat01-other", "sk-ant-oat01-access"),
+    ).toBe(false);
+  });
+
+  it("rejects a missing or blank refresh token", () => {
+    expect(isUsableRefreshToken(undefined, "sk-ant-oat01-access")).toBe(false);
+    expect(isUsableRefreshToken("   ", "sk-ant-oat01-access")).toBe(false);
+  });
+});
+
+describe("claudeCredentialsToTokenLifetime", () => {
+  it("converts a real expiry to seconds from now, not a year", () => {
+    const lifetime = claudeCredentialsToTokenLifetime(
+      {
+        accessToken: "sk-ant-oat01-access",
+        refreshToken: "sk-ant-ort01-refresh",
+        expiresAt: NOW + 8 * HOUR_SECONDS * 1000,
+      },
+      { fallbackTtlSeconds: YEAR_SECONDS, now: NOW },
+    );
+
+    expect(lifetime).toEqual({
+      accessToken: "sk-ant-oat01-access",
+      refreshToken: "sk-ant-ort01-refresh",
+      expiresIn: 8 * HOUR_SECONDS,
+    });
+  });
+
+  it("reports an already-elapsed expiry as negative so it reads as expired", () => {
+    const lifetime = claudeCredentialsToTokenLifetime(
+      {
+        accessToken: "sk-ant-oat01-access",
+        refreshToken: "sk-ant-ort01-refresh",
+        expiresAt: NOW - HOUR_SECONDS * 1000,
+      },
+      { fallbackTtlSeconds: YEAR_SECONDS, now: NOW },
+    );
+
+    expect(lifetime.expiresIn).toBe(-HOUR_SECONDS);
+  });
+
+  it("falls back to the assumed lifetime only when no expiry was supplied", () => {
+    const lifetime = claudeCredentialsToTokenLifetime(
+      { accessToken: "sk-ant-oat01-access" },
+      { fallbackTtlSeconds: YEAR_SECONDS, now: NOW },
+    );
+
+    expect(lifetime.expiresIn).toBe(YEAR_SECONDS);
+    // storeToken requires a refresh token, so the access token stands in — and
+    // isUsableRefreshToken is what stops it being redeemed.
+    expect(lifetime.refreshToken).toBe("sk-ant-oat01-access");
+    expect(
+      isUsableRefreshToken(lifetime.refreshToken, lifetime.accessToken),
+    ).toBe(false);
+  });
+
+  it("does not carry a fabricated refresh token through as usable", () => {
+    const lifetime = claudeCredentialsToTokenLifetime(
+      {
+        accessToken: "sk-ant-oat01-access",
+        refreshToken: "sk-ant-oat01-access",
+        expiresAt: NOW + 8 * HOUR_SECONDS * 1000,
+      },
+      { fallbackTtlSeconds: YEAR_SECONDS, now: NOW },
+    );
+
+    expect(
+      isUsableRefreshToken(lifetime.refreshToken, lifetime.accessToken),
+    ).toBe(false);
+  });
+
+  it("round-trips a Claude Code record end to end", () => {
+    const parsed = parseClaudeCliCredentials(claudeCodeRecord());
+    const lifetime = claudeCredentialsToTokenLifetime(parsed!, {
+      fallbackTtlSeconds: YEAR_SECONDS,
+      now: NOW,
+    });
+
+    expect(lifetime.expiresIn).toBe(8 * HOUR_SECONDS);
+    expect(
+      isUsableRefreshToken(lifetime.refreshToken, lifetime.accessToken),
+    ).toBe(true);
+  });
+});

--- a/tests/context-budget.test.ts
+++ b/tests/context-budget.test.ts
@@ -3,6 +3,8 @@ import {
   computeHistoryTokenBudget,
   GEMINI_HISTORY_TOKEN_CAP,
   isContextLengthError,
+  MIN_CONTEXT_LIMIT,
+  resolveEffectiveContextWindow,
   resolveModelContextWindow,
   resolveSummarizeHistoryTokenThreshold,
   shouldForceGeminiResummarize,
@@ -47,6 +49,49 @@ describe("contextBudget", () => {
     expect(shouldForceGeminiResummarize("google", 149_999)).toBe(false);
     expect(shouldForceGeminiResummarize("google", 150_000)).toBe(true);
     expect(shouldForceGeminiResummarize("openai", 200_000)).toBe(false);
+  });
+
+  it("narrows the window to a user-chosen cap", () => {
+    const capped = computeHistoryTokenBudget({
+      provider: "anthropic",
+      modelId: "claude-opus-5",
+      toolTokenEstimate: 86_000,
+      maxOutputTokens: 16_000,
+      contextLimit: 200_000,
+    });
+    // floor(200000 * 0.85) - 86000 - 16000 = 68000
+    expect(capped).toBe(68_000);
+  });
+
+  it("never widens the window past what the model advertises", () => {
+    const asked = computeHistoryTokenBudget({
+      provider: "groq",
+      modelId: "qwen/qwen3-32b",
+      toolTokenEstimate: 20_000,
+      maxOutputTokens: 16_000,
+      contextLimit: 1_000_000,
+    });
+    const unasked = computeHistoryTokenBudget({
+      provider: "groq",
+      modelId: "qwen/qwen3-32b",
+      toolTokenEstimate: 20_000,
+      maxOutputTokens: 16_000,
+    });
+    expect(asked).toBe(unasked);
+  });
+
+  it("ignores a cap that would starve the tool schemas", () => {
+    // A 20K cap cannot carry ~86K of tools, so it clamps to the floor rather
+    // than computing a budget the request could never satisfy.
+    expect(
+      resolveEffectiveContextWindow("anthropic", "claude-opus-5", 20_000),
+    ).toBe(MIN_CONTEXT_LIMIT);
+  });
+
+  it("falls back to the model window when no cap is set", () => {
+    expect(
+      resolveEffectiveContextWindow("anthropic", "claude-opus-5"),
+    ).toBe(resolveModelContextWindow("anthropic", "claude-opus-5"));
   });
 
   it("detects Groq context length errors", () => {

--- a/tests/document-meta-normalize.test.ts
+++ b/tests/document-meta-normalize.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  documentMetaNeedsRewrite,
+  normalizeDocumentMeta,
+} from "../src/gateway/services/documentMetaNormalize.js";
+
+/**
+ * The exact meta.json that produced the reported warning. It is favourited, so
+ * it reaches the sidebar's favourites list, and it carries neither `id` nor
+ * `type` — the cast in `readMeta` supplied `undefined` for both and the missing
+ * id became a React list key.
+ */
+const SEEDED_META_WITHOUT_ID = {
+  title: "My Document",
+  tags: ["test", "migration"],
+  favorite: true,
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: "2025-01-01T12:00:00Z",
+  preview: "This is my document.",
+  wordCount: 6,
+};
+
+const OPTIONS = { fallbackTitle: "Doc 001" };
+
+describe("normalizeDocumentMeta", () => {
+  it("supplies the id the reported file was missing", () => {
+    const meta = normalizeDocumentMeta("doc-001", SEEDED_META_WITHOUT_ID, OPTIONS);
+    expect(meta?.id).toBe("doc-001");
+    expect(meta?.type).toBe("document");
+  });
+
+  it("keeps every field the file did state", () => {
+    // Repair must not cost data: the record is completed, not replaced.
+    const meta = normalizeDocumentMeta("doc-001", SEEDED_META_WITHOUT_ID, OPTIONS);
+    expect(meta).toMatchObject({
+      title: "My Document",
+      tags: ["test", "migration"],
+      favorite: true,
+      createdAt: "2025-01-01T00:00:00Z",
+      updatedAt: "2025-01-01T12:00:00Z",
+      preview: "This is my document.",
+      wordCount: 6,
+    });
+  });
+
+  it("lets the directory name override a contradicting stored id", () => {
+    // Every lookup path is built from the directory name, so a document is
+    // reachable under it whatever the file claims. Trusting the file instead
+    // would hand out an id that resolves to nothing.
+    const meta = normalizeDocumentMeta(
+      "actual-dir",
+      { ...SEEDED_META_WITHOUT_ID, id: "stale-id" },
+      OPTIONS,
+    );
+    expect(meta?.id).toBe("actual-dir");
+  });
+
+  it("falls back to the derived title when none is stored", () => {
+    const meta = normalizeDocumentMeta("doc-001", { favorite: false }, OPTIONS);
+    expect(meta?.title).toBe("Doc 001");
+  });
+
+  it("ignores fields of the wrong type rather than passing them through", () => {
+    const meta = normalizeDocumentMeta(
+      "doc-001",
+      { title: 42, tags: "not-an-array", wordCount: "six", favorite: "yes" },
+      OPTIONS,
+    );
+    expect(meta).toMatchObject({
+      title: "Doc 001",
+      tags: [],
+      wordCount: 0,
+      // Only a real boolean true counts; a truthy string must not favourite a
+      // document, since that is what puts it in the sidebar.
+      favorite: false,
+    });
+  });
+
+  it("drops blank tag entries but keeps real ones", () => {
+    const meta = normalizeDocumentMeta(
+      "doc-001",
+      { tags: ["real", 7, null, "also-real"] },
+      OPTIONS,
+    );
+    expect(meta?.tags).toEqual(["real", "also-real"]);
+  });
+
+  it("defaults updatedAt to createdAt rather than to now", () => {
+    const meta = normalizeDocumentMeta(
+      "doc-001",
+      { createdAt: "2025-01-01T00:00:00Z" },
+      OPTIONS,
+    );
+    expect(meta?.updatedAt).toBe("2025-01-01T00:00:00Z");
+  });
+
+  it("returns null for content that is not an object, so the caller rebuilds", () => {
+    // Corruption, not an incomplete record — there is nothing here to complete,
+    // and `readMeta` regenerates from content.md instead.
+    expect(normalizeDocumentMeta("doc-001", "just a string", OPTIONS)).toBeNull();
+    expect(normalizeDocumentMeta("doc-001", null, OPTIONS)).toBeNull();
+    expect(normalizeDocumentMeta("doc-001", [1, 2], OPTIONS)).toBeNull();
+  });
+});
+
+describe("documentMetaNeedsRewrite", () => {
+  it("flags the reported file", () => {
+    expect(documentMetaNeedsRewrite("doc-001", SEEDED_META_WITHOUT_ID)).toBe(true);
+  });
+
+  it("flags an id that disagrees with its directory", () => {
+    expect(
+      documentMetaNeedsRewrite("actual-dir", {
+        ...SEEDED_META_WITHOUT_ID,
+        id: "stale-id",
+        type: "document",
+      }),
+    ).toBe(true);
+  });
+
+  it("leaves a healthy file alone", () => {
+    // Guards against rewriting all ~288 documents on every launch.
+    expect(
+      documentMetaNeedsRewrite("doc-001", {
+        ...SEEDED_META_WITHOUT_ID,
+        id: "doc-001",
+        type: "document",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flag a healthy file merely for omitting optional fields", () => {
+    expect(
+      documentMetaNeedsRewrite("doc-001", { id: "doc-001", type: "document" }),
+    ).toBe(false);
+  });
+});

--- a/tests/model-controls.test.ts
+++ b/tests/model-controls.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Per-chat model controls: capability gating, settings resolution, config shape.
+ *
+ * The cases that matter are the ones where a stored value must be *dropped*:
+ * a saved choice that a newly selected model cannot honour has to fall back
+ * rather than ride along into a request that will misbehave or overspend.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { ModelFallback } from "../src/core/agents/ModelFallback";
+import {
+  CONTEXT_OPTIONS,
+  DEFAULT_CONTEXT_LIMIT,
+  EFFORT_VARIANT_MODELS,
+  MODEL_CONTEXT_WINDOWS,
+  contextOptionsForModel,
+  effortLevelsForModel,
+  formatContextLimit,
+  modelSupportsEffort,
+  modelSupportsFast,
+  modelSupportsThinkingToggle,
+  unpackEffortVariant,
+} from "../ui/constants/modelControls";
+import type { AIModel } from "../ui/constants/models";
+import { CHAT_MODELS } from "../ui/constants/models";
+import {
+  buildAgentConfig,
+  resolveModelSettings,
+} from "../ui/utils/buildAgentConfig";
+import {
+  adoptEffortFromVariant,
+  forgetChatSettings,
+  readChatSettings,
+  renameChatSettings,
+  sanitizeSettings,
+  writeChatSettings,
+} from "../ui/utils/chatModelSettings";
+import {
+  PICKER_DEFAULT_MODEL_IDS,
+  isChatPickerModelId,
+  migrateEnabledPickerModelIds,
+  migratePickerModelId,
+} from "../ui/constants/modelPicker";
+
+/** Minimal localStorage so these run without a DOM (matches chat-model-scoping). */
+class MemoryStorage implements Storage {
+  private data = new Map<string, string>();
+  get length(): number {
+    return this.data.size;
+  }
+  clear(): void {
+    this.data.clear();
+  }
+  getItem(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.data.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.data.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.data.set(key, String(value));
+  }
+}
+
+function model(overrides: Partial<AIModel> = {}): AIModel {
+  return {
+    id: "claude-opus-5",
+    name: "Claude Opus 5",
+    description: "",
+    provider: "anthropic",
+    group: "Anthropic",
+    supportsThinking: true,
+    requiresApiKey: "ANTHROPIC_API_KEY",
+    ...overrides,
+  };
+}
+
+describe("effort variant collapse", () => {
+  it("unpacks a variant id into its base model and implied effort", () => {
+    expect(unpackEffortVariant("gpt-5-6-sol-high")).toEqual({
+      modelId: "gpt-5-6-sol",
+      effort: "high",
+    });
+    expect(unpackEffortVariant("glm-5.2-max")).toEqual({
+      modelId: "glm-5.2",
+      effort: "max",
+    });
+  });
+
+  it("leaves a non-variant id untouched", () => {
+    expect(unpackEffortVariant("claude-opus-5")).toEqual({
+      modelId: "claude-opus-5",
+    });
+  });
+
+  it("never maps a variant onto another variant", () => {
+    for (const { modelId } of Object.values(EFFORT_VARIANT_MODELS)) {
+      expect(EFFORT_VARIANT_MODELS[modelId]).toBeUndefined();
+    }
+  });
+
+  it("only names base models that still exist in the catalog", () => {
+    const known = new Set(CHAT_MODELS.map((entry) => entry.id));
+    for (const { modelId } of Object.values(EFFORT_VARIANT_MODELS)) {
+      expect(known).toContain(modelId);
+    }
+  });
+});
+
+describe("capability gating", () => {
+  it("offers a thinking toggle only where the request can carry an off switch", () => {
+    expect(modelSupportsThinkingToggle(model())).toBe(true);
+    expect(modelSupportsThinkingToggle(model({ provider: "google" }))).toBe(
+      true,
+    );
+    // OpenAI reasoning is intrinsic — a toggle would be wired to nothing.
+    expect(modelSupportsThinkingToggle(model({ provider: "openai" }))).toBe(
+      false,
+    );
+  });
+
+  it("hides every reasoning control on a non-thinking model", () => {
+    const plain = model({ provider: "groq", supportsThinking: false });
+    expect(modelSupportsThinkingToggle(plain)).toBe(false);
+    expect(modelSupportsEffort(plain)).toBe(false);
+  });
+
+  it("offers max effort only where the provider accepts it", () => {
+    expect(effortLevelsForModel(model())).toContain("max");
+    expect(effortLevelsForModel(model({ provider: "openai" }))).not.toContain(
+      "max",
+    );
+  });
+
+  // `effort` is part of Anthropic's adaptive thinking surface. The
+  // budget-thinking models take `{ type: "enabled", budgetTokens }` and have no
+  // effort field, so an Effort row there would send a parameter the request
+  // cannot carry. This mirrors the gateway gate in AgentService.
+  it("offers Anthropic effort only on adaptive-thinking models", () => {
+    for (const id of [
+      "claude-opus-5",
+      "claude-fable-5-1",
+      "claude-sonnet-5",
+      "claude-opus-4-8",
+    ]) {
+      expect(modelSupportsEffort(model({ id })), id).toBe(true);
+    }
+    for (const id of [
+      "claude-sonnet-4-6",
+      "claude-haiku-4-5",
+      "claude-opus-4-6",
+    ]) {
+      expect(modelSupportsEffort(model({ id })), id).toBe(false);
+    }
+  });
+
+  it("caps Anthropic effort at max only on the frontier models", () => {
+    expect(effortLevelsForModel(model({ id: "claude-opus-5" }))).toContain(
+      "max",
+    );
+    expect(effortLevelsForModel(model({ id: "claude-fable-5-1" }))).toContain(
+      "max",
+    );
+    // The gateway maps xhigh -> high for Sonnet 5, so max is not on offer.
+    expect(
+      effortLevelsForModel(model({ id: "claude-sonnet-5" })),
+    ).not.toContain("max");
+  });
+
+  it("restricts fast mode to Opus-class models on an API key", () => {
+    expect(modelSupportsFast(model(), "apiKey")).toBe(true);
+    // pi-ai has no `speed` parameter, so OAuth would silently ignore it.
+    expect(modelSupportsFast(model(), "oauth")).toBe(false);
+    expect(modelSupportsFast(model({ id: "claude-sonnet-5" }), "apiKey")).toBe(
+      false,
+    );
+  });
+});
+
+describe("context options", () => {
+  it("never offers more context than the model's window", () => {
+    const narrow = model({ id: "qwen/qwen3-32b", provider: "groq" });
+    for (const option of contextOptionsForModel(narrow)) {
+      expect(option).toBeLessThanOrEqual(
+        MODEL_CONTEXT_WINDOWS["qwen/qwen3-32b"],
+      );
+    }
+  });
+
+  it("still returns one honest choice for a model below the smallest option", () => {
+    const tiny = model({ id: "gpt-5.3-codex", provider: "openai" });
+    expect(contextOptionsForModel(tiny)).toEqual([128_000]);
+  });
+
+  it("formats the options the way the row renders them", () => {
+    expect(CONTEXT_OPTIONS.map(formatContextLimit)).toEqual([
+      "200K",
+      "400K",
+      "1M",
+    ]);
+  });
+});
+
+describe("resolveModelSettings", () => {
+  it("defaults context to the narrowest option rather than the model's window", () => {
+    // The whole point of the control: a 1M window should not be the default
+    // spend, because every token in the budget is re-sent on every step.
+    expect(resolveModelSettings(model(), {}).contextLimit).toBe(
+      DEFAULT_CONTEXT_LIMIT,
+    );
+  });
+
+  it("drops a stored context that the newly selected model cannot honour", () => {
+    const narrow = model({ id: "qwen/qwen3-32b", provider: "groq" });
+    const resolved = resolveModelSettings(narrow, {
+      contextLimit: 1_000_000,
+    });
+    expect(resolved.contextLimit).toBe(131_072);
+  });
+
+  it("drops a stored effort the new provider does not accept", () => {
+    const openai = model({
+      provider: "openai",
+      reasoning: { effort: "medium" },
+    });
+    expect(resolveModelSettings(openai, { effort: "max" }).effort).toBe(
+      "medium",
+    );
+  });
+
+  it("keeps a stored effort the provider does accept", () => {
+    expect(resolveModelSettings(model(), { effort: "max" }).effort).toBe("max");
+  });
+
+  it("falls back to the model's own default effort when unset", () => {
+    const glm = model({
+      id: "glm-5.2",
+      provider: "zai",
+      reasoning: { effort: "high" },
+    });
+    expect(resolveModelSettings(glm, {}).effort).toBe("high");
+  });
+
+  it("treats thinking as on unless the user turned it off", () => {
+    expect(resolveModelSettings(model(), {}).thinking).toBe(true);
+    expect(resolveModelSettings(model(), { thinking: false }).thinking).toBe(
+      false,
+    );
+  });
+
+  it("ignores a thinking-off setting on a model with no off switch", () => {
+    const openai = model({ provider: "openai" });
+    expect(resolveModelSettings(openai, { thinking: false }).thinking).toBe(
+      true,
+    );
+  });
+});
+
+describe("buildAgentConfig", () => {
+  const systemPrompt = "sp";
+
+  it("carries provider, model and output cap through unchanged", () => {
+    const config = buildAgentConfig({
+      model: model({ maxTokens: 128_000 }),
+      settings: {},
+      systemPrompt,
+    });
+    expect(config.provider).toBe("anthropic");
+    expect(config.model).toBe("claude-opus-5");
+    expect(config.maxTokens).toBe(128_000);
+    expect(config.systemPrompt).toBe(systemPrompt);
+  });
+
+  it("does not use a zero thinking budget to mean 'off'", () => {
+    // Opus 5 ships defaultThinkingBudget: 0 and still thinks adaptively, so a
+    // zero budget alone must never be read as the user disabling reasoning.
+    const config = buildAgentConfig({
+      model: model({ defaultThinkingBudget: 0 }),
+      settings: {},
+      systemPrompt,
+    });
+    expect(config.thinkingBudget).toBe(0);
+    expect(config.thinking).toBeUndefined();
+  });
+
+  it("sends an explicit off flag when the user disables thinking", () => {
+    const config = buildAgentConfig({
+      model: model({ defaultThinkingBudget: 0 }),
+      settings: { thinking: false },
+      systemPrompt,
+    });
+    expect(config.thinking).toBe(false);
+  });
+
+  it("omits reasoning entirely when the model has no effort control", () => {
+    const config = buildAgentConfig({
+      model: model({ provider: "groq", supportsThinking: false }),
+      settings: { effort: "high" },
+      systemPrompt,
+    });
+    expect(config.reasoning).toBeUndefined();
+  });
+
+  it("sends fast only on a supported model with an API key", () => {
+    const settings = { fast: true };
+    expect(
+      buildAgentConfig({
+        model: model(),
+        settings,
+        systemPrompt,
+        authType: "apiKey",
+      }).speed,
+    ).toBe("fast");
+    expect(
+      buildAgentConfig({
+        model: model(),
+        settings,
+        systemPrompt,
+        authType: "oauth",
+      }).speed,
+    ).toBeUndefined();
+  });
+});
+
+describe("context window table", () => {
+  it("matches the gateway registry the request is actually budgeted against", () => {
+    // The renderer cannot import ModelFallback (its `.js` specifiers do not
+    // resolve under Vite), so the table is restated in the UI. This is the
+    // guard that keeps the copy from drifting away from the real value.
+    const fallback = new ModelFallback();
+    for (const [modelId, window] of Object.entries(MODEL_CONTEXT_WINDOWS)) {
+      const info = fallback.getModelInfo(modelId);
+      expect(
+        info?.contextWindow,
+        `${modelId} context window drifted from ModelFallback`,
+      ).toBe(window);
+    }
+  });
+});
+
+describe("chat settings persistence", () => {
+  beforeEach(() => {
+    const storage = new MemoryStorage();
+    // @ts-expect-error -- test shim for a browser global
+    globalThis.window = { localStorage: storage };
+  });
+
+  it("keeps one chat's settings out of another's", () => {
+    writeChatSettings("chat-a", { effort: "max" });
+    expect(readChatSettings("chat-b")).toEqual({});
+  });
+
+  it("merges a patch instead of replacing the whole entry", () => {
+    writeChatSettings("chat-a", { effort: "high" });
+    writeChatSettings("chat-a", { contextLimit: 400_000 });
+    expect(readChatSettings("chat-a")).toEqual({
+      effort: "high",
+      contextLimit: 400_000,
+    });
+  });
+
+  it("carries settings across the temp-to-permanent chat id rename", () => {
+    writeChatSettings("temp-1", { fast: true });
+    renameChatSettings("temp-1", "chat-1");
+    expect(readChatSettings("chat-1")).toEqual({ fast: true });
+    expect(readChatSettings("temp-1")).toEqual({});
+  });
+
+  it("forgets a deleted chat", () => {
+    writeChatSettings("chat-a", { effort: "low" });
+    forgetChatSettings("chat-a");
+    expect(readChatSettings("chat-a")).toEqual({});
+  });
+
+  it("discards malformed stored values rather than sending them", () => {
+    expect(sanitizeSettings({ effort: "turbo" })).toBeNull();
+    expect(sanitizeSettings({ contextLimit: -5 })).toBeNull();
+    expect(sanitizeSettings({ thinking: "yes" })).toBeNull();
+    expect(sanitizeSettings({ effort: "high", contextLimit: -5 })).toEqual({
+      effort: "high",
+    });
+  });
+
+  it("survives a corrupt storage blob", () => {
+    window.localStorage.setItem("paprwork_chat_model_settings", "{not json");
+    expect(readChatSettings("chat-a")).toEqual({});
+  });
+
+  it("adopts the effort a retired variant model implied", () => {
+    expect(adoptEffortFromVariant("chat-a", "gpt-5-6-sol-high")).toBe("high");
+    expect(readChatSettings("chat-a")).toEqual({ effort: "high" });
+  });
+
+  it("does not overwrite an effort the user already chose", () => {
+    writeChatSettings("chat-a", { effort: "low" });
+    expect(adoptEffortFromVariant("chat-a", "gpt-5-6-sol-high")).toBeNull();
+    expect(readChatSettings("chat-a").effort).toBe("low");
+  });
+
+  it("does nothing for a model that was never a variant", () => {
+    expect(adoptEffortFromVariant("chat-a", "claude-opus-5")).toBeNull();
+    expect(readChatSettings("chat-a")).toEqual({});
+  });
+});
+
+describe("picker collapse", () => {
+  it("stops listing every effort variant as its own model", () => {
+    for (const variantId of Object.keys(EFFORT_VARIANT_MODELS)) {
+      expect(
+        isChatPickerModelId(variantId),
+        `${variantId} is still offered as a separate picker row`,
+      ).toBe(false);
+    }
+  });
+
+  it("still lists the base model each variant collapses onto", () => {
+    for (const { modelId } of Object.values(EFFORT_VARIANT_MODELS)) {
+      expect(isChatPickerModelId(modelId)).toBe(true);
+    }
+  });
+
+  it("migrates a saved variant preference onto its base model", () => {
+    expect(migratePickerModelId("gpt-5-6-sol-high")).toBe("gpt-5-6-sol");
+    expect(migratePickerModelId("glm-5.2-max")).toBe("glm-5.2");
+  });
+
+  it("upgrades a saved default list without dropping any row", () => {
+    // The list users have today, before the collapse.
+    const saved = [
+      "claude-sonnet-5",
+      "claude-opus-5",
+      "claude-fable-5-1",
+      "gpt-5-6-sol",
+      "glm-5.2-max",
+      "qwen/qwen3-32b",
+      "gemini-3.5-flash-lite",
+      "gemini-3.8-flash",
+      "gemini-3.1-pro-preview",
+    ];
+    const migrated = migrateEnabledPickerModelIds(saved);
+    expect(migrated).toEqual([...PICKER_DEFAULT_MODEL_IDS]);
+    expect(migrated).toHaveLength(saved.length);
+  });
+
+  it("leaves no default pointing at an id the picker hides", () => {
+    for (const id of PICKER_DEFAULT_MODEL_IDS) {
+      expect(isChatPickerModelId(id), `${id} is hidden but default`).toBe(true);
+    }
+  });
+});

--- a/tests/model-controls.test.ts
+++ b/tests/model-controls.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
+import { readFileSync } from "fs";
 import { ModelFallback } from "../src/core/agents/ModelFallback";
 import {
   CONTEXT_OPTIONS,
@@ -449,5 +450,32 @@ describe("picker collapse", () => {
     for (const id of PICKER_DEFAULT_MODEL_IDS) {
       expect(isChatPickerModelId(id), `${id} is hidden but default`).toBe(true);
     }
+  });
+});
+
+describe("renderer -> gateway import boundary", () => {
+  it("keeps anthropicAdaptiveThinking importable from the renderer", () => {
+    // `modelControls` reaches across into the gateway for this one predicate,
+    // so the effort control is gated by the same rule the request is built
+    // from rather than a second hand-kept list. That only works because the
+    // file is a leaf: gateway modules import each other with `.js` specifiers,
+    // which Vite will not resolve back to `.ts`, so the first import added
+    // here would break the renderer build — and only the release build, since
+    // the dev server is more forgiving. Hence this guard.
+    const source = readFileSync(
+      new URL(
+        "../src/gateway/utils/anthropicAdaptiveThinking.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const runtimeImports = source
+      .split("\n")
+      .filter((line) => /^\s*import\s/.test(line))
+      .filter((line) => !/^\s*import\s+type\s/.test(line));
+    expect(
+      runtimeImports,
+      "anthropicAdaptiveThinking must stay import-free to remain renderer-safe",
+    ).toEqual([]);
   });
 });

--- a/tests/model-picker.test.ts
+++ b/tests/model-picker.test.ts
@@ -65,7 +65,8 @@ describe("modelPicker", () => {
       "claude-opus-4-6",
       "claude-opus-5",
       "gpt-5-6-sol",
-      "glm-5.2-max",
+      // Collapsed: max reasoning is now an Effort choice on glm-5.2, not a row.
+      "glm-5.2",
       "qwen/qwen3-32b",
       "gemini-3.5-flash-lite",
       "gemini-3.8-flash",
@@ -177,7 +178,8 @@ describe("modelPicker", () => {
     expect(isPickerDefaultModelId("claude-opus-5")).toBe(true);
     expect(isPickerDefaultModelId("claude-fable-5-1")).toBe(true);
     expect(isPickerDefaultModelId("claude-sonnet-5")).toBe(true);
-    expect(isPickerDefaultModelId("glm-5.2-max")).toBe(true);
+    expect(isPickerDefaultModelId("glm-5.2")).toBe(true);
+    expect(isPickerDefaultModelId("glm-5.2-max")).toBe(false);
     expect(isPickerDefaultModelId("claude-haiku-4-5")).toBe(false);
   });
 

--- a/tests/oauth-credential-adoption.test.ts
+++ b/tests/oauth-credential-adoption.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CREDENTIAL_EXPIRY_SKEW_MS,
   claudeAccessTokenIsLive,
-  claudeCredentialsAreUsable,
+  isUsableRefreshToken,
   type ClaudeCliCredentials,
 } from "../src/core/services/claudeCliCredentials.js";
 import {
@@ -32,13 +32,17 @@ describe("claudeAccessTokenIsLive", () => {
     ).toBe(false);
   });
 
-  it("is stricter than claudeCredentialsAreUsable, which the bug needed", () => {
-    // Pins the distinction the fix turns on. `claudeCredentialsAreUsable`
-    // answers "could these ever authenticate?", so a refresh token makes even
-    // the April credential "usable" — which is why simply reusing that
-    // predicate at the adoption site would not have fixed anything.
+  it("does not treat a well-formed refresh token as evidence of health", () => {
+    // The credential that caused every variant of this bug looks healthy by
+    // structure: its refresh token is real and distinct from the access token.
+    // A predicate that stopped there returned true for it, which is how it came
+    // to overwrite a working token, satisfy Connect without opening a terminal,
+    // and satisfy the poll that waits for the user to finish signing in.
     expect(
-      claudeCredentialsAreUsable(APRIL_KEYCHAIN_CREDENTIAL, SEPTEMBER_NOW),
+      isUsableRefreshToken(
+        APRIL_KEYCHAIN_CREDENTIAL.refreshToken,
+        APRIL_KEYCHAIN_CREDENTIAL.accessToken,
+      ),
     ).toBe(true);
     expect(
       claudeAccessTokenIsLive(APRIL_KEYCHAIN_CREDENTIAL, {

--- a/tests/oauth-credential-adoption.test.ts
+++ b/tests/oauth-credential-adoption.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  CREDENTIAL_EXPIRY_SKEW_MS,
+  claudeAccessTokenIsLive,
+  claudeCredentialsAreUsable,
+  type ClaudeCliCredentials,
+} from "../src/core/services/claudeCliCredentials.js";
+import {
+  isInvalidGrantError,
+  RefreshRejectionLedger,
+} from "../src/core/services/oauthRefreshRejection.js";
+
+/**
+ * The exact credential from the reported failure: Claude Code's Keychain entry
+ * carried a real refresh token and an access token that had expired 136 days
+ * earlier, and adopting it overwrote a token the user had just entered by hand.
+ */
+const APRIL_KEYCHAIN_CREDENTIAL: ClaudeCliCredentials = {
+  accessToken: "sk-ant-oat-april",
+  refreshToken: "sk-ant-ort-april",
+  expiresAt: Date.parse("2026-04-24T23:03:09.865Z"),
+};
+
+const SEPTEMBER_NOW = Date.parse("2026-09-07T23:20:00.000Z");
+
+describe("claudeAccessTokenIsLive", () => {
+  it("rejects the expired Keychain credential that caused the overwrite", () => {
+    expect(
+      claudeAccessTokenIsLive(APRIL_KEYCHAIN_CREDENTIAL, {
+        now: SEPTEMBER_NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("is stricter than claudeCredentialsAreUsable, which the bug needed", () => {
+    // Pins the distinction the fix turns on. `claudeCredentialsAreUsable`
+    // answers "could these ever authenticate?", so a refresh token makes even
+    // the April credential "usable" — which is why simply reusing that
+    // predicate at the adoption site would not have fixed anything.
+    expect(
+      claudeCredentialsAreUsable(APRIL_KEYCHAIN_CREDENTIAL, SEPTEMBER_NOW),
+    ).toBe(true);
+    expect(
+      claudeAccessTokenIsLive(APRIL_KEYCHAIN_CREDENTIAL, {
+        now: SEPTEMBER_NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a credential whose access token is still live", () => {
+    expect(
+      claudeAccessTokenIsLive(
+        { ...APRIL_KEYCHAIN_CREDENTIAL, expiresAt: SEPTEMBER_NOW + 3_600_000 },
+        { now: SEPTEMBER_NOW },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a credential lapsing inside the skew window", () => {
+    expect(
+      claudeAccessTokenIsLive(
+        {
+          ...APRIL_KEYCHAIN_CREDENTIAL,
+          expiresAt: SEPTEMBER_NOW + CREDENTIAL_EXPIRY_SKEW_MS - 1,
+        },
+        { now: SEPTEMBER_NOW },
+      ),
+    ).toBe(false);
+  });
+
+  it("treats an absent expiry as live, keeping pasted setup-tokens working", () => {
+    // The source never told us an expiry; callers apply a fallback TTL to
+    // these, so discarding them would regress the manual paste flow.
+    expect(
+      claudeAccessTokenIsLive(
+        { accessToken: "sk-ant-oat-pasted" },
+        { now: SEPTEMBER_NOW },
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("isInvalidGrantError", () => {
+  it("recognises the provider's rejection from the reported failure", () => {
+    expect(
+      isInvalidGrantError(
+        new Error(
+          'Token refresh failed: 400 - {"error": "invalid_grant", ' +
+            '"error_description": "Refresh token not found or invalid"}',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("leaves a Cloudflare challenge retryable", () => {
+    // A 403 interstitial says nothing about the token. Condemning it here
+    // would strand a perfectly good grant behind a transient gateway block.
+    expect(
+      isInvalidGrantError(
+        new Error("Token refresh failed: 403 - <!DOCTYPE html>Just a moment..."),
+      ),
+    ).toBe(false);
+  });
+
+  it("leaves transport faults retryable", () => {
+    expect(isInvalidGrantError(new Error("fetch failed: ETIMEDOUT"))).toBe(
+      false,
+    );
+    expect(isInvalidGrantError(undefined)).toBe(false);
+  });
+});
+
+describe("RefreshRejectionLedger", () => {
+  it("suppresses a re-post of the token the provider rejected", () => {
+    const ledger = new RefreshRejectionLedger();
+    ledger.record("anthropic", "sk-ant-ort-dead");
+    expect(ledger.isRejected("anthropic", "sk-ant-ort-dead")).toBe(true);
+  });
+
+  it("does not carry a verdict onto a newly issued refresh token", () => {
+    // Keyed by token value, so reconnecting is enough to resume refreshing
+    // without any explicit reset.
+    const ledger = new RefreshRejectionLedger();
+    ledger.record("anthropic", "sk-ant-ort-dead");
+    expect(ledger.isRejected("anthropic", "sk-ant-ort-fresh")).toBe(false);
+  });
+
+  it("keeps verdicts per provider", () => {
+    const ledger = new RefreshRejectionLedger();
+    ledger.record("anthropic", "shared-value");
+    expect(ledger.isRejected("openai", "shared-value")).toBe(false);
+  });
+
+  it("ignores blank tokens rather than banning the empty string", () => {
+    const ledger = new RefreshRejectionLedger();
+    ledger.record("anthropic", "   ");
+    expect(ledger.isRejected("anthropic", "")).toBe(false);
+    expect(ledger.isRejected("anthropic", undefined)).toBe(false);
+  });
+
+  it("forgets verdicts on disconnect", () => {
+    const ledger = new RefreshRejectionLedger();
+    ledger.record("anthropic", "sk-ant-ort-dead");
+    ledger.clear("anthropic");
+    expect(ledger.isRejected("anthropic", "sk-ant-ort-dead")).toBe(false);
+  });
+});

--- a/tests/provider-auth-rejection.test.ts
+++ b/tests/provider-auth-rejection.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  isProviderAuthRejection,
+  providerForModelId,
+} from "../ui/utils/providerAuthRejection";
+import { useProviderAuthStore } from "../ui/stores/providerAuthStore";
+
+describe("isProviderAuthRejection", () => {
+  it("matches the message the gateway rewrites a 401 into", () => {
+    expect(
+      isProviderAuthRejection(
+        "Invalid API key. Please check your API key in Settings.",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the raw Anthropic OAuth body seen in the failing turn", () => {
+    expect(
+      isProviderAuthRejection(
+        '401 {"type":"error","error":{"type":"authentication_error","message":"OAuth access token is invalid."},"request_id":null}',
+      ),
+    ).toBe(true);
+  });
+
+  it("matches an Anthropic API-key rejection", () => {
+    expect(isProviderAuthRejection("invalid x-api-key")).toBe(true);
+  });
+
+  it("ignores failures that are not about credentials", () => {
+    // Misreading any of these as an auth failure would tell the user to
+    // reconnect a connection that is fine.
+    expect(isProviderAuthRejection("Rate limit exceeded (429)")).toBe(false);
+    expect(isProviderAuthRejection("Overloaded (529)")).toBe(false);
+    expect(
+      isProviderAuthRejection("AI_TypeValidationError: invalid_union"),
+    ).toBe(false);
+    expect(isProviderAuthRejection("Context limit approaching")).toBe(false);
+  });
+});
+
+describe("providerForModelId", () => {
+  it("attributes the model from the failing turn to Anthropic", () => {
+    expect(providerForModelId("claude-opus-5")).toBe("anthropic");
+  });
+
+  it("returns undefined rather than guessing for an unknown model", () => {
+    // An unattributed rejection must not tint an unrelated provider's card.
+    expect(providerForModelId("some-model-we-do-not-ship")).toBeUndefined();
+    expect(providerForModelId(undefined)).toBeUndefined();
+  });
+});
+
+describe("useProviderAuthStore", () => {
+  beforeEach(() => {
+    useProviderAuthStore.setState({ rejections: {} });
+  });
+
+  it("holds no rejection until one is observed", () => {
+    expect(
+      useProviderAuthStore.getState().rejections.anthropic,
+    ).toBeUndefined();
+  });
+
+  it("records a rejection against one provider only", () => {
+    useProviderAuthStore
+      .getState()
+      .recordRejection("anthropic", "Invalid API key.");
+
+    const { rejections } = useProviderAuthStore.getState();
+    expect(rejections.anthropic?.message).toBe("Invalid API key.");
+    expect(rejections.openai).toBeUndefined();
+  });
+
+  it("clears on remediation", () => {
+    const store = useProviderAuthStore.getState();
+    store.recordRejection("anthropic", "Invalid API key.");
+    store.clearRejection("anthropic");
+
+    expect(
+      useProviderAuthStore.getState().rejections.anthropic,
+    ).toBeUndefined();
+  });
+
+  it("keeps the same state object when clearing something not recorded", () => {
+    // Guards against a no-op clear (every successful turn calls it) forcing a
+    // re-render of the Settings card.
+    const before = useProviderAuthStore.getState().rejections;
+    useProviderAuthStore.getState().clearRejection("openai");
+
+    expect(useProviderAuthStore.getState().rejections).toBe(before);
+  });
+});

--- a/tests/provider-connection-state.test.ts
+++ b/tests/provider-connection-state.test.ts
@@ -5,7 +5,7 @@ import {
   type ProviderConnectionInputs,
 } from "../ui/utils/providerConnectionState";
 import {
-  claudeCredentialsAreUsable,
+  claudeAccessTokenIsLive,
   parseClaudeCliCredentials,
 } from "../src/core/services/claudeCliCredentials";
 
@@ -125,15 +125,15 @@ describe("deriveProviderConnectionState", () => {
   });
 });
 
-describe("claudeCredentialsAreUsable", () => {
+describe("claudeAccessTokenIsLive", () => {
   const now = Date.UTC(2026, 8, 7);
   const hour = 3_600_000;
 
   it("accepts a live access token", () => {
     expect(
-      claudeCredentialsAreUsable(
+      claudeAccessTokenIsLive(
         { accessToken: "sk-ant-oat-live", expiresAt: now + hour },
-        now,
+        { now },
       ),
     ).toBe(true);
   });
@@ -142,46 +142,51 @@ describe("claudeCredentialsAreUsable", () => {
   // put the user back on the expired card they pressed Connect to escape.
   it("rejects an expired token with no refresh token", () => {
     expect(
-      claudeCredentialsAreUsable(
+      claudeAccessTokenIsLive(
         { accessToken: "sk-ant-oat-dead", expiresAt: now - hour },
-        now,
+        { now },
       ),
     ).toBe(false);
   });
 
   it("rejects an expired token whose refresh token echoes the access token", () => {
     expect(
-      claudeCredentialsAreUsable(
+      claudeAccessTokenIsLive(
         {
           accessToken: "sk-ant-oat-dead",
           refreshToken: "sk-ant-oat-dead",
           expiresAt: now - hour,
         },
-        now,
+        { now },
       ),
     ).toBe(false);
   });
 
-  it("accepts an expired token that can be refreshed", () => {
+  it("rejects an expired token even when it carries a real refresh token", () => {
+    // This case previously returned true, on the theory that a refresh token
+    // makes an expired credential recoverable. That is an assumption, and
+    // acting on it is what let a five-month-dead credential be adopted as if
+    // it worked. Callers that can accept a renewable credential now run the
+    // refresh and check the result instead of predicting it.
     expect(
-      claudeCredentialsAreUsable(
+      claudeAccessTokenIsLive(
         {
           accessToken: "sk-ant-oat-dead",
           refreshToken: "sk-ant-ort-real",
           expiresAt: now - hour,
         },
-        now,
+        { now },
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("accepts credentials with no stated expiry", () => {
     expect(
-      claudeCredentialsAreUsable({ accessToken: "sk-ant-oat-pasted" }, now),
+      claudeAccessTokenIsLive({ accessToken: "sk-ant-oat-pasted" }, { now }),
     ).toBe(true);
   });
 
-  it("rejects a real Claude Code blob once expired and unrenewable", () => {
+  it("rejects a real Claude Code blob once expired", () => {
     const parsed = parseClaudeCliCredentials(
       JSON.stringify({
         claudeAiOauth: {
@@ -193,6 +198,6 @@ describe("claudeCredentialsAreUsable", () => {
     );
 
     expect(parsed).not.toBeNull();
-    expect(claudeCredentialsAreUsable(parsed!, now)).toBe(false);
+    expect(claudeAccessTokenIsLive(parsed!, { now })).toBe(false);
   });
 });

--- a/tests/provider-connection-state.test.ts
+++ b/tests/provider-connection-state.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveProviderConnectionState,
+  isHealthyConnection,
+  type ProviderConnectionInputs,
+} from "../ui/utils/providerConnectionState";
+import {
+  claudeCredentialsAreUsable,
+  parseClaudeCliCredentials,
+} from "../src/core/services/claudeCliCredentials";
+
+const base: ProviderConnectionInputs = {
+  mode: "oauth",
+  platformApiKeyConfigured: false,
+  status: { connected: true },
+  authRejected: false,
+};
+
+describe("deriveProviderConnectionState", () => {
+  it("reports a live token as connected", () => {
+    expect(deriveProviderConnectionState(base)).toEqual({ kind: "connected" });
+  });
+
+  it("reports no token as disconnected", () => {
+    expect(
+      deriveProviderConnectionState({
+        ...base,
+        status: { connected: false },
+      }),
+    ).toEqual({ kind: "disconnected" });
+  });
+
+  // The reported bug: card read "Connected" in green while every request was
+  // being refused, with the only contrary signal a small "Token: Expired".
+  it("does not report an expired unrenewable token as connected", () => {
+    const state = deriveProviderConnectionState({
+      ...base,
+      status: { connected: true, isExpired: true, canRenew: false },
+    });
+
+    expect(state).toEqual({
+      kind: "needs_signin",
+      reason: "expired",
+      fallsBackToApiKey: false,
+    });
+    expect(isHealthyConnection(state)).toBe(false);
+  });
+
+  it("leaves an expired but renewable token alone, since it self-heals", () => {
+    const state = deriveProviderConnectionState({
+      ...base,
+      status: { connected: true, isExpired: true, canRenew: true },
+    });
+
+    expect(state).toEqual({ kind: "connected" });
+    expect(isHealthyConnection(state)).toBe(true);
+  });
+
+  it("flags the silent fallback when a platform key will serve requests", () => {
+    expect(
+      deriveProviderConnectionState({
+        ...base,
+        platformApiKeyConfigured: true,
+        status: { connected: true, isExpired: true, canRenew: false },
+      }),
+    ).toEqual({
+      kind: "needs_signin",
+      reason: "expired",
+      fallsBackToApiKey: true,
+    });
+  });
+
+  it("treats an observed rejection as needing sign-in even when unexpired", () => {
+    expect(
+      deriveProviderConnectionState({
+        ...base,
+        status: { connected: true, isExpired: false, canRenew: true },
+        authRejected: true,
+      }),
+    ).toEqual({
+      kind: "needs_signin",
+      reason: "rejected",
+      fallsBackToApiKey: false,
+    });
+  });
+
+  it("prefers the observed rejection over the derived expiry", () => {
+    const state = deriveProviderConnectionState({
+      ...base,
+      status: { connected: true, isExpired: true, canRenew: false },
+      authRejected: true,
+    });
+
+    expect(state).toMatchObject({ reason: "rejected" });
+  });
+
+  it("ignores OAuth state entirely in API key mode", () => {
+    // Otherwise switching to API key looks like it did not apply, because the
+    // OAuth badge keeps reporting the token it is no longer using.
+    expect(
+      deriveProviderConnectionState({
+        mode: "apiKey",
+        platformApiKeyConfigured: true,
+        status: { connected: true, isExpired: true, canRenew: false },
+        authRejected: true,
+      }),
+    ).toEqual({ kind: "api_key_mode", configured: true });
+  });
+
+  it("does not call API key mode healthy without a key", () => {
+    expect(
+      isHealthyConnection({ kind: "api_key_mode", configured: false }),
+    ).toBe(false);
+  });
+
+  it("treats an unknown expiry as connected rather than alarming", () => {
+    // A pasted setup token carries no expiry; guessing "broken" would send
+    // users to reconnect a credential that works.
+    expect(
+      deriveProviderConnectionState({
+        ...base,
+        status: { connected: true },
+      }),
+    ).toEqual({ kind: "connected" });
+  });
+});
+
+describe("claudeCredentialsAreUsable", () => {
+  const now = Date.UTC(2026, 8, 7);
+  const hour = 3_600_000;
+
+  it("accepts a live access token", () => {
+    expect(
+      claudeCredentialsAreUsable(
+        { accessToken: "sk-ant-oat-live", expiresAt: now + hour },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  // The reported bug: Connect found this, adopted it, reported success, and
+  // put the user back on the expired card they pressed Connect to escape.
+  it("rejects an expired token with no refresh token", () => {
+    expect(
+      claudeCredentialsAreUsable(
+        { accessToken: "sk-ant-oat-dead", expiresAt: now - hour },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects an expired token whose refresh token echoes the access token", () => {
+    expect(
+      claudeCredentialsAreUsable(
+        {
+          accessToken: "sk-ant-oat-dead",
+          refreshToken: "sk-ant-oat-dead",
+          expiresAt: now - hour,
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts an expired token that can be refreshed", () => {
+    expect(
+      claudeCredentialsAreUsable(
+        {
+          accessToken: "sk-ant-oat-dead",
+          refreshToken: "sk-ant-ort-real",
+          expiresAt: now - hour,
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts credentials with no stated expiry", () => {
+    expect(
+      claudeCredentialsAreUsable({ accessToken: "sk-ant-oat-pasted" }, now),
+    ).toBe(true);
+  });
+
+  it("rejects a real Claude Code blob once expired and unrenewable", () => {
+    const parsed = parseClaudeCliCredentials(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "sk-ant-oat01-abc",
+          refreshToken: "sk-ant-oat01-abc",
+          expiresAt: now - hour,
+        },
+      }),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(claudeCredentialsAreUsable(parsed!, now)).toBe(false);
+  });
+});

--- a/tests/provider-error-message.test.ts
+++ b/tests/provider-error-message.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Recovering the provider's message instead of reporting a bare status.
+ *
+ * The fixtures here are the real shapes taken from a captured failure: an
+ * Anthropic spend cap arriving as `400 invalid_request_error` with an empty
+ * `message` and the whole explanation sitting in `responseBody`/`data`.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  describeUsageLimitError,
+  extractProviderErrorPayload,
+  formatProviderErrorPayload,
+  isNoOutputGeneratedError,
+  isUsageLimitError,
+  providerFromRequestUrl,
+} from "../src/gateway/services/agent/providerErrorMessage.js";
+
+const LIMIT_MESSAGE =
+  "You have reached your specified API usage limits. You will regain access on 2026-10-01 at 00:00 UTC.";
+
+/** The captured error, verbatim in shape: empty message, populated body. */
+function anthropicLimitError(): Record<string, unknown> {
+  return {
+    name: "AI_APICallError",
+    message: "",
+    statusCode: 400,
+    url: "https://api.anthropic.com/v1/messages",
+    responseBody: JSON.stringify({
+      type: "error",
+      error: { type: "invalid_request_error", message: LIMIT_MESSAGE },
+      request_id: "req_011CepmdjULh5K27wfxC8u1j",
+    }),
+    data: {
+      type: "error",
+      error: { type: "invalid_request_error", message: LIMIT_MESSAGE },
+    },
+    isRetryable: false,
+  };
+}
+
+describe("extractProviderErrorPayload", () => {
+  it("recovers the message the SDK left empty", () => {
+    const payload = extractProviderErrorPayload(anthropicLimitError());
+    expect(payload).toEqual({
+      type: "invalid_request_error",
+      message: LIMIT_MESSAGE,
+    });
+  });
+
+  it("reads responseBody when data is absent", () => {
+    const error = anthropicLimitError();
+    delete error.data;
+    expect(extractProviderErrorPayload(error)?.message).toBe(LIMIT_MESSAGE);
+  });
+
+  it("reads data when responseBody is absent", () => {
+    const error = anthropicLimitError();
+    delete error.responseBody;
+    expect(extractProviderErrorPayload(error)?.message).toBe(LIMIT_MESSAGE);
+  });
+
+  it("returns undefined rather than throwing on a non-JSON body", () => {
+    expect(
+      extractProviderErrorPayload({ responseBody: "<html>nope</html>" }),
+    ).toBeUndefined();
+  });
+
+  it("treats a blank provider message as absent", () => {
+    // An empty string is not something worth showing a user, and letting it
+    // through is how "API error (400): " happened in the first place.
+    expect(
+      extractProviderErrorPayload({
+        responseBody: JSON.stringify({ error: { message: "   " } }),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("ignores shapes with no error member", () => {
+    expect(extractProviderErrorPayload({ responseBody: "{}" })).toBeUndefined();
+    expect(extractProviderErrorPayload(null)).toBeUndefined();
+    expect(extractProviderErrorPayload("a string")).toBeUndefined();
+  });
+});
+
+describe("isUsageLimitError", () => {
+  it("recognises an exhausted usage limit", () => {
+    expect(isUsageLimitError({ message: LIMIT_MESSAGE })).toBe(true);
+  });
+
+  it("recognises the other ways providers word a cap", () => {
+    expect(isUsageLimitError({ message: "Spend limit reached" })).toBe(true);
+    expect(isUsageLimitError({ message: "Monthly spending limit hit" })).toBe(
+      true,
+    );
+    expect(isUsageLimitError({ message: "Quota exceeded for this model" })).toBe(
+      true,
+    );
+  });
+
+  it("leaves a low credit balance to the existing 402 message", () => {
+    // Adding credits and raising a cap are different actions, so this must not
+    // be swallowed by the cap branch.
+    expect(
+      isUsageLimitError({ message: "Your credit balance is too low" }),
+    ).toBe(false);
+  });
+
+  it("does not fire on unrelated failures", () => {
+    expect(isUsageLimitError({ message: "Overloaded" })).toBe(false);
+    expect(isUsageLimitError({ message: "invalid x-api-key" })).toBe(false);
+    expect(isUsageLimitError({})).toBe(false);
+  });
+});
+
+describe("describeUsageLimitError", () => {
+  it("says what happened, when it lifts, and where to fix it", () => {
+    const described = describeUsageLimitError(
+      { type: "invalid_request_error", message: LIMIT_MESSAGE },
+      "anthropic",
+    );
+
+    expect(described).toContain("reached your API usage limit");
+    expect(described).toContain("2026-10-01 at 00:00 UTC");
+    expect(described).toContain("console.anthropic.com/settings/limits");
+    // Something the user can do right now, without leaving the app.
+    expect(described).toContain("switch to a different model");
+  });
+
+  it("still explains itself for a provider we cannot link", () => {
+    const described = describeUsageLimitError(
+      { message: "Quota exceeded" },
+      undefined,
+    );
+    expect(described).toContain("reached your API usage limit");
+    expect(described).not.toContain("http");
+  });
+
+  it("omits the date when the provider did not give one", () => {
+    const described = describeUsageLimitError(
+      { message: "Usage limit reached." },
+      "anthropic",
+    );
+    expect(described).not.toContain("Access returns on");
+  });
+
+  it("returns null for anything that is not a limit", () => {
+    expect(describeUsageLimitError({ message: "Overloaded" })).toBeNull();
+  });
+});
+
+describe("providerFromRequestUrl", () => {
+  it("identifies providers from the URL the request went to", () => {
+    expect(providerFromRequestUrl("https://api.anthropic.com/v1/messages")).toBe(
+      "anthropic",
+    );
+    expect(
+      providerFromRequestUrl("https://api.openai.com/v1/responses"),
+    ).toBe("openai");
+    expect(
+      providerFromRequestUrl(
+        "https://generativelanguage.googleapis.com/v1beta/models",
+      ),
+    ).toBe("google");
+  });
+
+  it("returns undefined for an unknown or missing host", () => {
+    expect(providerFromRequestUrl("http://localhost:11434/api")).toBeUndefined();
+    expect(providerFromRequestUrl(undefined)).toBeUndefined();
+  });
+});
+
+describe("formatProviderErrorPayload", () => {
+  it("includes the status when there is one", () => {
+    expect(formatProviderErrorPayload({ message: "Bad thing" }, 400)).toBe(
+      "API error (400): Bad thing",
+    );
+  });
+
+  it("omits the status when there is none", () => {
+    expect(formatProviderErrorPayload({ message: "Bad thing" })).toBe(
+      "API error: Bad thing",
+    );
+  });
+
+  it("produces nothing without a message, rather than a dangling colon", () => {
+    expect(
+      formatProviderErrorPayload({ type: "invalid_request_error" }, 400),
+    ).toBeUndefined();
+  });
+});
+
+describe("isNoOutputGeneratedError", () => {
+  it("recognises the SDK error by name across realms", () => {
+    // Matched by name rather than instanceof/Symbol because the error crosses
+    // a module realm before we see it.
+    expect(isNoOutputGeneratedError({ name: "AI_NoOutputGeneratedError" })).toBe(
+      true,
+    );
+    expect(isNoOutputGeneratedError({ name: "NoOutputGeneratedError" })).toBe(
+      true,
+    );
+  });
+
+  it("recognises it by message when the name is stripped", () => {
+    expect(
+      isNoOutputGeneratedError(
+        new Error("No output generated. Check the stream for errors."),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not swallow a real error", () => {
+    expect(isNoOutputGeneratedError(new Error(LIMIT_MESSAGE))).toBe(false);
+    expect(isNoOutputGeneratedError(new Error("fetch failed"))).toBe(false);
+    expect(isNoOutputGeneratedError(null)).toBe(false);
+  });
+});

--- a/tests/provider-quota-exhaustion.test.ts
+++ b/tests/provider-quota-exhaustion.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  PROVIDER_QUOTA_EXHAUSTED_ERROR_CODE,
+  createProviderQuotaExhaustedError,
+  createRateLimitExhaustedError,
+  describeQuotaExhaustion,
+  detectProviderQuotaExhaustion,
+  isProviderRateLimitError,
+  isRetryableProviderCapacityError,
+} from "../src/gateway/utils/providerRateLimitRetry.js";
+
+/**
+ * The reported failure. Anthropic returns this as HTTP 429 with
+ * `type: "rate_limit_error"` — structurally identical to a per-minute burst
+ * limit — so only the sentence distinguishes "you are going too fast" from
+ * "your month is spent". The old code read the status and retried.
+ */
+const SPEND_CAP_ERROR = {
+  statusCode: 429,
+  responseBody: JSON.stringify({
+    type: "error",
+    error: {
+      type: "rate_limit_error",
+      message:
+        "You have reached your specified API usage limits. You will regain access on 2026-10-01 at 00:00 UTC.",
+    },
+  }),
+};
+
+/** An ordinary burst ceiling: clears by itself, so retrying is correct. */
+const PER_MINUTE_ERROR = {
+  statusCode: 429,
+  message:
+    "Number of request tokens has exceeded your per-minute rate limit. Please try again later.",
+};
+
+describe("detectProviderQuotaExhaustion", () => {
+  it("recognizes the reported spend cap and its reset date", () => {
+    const detail = detectProviderQuotaExhaustion(SPEND_CAP_ERROR);
+    expect(detail?.remedy).toBe("api_spend_cap");
+    expect(detail?.resetsAt?.toISOString()).toBe("2026-10-01T00:00:00.000Z");
+  });
+
+  it("keeps the provider's own sentence rather than paraphrasing it", () => {
+    const detail = detectProviderQuotaExhaustion(SPEND_CAP_ERROR);
+    expect(detail?.providerMessage).toContain(
+      "You will regain access on 2026-10-01",
+    );
+  });
+
+  it("recognizes a Claude subscription limit and its epoch reset", () => {
+    // Subscription limits arrive with the reset packed after a pipe.
+    const detail = detectProviderQuotaExhaustion({
+      message: "Claude AI usage limit reached|1790000000",
+    });
+    expect(detail?.remedy).toBe("subscription_quota");
+    expect(detail?.resetsAt?.toISOString()).toBe("2026-09-21T14:13:20.000Z");
+  });
+
+  it("recognizes an empty credit balance", () => {
+    const detail = detectProviderQuotaExhaustion({
+      message: "Your credit balance is too low to access the Anthropic API",
+    });
+    expect(detail?.remedy).toBe("api_credits");
+  });
+
+  it("leaves a per-minute limit alone so it still gets retried", () => {
+    // The asymmetry that matters: misreading this one would delete a retry
+    // that genuinely works.
+    expect(detectProviderQuotaExhaustion(PER_MINUTE_ERROR)).toBeNull();
+    expect(isRetryableProviderCapacityError(PER_MINUTE_ERROR)).toBe(true);
+  });
+
+  it("prefers transient when a payload carries both signals", () => {
+    expect(
+      detectProviderQuotaExhaustion({
+        message:
+          "usage limit reached: tokens per minute exceeded, please retry",
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores a plain 429 with nothing quota-shaped in it", () => {
+    expect(detectProviderQuotaExhaustion({ statusCode: 429 })).toBeNull();
+    expect(detectProviderQuotaExhaustion("Too Many Requests")).toBeNull();
+  });
+
+  it("does not read an unrelated timestamp as the reset time", () => {
+    // A date has to be anchored to a reset word. A confidently wrong reset time
+    // is worse than admitting we do not know.
+    const detail = detectProviderQuotaExhaustion({
+      message:
+        "credit balance is too low (account created 2020-03-04T00:00:00Z)",
+    });
+    expect(detail?.remedy).toBe("api_credits");
+    expect(detail?.resetsAt).toBeUndefined();
+  });
+});
+
+describe("isRetryableProviderCapacityError", () => {
+  it("stops treating spent allowance as capacity pressure", () => {
+    // It is still a rate-limit-shaped error; it is just not worth retrying.
+    expect(isProviderRateLimitError(SPEND_CAP_ERROR)).toBe(true);
+    expect(isRetryableProviderCapacityError(SPEND_CAP_ERROR)).toBe(false);
+  });
+
+  it("still retries overloaded servers", () => {
+    expect(
+      isRetryableProviderCapacityError({ message: "overloaded_error" }),
+    ).toBe(true);
+  });
+});
+
+describe("describeQuotaExhaustion", () => {
+  it("says waiting will not help, when it clears, and what to change", () => {
+    const message = describeQuotaExhaustion(
+      detectProviderQuotaExhaustion(SPEND_CAP_ERROR)!,
+    );
+    expect(message).toContain("retrying won't help");
+    expect(message).toContain("Oct 1, 2026");
+    expect(message).toContain("console");
+    expect(message).toContain("You will regain access on 2026-10-01");
+  });
+
+  it("omits the timing sentence when the provider gave no reset", () => {
+    const message = describeQuotaExhaustion({ remedy: "api_credits" });
+    expect(message).not.toContain("Access returns");
+    expect(message).toContain("credit balance is empty");
+  });
+
+  it("points a subscription limit at model choice, not at billing", () => {
+    const message = describeQuotaExhaustion({ remedy: "subscription_quota" });
+    expect(message).toContain("subscription's usage limit");
+    expect(message).toContain("model that still has quota");
+  });
+});
+
+describe("error payloads", () => {
+  it("tags a quota refusal with its own code so Resume can be withheld", () => {
+    const error = createProviderQuotaExhaustedError({
+      remedy: "api_spend_cap",
+      resetsAt: new Date("2026-10-01T00:00:00Z"),
+    });
+    expect(error.code).toBe(PROVIDER_QUOTA_EXHAUSTED_ERROR_CODE);
+    expect(error.code).not.toBe("rate_limit_exhausted");
+  });
+
+  it("still offers Resume for a transient limit, now quoting the provider", () => {
+    const error = createRateLimitExhaustedError(PER_MINUTE_ERROR);
+    expect(error.code).toBe("rate_limit_exhausted");
+    expect(error.message).toContain("Tap Resume");
+    expect(error.message).toContain("per-minute rate limit");
+  });
+
+  it("keeps the bare Resume message when there is no useful sentence", () => {
+    const error = createRateLimitExhaustedError({ statusCode: 429 });
+    expect(error.message).toBe(
+      "The AI provider is rate limited. Tap Resume when ready to continue.",
+    );
+  });
+});

--- a/tests/render-loop-invariants.test.ts
+++ b/tests/render-loop-invariants.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression guards for the "Maximum update depth exceeded" loop in the chat pane.
+ *
+ * The loop needed two ingredients, and each on its own was survivable:
+ *
+ *  1. `useModelPickerSettings` built `pickerModels` inline in its return, so
+ *     the array had a new identity on every render. Every ChatContainer effect
+ *     depending on it therefore re-ran on every render.
+ *  2. That effect then called `setModelSettings` with a freshly-read object.
+ *     Fresh reference means React never bails out, so the state "changed",
+ *     which re-rendered, which re-ran the effect.
+ *
+ * Ingredient 1 alone was harmless for exactly as long as every effect
+ * depending on it happened to bail out — far too sharp an edge to leave in
+ * place, so both are guarded here.
+ *
+ * These are static invariant tests: the failure is a React render cycle, which
+ * a unit test cannot reproduce without mounting the real tree, but the two
+ * code-level properties that make it impossible are cheap to assert.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(ROOT, relativePath), "utf-8");
+}
+
+describe("useModelPickerSettings — stable effect dependencies", () => {
+  it("memoises pickerModels rather than rebuilding it every render", () => {
+    const content = read("ui/hooks/useModelPickerSettings.ts");
+
+    expect(content).toMatch(
+      /useMemo\(\s*\(\)\s*=>\s*getPickerModels\(enabledIds\),\s*\[enabledIds\]\s*\)/,
+    );
+    // The inline form is what made the array unstable.
+    expect(content).not.toMatch(/pickerModels:\s*getPickerModels\(/);
+  });
+
+  it("imports useMemo, so the guard above cannot be satisfied vacuously", () => {
+    const content = read("ui/hooks/useModelPickerSettings.ts");
+    expect(content).toMatch(/import \{[^}]*useMemo[^}]*\} from "react"/);
+  });
+});
+
+describe("ChatContainer — model settings state cannot self-trigger", () => {
+  it("sets model settings through a bail-out updater, not a bare fresh object", () => {
+    const content = read("ui/components/Chat/ChatContainer.tsx");
+
+    // A functional updater returning `prev` lets React skip the re-render when
+    // nothing actually changed. The local's name is incidental, so it is
+    // captured rather than spelled out — what matters is that the same value
+    // is compared and then returned.
+    expect(content).toMatch(
+      /setModelSettings\(\s*\(prev\)\s*=>\s*\(?\s*sameSettings\(prev,\s*(\w+)\)\s*\?\s*prev\s*:\s*\1\s*\)?\s*,?\s*\)/,
+    );
+  });
+
+  it("does not set model settings from a freshly-read object directly", () => {
+    const content = read("ui/components/Chat/ChatContainer.tsx");
+
+    // These are the shapes that never bail out, because every read builds a
+    // new object.
+    expect(content).not.toMatch(/setModelSettings\(\s*readChatSettings\(/);
+    expect(content).not.toMatch(
+      /setModelSettings\(\s*readNewChatDefaultSettings\(/,
+    );
+  });
+});
+
+describe("panes are wrapped in an error boundary", () => {
+  it("contains a render throw to the tab it happened in", () => {
+    const content = read("ui/components/Layout/ContentArea.tsx");
+
+    // Without this, React's only recourse for a throw in one pane is to
+    // unmount the whole tree — which reads as the entire app reloading and
+    // takes every other tab with it.
+    expect(content).toContain("PaneErrorBoundary");
+    expect(content).toMatch(
+      /<PaneErrorBoundary paneKey=\{tabId \?\? "unknown"\}>/,
+    );
+  });
+
+  it("wraps every tab type, not just chat", () => {
+    const content = read("ui/components/Layout/ContentArea.tsx");
+
+    // The boundary sits around the result of the type switch rather than
+    // around individual views, so a new tab type is covered by default.
+    const renderView = content.slice(
+      content.indexOf("const renderView = ("),
+      content.indexOf("const renderViewForTab = ("),
+    );
+    expect(renderView).toContain("PaneErrorBoundary");
+    expect(renderView).toContain("renderViewForTab(tabId, skipAgents)");
+  });
+});
+
+describe("drafts are persisted outside React", () => {
+  it("the store writes drafts through the durable copy", () => {
+    const content = read("ui/stores/chatStore.ts");
+
+    expect(content).toMatch(/writeDraft\(chatId, draft\)/);
+    // Reads must fall back to storage, or a draft is lost whenever the
+    // in-memory map is emptied (crash, reload, workspace switch).
+    expect(content).toMatch(/return readDraft\(chatId\)/);
+    expect(content).toMatch(/forgetDraft\(chatId\)/);
+    // The temp -> permanent rename must carry the draft with it.
+    expect(content).toMatch(/renameDraft\(oldChatId, newChatId\)/);
+  });
+
+  it("the draft store does not depend on React", () => {
+    const content = read("ui/utils/chatDraftStore.ts");
+
+    // It has to keep working while the tree above it has thrown.
+    expect(content).not.toMatch(/from "react"/);
+    expect(content).not.toMatch(/useChatStore/);
+  });
+
+  it("the composer seeds from the store getter, not the raw map", () => {
+    const content = read("ui/components/Chat/InputBar.tsx");
+
+    // Reading the map directly paints an empty composer over a draft that
+    // still exists in storage.
+    expect(content).toMatch(
+      /useChatStore\.getState\(\)\.getDraftMessage\(chatId\)/,
+    );
+    expect(content).not.toMatch(/useState\(\s*draftMessage\s*\)/);
+  });
+
+  it("the composer flushes the debounce window on unmount and pagehide", () => {
+    const content = read("ui/components/Chat/InputBar.tsx");
+
+    // The 300ms debounce is exactly the window a crash lands in.
+    expect(content).toMatch(/addEventListener\("pagehide", flush\)/);
+    expect(content).toMatch(/removeEventListener\("pagehide", flush\)/);
+  });
+});

--- a/tests/replica-busy-retry.test.ts
+++ b/tests/replica-busy-retry.test.ts
@@ -1,0 +1,149 @@
+/**
+ * A lock is contention, not damage.
+ *
+ * The replica engine sets no `busy_timeout`, so a read that lands while a push
+ * or a migration holds the file used to fail on its first attempt and hand the
+ * raw "database is locked" to the mini-app UI. These tests pin the two rules
+ * that fix makes: a lock is retried, and it is *only* retried — it must never
+ * reach the wedge-recovery branch, which resets the sync sidecars.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  isReplicaBusyError,
+  isSqliteBusyError,
+} from "../src/gateway/services/tursoReplica/tursoReplicaErrors";
+import {
+  isReplicaReadTransportError,
+  isReplicaSqlSchemaError,
+} from "../src/gateway/services/tursoReplica/tursoReplicaCheckpointRecovery";
+import {
+  retryWhileReplicaBusy,
+  BUSY_RETRY_ATTEMPTS,
+} from "../src/gateway/services/tursoReplica/replicaBusyRetry";
+
+describe("isReplicaBusyError", () => {
+  it("matches the engine's bare lock message", () => {
+    // `@tursodatabase/sync` reports this with no error code attached.
+    expect(isReplicaBusyError(new Error("database is locked"))).toBe(true);
+  });
+
+  it("matches the table-level variant and the code spelling", () => {
+    expect(isReplicaBusyError(new Error("database table is locked"))).toBe(
+      true,
+    );
+    expect(isReplicaBusyError(new Error("SQLITE_BUSY: busy"))).toBe(true);
+  });
+
+  it("matches regardless of surrounding text or case", () => {
+    expect(
+      isReplicaBusyError(
+        new Error("Turso replica query failed: Database Is Locked"),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts non-Error throwables", () => {
+    expect(isReplicaBusyError("database is locked")).toBe(true);
+  });
+
+  it("does not match unrelated failures", () => {
+    expect(isReplicaBusyError(new Error("no such table: briefs"))).toBe(false);
+    expect(isReplicaBusyError(new Error("timed out after 30000ms"))).toBe(
+      false,
+    );
+    expect(isReplicaBusyError(null)).toBe(false);
+    expect(isReplicaBusyError(undefined)).toBe(false);
+  });
+});
+
+describe("busy and wedge classifiers stay disjoint", () => {
+  // This is the whole reason the lock check is a separate predicate rather than
+  // another clause in `isReplicaReadTransportError`. That classifier's recovery
+  // path calls `recoverReadWedge`, which closes the handle and resets sidecars.
+  // Doing that because another operation briefly held the lock would be
+  // destructive, so a lock must not be classified as a transport wedge.
+  it("does not route a lock into sidecar-resetting wedge recovery", () => {
+    expect(isReplicaReadTransportError("database is locked")).toBe(false);
+  });
+
+  it("still routes genuine wedges into recovery", () => {
+    expect(
+      isReplicaReadTransportError("unable to checkpoint synced portion of WAL"),
+    ).toBe(true);
+    expect(isReplicaReadTransportError("REPLICA_GEN_DRIFT")).toBe(true);
+  });
+
+  it("keeps a lock distinct from a SQL/schema error", () => {
+    // A schema error is permanent; retrying it only delays the real report.
+    expect(isReplicaSqlSchemaError("database is locked")).toBe(false);
+    expect(isReplicaBusyError(new Error("no such column: brief_json"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("isSqliteBusyError", () => {
+  it("matches the better-sqlite3 shape, which carries a code", () => {
+    const err = Object.assign(new Error("SQLITE_BUSY"), {
+      code: "SQLITE_BUSY",
+    });
+    expect(isSqliteBusyError(err)).toBe(true);
+  });
+
+  it("matches the engine shape, which carries no code", () => {
+    // The regression: checking only `code` meant every "DB busy, defer" branch
+    // silently never fired for replica-backed databases.
+    expect(isSqliteBusyError(new Error("database is locked"))).toBe(true);
+  });
+
+  it("does not match unrelated coded errors", () => {
+    const err = Object.assign(new Error("file is not a database"), {
+      code: "SQLITE_NOTADB",
+    });
+    expect(isSqliteBusyError(err)).toBe(false);
+  });
+});
+
+describe("retryWhileReplicaBusy", () => {
+  it("returns the first result when nothing is locked", async () => {
+    const fn = vi.fn().mockResolvedValue("rows");
+
+    await expect(retryWhileReplicaBusy(fn, "read")).resolves.toBe("rows");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits out a transient lock and succeeds", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("database is locked"))
+      .mockResolvedValue("rows");
+
+    await expect(retryWhileReplicaBusy(fn, "read")).resolves.toBe("rows");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a non-lock failure", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("no such table: briefs"));
+
+    await expect(retryWhileReplicaBusy(fn, "read")).rejects.toThrow(
+      "no such table: briefs",
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows the lock once the budget is spent, rather than masking it", async () => {
+    // Giving up must surface the real error: the caller's own recovery and the
+    // logs both depend on seeing the lock.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fn = vi.fn().mockRejectedValue(new Error("database is locked"));
+
+    await expect(retryWhileReplicaBusy(fn, "read briefs")).rejects.toThrow(
+      "database is locked",
+    );
+    expect(fn).toHaveBeenCalledTimes(BUSY_RETRY_ATTEMPTS);
+    expect(warn).toHaveBeenCalled();
+
+    warn.mockRestore();
+  }, 10_000);
+});

--- a/tests/retired-cutover-blocks.test.ts
+++ b/tests/retired-cutover-blocks.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { isRetiredCutoverBlockReason } from "../src/gateway/services/tursoReplica/cutover/retiredCutoverBlocks.js";
+
+describe("isRetiredCutoverBlockReason", () => {
+  it("retires a block citing a synthetic drift-heal id", () => {
+    // The exact string found in a real registry, where it had pinned the
+    // database to the legacy sync path since Sep 3.
+    expect(
+      isRetiredCutoverBlockReason(
+        "Migration SQL missing for __schema_drift_heal___1788489428341",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps a genuine missing migration blocked", () => {
+    // Here the SQL really is needed and really is gone, so the block is a live
+    // verdict, not a fossil. Retiring it would let cutover proceed against a
+    // remote that never received the migration.
+    expect(
+      isRetiredCutoverBlockReason("Migration SQL missing for 0002_feed_schema"),
+    ).toBe(false);
+  });
+
+  it("does not retire unrelated block reasons", () => {
+    for (const reason of [
+      "Database quarantined — repair required",
+      "Migration ledger conflict — repair required",
+      "Schema drift — Turso primary is ahead of local migration ledger",
+      "Could not verify Turso remote state while local data exists",
+      "database is locked",
+    ]) {
+      expect(isRetiredCutoverBlockReason(reason)).toBe(false);
+    }
+  });
+
+  it("treats an absent or empty reason as not retired", () => {
+    // A block with no recorded reason gives no evidence its cause is gone, so
+    // the conservative answer is to leave it blocked.
+    expect(isRetiredCutoverBlockReason(undefined)).toBe(false);
+    expect(isRetiredCutoverBlockReason("")).toBe(false);
+  });
+
+  it("requires the drift-heal prefix on the id, not merely in the text", () => {
+    // Guards against a substring match: the prefix has to start the migration
+    // id, otherwise a real migration whose name mentions the heal would be
+    // silently unblocked.
+    expect(
+      isRetiredCutoverBlockReason(
+        "Migration SQL missing for 0003_after___schema_drift_heal__cleanup",
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores a drift-heal id in a reason that is not a missing-SQL failure", () => {
+    // Only the missing-SQL throw was made impossible. Any other failure
+    // mentioning the same id is still a live block.
+    expect(
+      isRetiredCutoverBlockReason(
+        "Remote rejected __schema_drift_heal___1788489428341",
+      ),
+    ).toBe(false);
+  });
+});

--- a/tests/turso-sync-bridge.test.ts
+++ b/tests/turso-sync-bridge.test.ts
@@ -209,9 +209,22 @@ describe("tursoSyncBridgeCore", () => {
     },
   );
 
-  it("isSqliteBusyError detects SQLITE_BUSY", () => {
+  it("isSqliteBusyError detects a lock from either engine", () => {
+    // This assertion used to require `false` for the message-only form. That
+    // pinned the implementation rather than a requirement, and it was wrong:
+    // two engines touch these files and only one of them sets a code.
+    // better-sqlite3 raises `code: "SQLITE_BUSY"`; `@tursodatabase/sync`
+    // surfaces a bare "database is locked". Every caller uses this predicate to
+    // decide "defer and try again later", so not recognising the engine's form
+    // turned a wait into a hard failure for replica-backed databases — while
+    // the sibling copy of this function in registryDbSchemaReader.ts had always
+    // matched the message. One definition now, and it matches both.
     expect(isSqliteBusyError({ code: "SQLITE_BUSY" })).toBe(true);
-    expect(isSqliteBusyError(new Error("database is locked"))).toBe(false);
+    expect(isSqliteBusyError(new Error("database is locked"))).toBe(true);
+
+    // Still narrow enough to leave unrelated failures alone.
+    expect(isSqliteBusyError(new Error("no such table: briefs"))).toBe(false);
+    expect(isSqliteBusyError({ code: "SQLITE_NOTADB" })).toBe(false);
   });
 
   it("pushLocalDbToTurso skips missing database", async () => {

--- a/tests/wiki-related-memories.test.ts
+++ b/tests/wiki-related-memories.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Related memories must carry one entry per id.
+ *
+ * The UI keys this list by id and looks up the open memory with a find-by-id,
+ * so a repeated id both breaks React reconciliation and makes "which one is
+ * open" ambiguous. Search returns a memory once per matching chunk, so the
+ * duplication is expected upstream and has to be collapsed here.
+ */
+
+import { describe, it, expect } from "vitest";
+import { toRelatedMemories } from "../src/gateway/services/KnowledgeGraphWikiService";
+
+const hit = (id: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  content: `content for ${id}`,
+  category: "fact",
+  source: "chat",
+  created_at: "2026-09-07T00:00:00Z",
+  chat_id: "chat-1",
+  ...extra,
+});
+
+describe("toRelatedMemories", () => {
+  it("collapses repeated ids to a single entry", () => {
+    const result = toRelatedMemories([hit("a"), hit("a"), hit("b")]);
+
+    expect(result.map((m) => m.id)).toEqual(["a", "b"]);
+  });
+
+  it("yields ids that are unique, which is what the React key requires", () => {
+    const result = toRelatedMemories([
+      hit("a"),
+      hit("b"),
+      hit("a"),
+      hit("c"),
+      hit("b"),
+    ]);
+
+    expect(new Set(result.map((m) => m.id)).size).toBe(result.length);
+  });
+
+  it("keeps the first hit for an id, so the strongest match wins", () => {
+    // Search returns hits strongest-first; a later chunk of the same memory
+    // must not overwrite the content that ranked highest.
+    const result = toRelatedMemories([
+      hit("a", { content: "strongest match" }),
+      hit("a", { content: "weaker chunk" }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("strongest match");
+  });
+
+  it("preserves search order for distinct ids", () => {
+    const result = toRelatedMemories([hit("c"), hit("a"), hit("b")]);
+
+    expect(result.map((m) => m.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("drops hits with no id, since they cannot be keyed or looked up", () => {
+    const result = toRelatedMemories([hit("a"), hit(""), { content: "x" }]);
+
+    expect(result.map((m) => m.id)).toEqual(["a"]);
+  });
+
+  it("drops hits with no content, which would render an empty card", () => {
+    const result = toRelatedMemories([
+      hit("a"),
+      { id: "b", content: "" },
+      { id: "c" },
+    ]);
+
+    expect(result.map((m) => m.id)).toEqual(["a"]);
+  });
+
+  it("coerces non-string fields rather than emitting undefined", () => {
+    // The payload is untyped, so a number where a string is expected must not
+    // reach the UI as a non-string.
+    const result = toRelatedMemories([
+      { id: 42, content: "body", category: 7, chat_id: null },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("42");
+    expect(result[0].category).toBe("7");
+    expect(result[0].chatId).toBe("");
+  });
+
+  it("returns an empty list for no hits", () => {
+    expect(toRelatedMemories([])).toEqual([]);
+  });
+});

--- a/ui/__tests__/hooks/useModelPickerSettings.test.tsx
+++ b/ui/__tests__/hooks/useModelPickerSettings.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * `pickerModels` must keep the same identity across renders.
+ *
+ * It is a dependency of effects in ChatContainer. When it was rebuilt inline
+ * on every render, those effects re-ran on every render — survivable only for
+ * as long as every one of them happened to bail out without setting state. One
+ * that did not (`setModelSettings`, fed a freshly-read object that never
+ * compares equal) turned that into "Maximum update depth exceeded" and took
+ * the whole app down with it, draft message included.
+ *
+ * This is the behavioural half of the guard; `tests/render-loop-invariants.ts`
+ * pins the shape of the code.
+ */
+
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const send = vi.fn();
+
+vi.mock("../../src/lib/gateway", () => ({
+  gateway: {
+    send: (...args: unknown[]) => send(...args),
+  },
+}));
+
+import { useModelPickerSettings } from "../../hooks/useModelPickerSettings";
+
+describe("useModelPickerSettings", () => {
+  beforeEach(() => {
+    send.mockReset();
+    // No stored preference: the hook falls back to curated defaults.
+    send.mockResolvedValue({ success: true, data: { uiPreferences: {} } });
+  });
+
+  it("returns the same pickerModels array across re-renders", async () => {
+    const { result, rerender } = renderHook(() => useModelPickerSettings());
+
+    // Let the initial settings load settle so identity is compared in the
+    // steady state the chat pane actually renders in.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const first = result.current.pickerModels;
+    rerender();
+    rerender();
+    rerender();
+
+    expect(result.current.pickerModels).toBe(first);
+  });
+
+  it("returns a non-empty model list", () => {
+    const { result } = renderHook(() => useModelPickerSettings());
+    expect(result.current.pickerModels.length).toBeGreaterThan(0);
+  });
+
+  it("gives a new array only when the enabled set actually changes", async () => {
+    const { result } = renderHook(() => useModelPickerSettings());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const before = result.current.pickerModels;
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("papr:picker-models-updated", {
+          detail: { enabledPickerModelIds: ["claude-sonnet-5"] },
+        }),
+      );
+    });
+
+    expect(result.current.pickerModels).not.toBe(before);
+    expect(result.current.pickerModels.map((m) => m.id)).toEqual([
+      "claude-sonnet-5",
+    ]);
+  });
+});

--- a/ui/components/Chat/ChatContainer.tsx
+++ b/ui/components/Chat/ChatContainer.tsx
@@ -42,6 +42,18 @@ import {
 } from "../../utils/resolveChatModel";
 import { extractFilesFromDataTransfer } from "../../utils/chatAttachmentFiles";
 import { shouldRehydrateAfterStoreWipe } from "../../utils/chatStateRecovery";
+import {
+  adoptEffortFromVariant,
+  readChatSettings,
+  readNewChatDefaultSettings,
+  writeChatSettings,
+  writeNewChatDefaultSettings,
+  type ChatModelSettings,
+} from "../../utils/chatModelSettings";
+import {
+  buildAgentConfig,
+  resolveModelSettings,
+} from "../../utils/buildAgentConfig";
 import "./ChatContainer.css";
 import { trackEvent } from "../../lib/telemetry";
 import { chatHasLiveStreamBlockingHistory, shouldAutoContinueInterruptedTurn, shouldDrainMessageQueue } from "../../lib/agentStreamRecovery";
@@ -176,6 +188,51 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
 
   const [selectedModel, setSelectedModel] = useState<AIModel>(fallbackModel);
   const [contextInfo, setContextInfo] = useState<ContextInfo | null>(null);
+
+  // Thinking / effort / context / fast for this chat. Stored sparsely, so a
+  // field the user never touched stays "unset" and follows the model.
+  const [modelSettings, setModelSettings] = useState<ChatModelSettings>({});
+
+  /** Effective dials for this chat, after dropping what the model can't honour. */
+  const resolvedModelSettings = useMemo(
+    () => resolveModelSettings(selectedModel, modelSettings),
+    [selectedModel, modelSettings],
+  );
+
+  /**
+   * Which credential this turn will actually run on. Only Anthropic needs it —
+   * Fast mode is an API-key-only parameter, and OAuth turns go through pi-ai,
+   * which has no `speed` field to carry it. The gateway prefers OAuth when both
+   * exist, so this mirrors that order rather than guessing.
+   */
+  const authType = useMemo<"oauth" | "apiKey" | undefined>(() => {
+    if (selectedModel.provider !== "anthropic") return undefined;
+    if (authStatus.anthropic.oauth) return "oauth";
+    if (authStatus.anthropic.apiKey) return "apiKey";
+    return undefined;
+  }, [selectedModel.provider, authStatus]);
+
+  const handleChangeModelSettings = useCallback(
+    (patch: ChatModelSettings) => {
+      const next = writeChatSettings(chatId, patch);
+      setModelSettings(next);
+      // Seed the next new chat, the same way the model picker does.
+      writeNewChatDefaultSettings(next);
+    },
+    [chatId],
+  );
+
+  /** One config shape for send, auto-continue and stream recovery alike. */
+  const makeAgentConfig = useCallback(
+    (systemPrompt: string) =>
+      buildAgentConfig({
+        model: selectedModel,
+        settings: modelSettings,
+        systemPrompt,
+        authType,
+      }),
+    [selectedModel, modelSettings, authType],
+  );
   const {
     message: gatewaySupervisorMessage,
     isReady: gatewaySupervisorReady,
@@ -265,14 +322,7 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
       ? `\n\n## Active Context\nThe user has merged this chat with a ${mergedArtifact.type} titled "${mergedArtifact.title}" (${idKey}: "${mergedArtifact.id}"). They are viewing and working on this ${mergedArtifact.type} alongside this conversation. Reference it directly when relevant.`
       : "";
 
-    const config = {
-      provider: selectedModel.provider,
-      model: selectedModel.id,
-      systemPrompt: DEFAULT_SYSTEM_PROMPT + mergedContext,
-      reasoning: selectedModel.reasoning,
-      thinkingBudget: selectedModel.defaultThinkingBudget,
-      maxTokens: selectedModel.maxTokens,
-    };
+    const config = makeAgentConfig(DEFAULT_SYSTEM_PROMPT + mergedContext);
 
     autoContinueInFlightRef.current = true;
     void autoContinueInterruptedTurn(chatId, config, messages).finally(() => {
@@ -287,7 +337,7 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
     isWaitingForAgentSlot,
     messages,
     needsStreamRecovery,
-    selectedModel,
+    makeAgentConfig,
   ]);
 
   const gatewayBanner =
@@ -323,7 +373,27 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
   // default (new chats only) > default order (sonnet-5 → gpt-5-6-sol →
   // gemini-3-flash) > first available
   useEffect(() => {
+    const store = useChatStore.getState();
+    const resolvedId = resolveChatModelId({
+      perChatModelId: store.getLastSelectedModel(chatId),
+      historyModelId,
+      newChatDefaultModelId: store.getDefaultModelForNewChat(),
+      hasHistory: chatHasHistory,
+    });
+
+    // A chat pinned to a retired effort variant keeps the effort that variant
+    // meant, rather than silently dropping to the base model's default.
+    adoptEffortFromVariant(chatId, resolvedId);
+
+    const stored = readChatSettings(chatId);
+    setModelSettings(
+      Object.keys(stored).length > 0 || chatHasHistory
+        ? stored
+        : readNewChatDefaultSettings(),
+    );
+
     setSelectedModel((prev) => {
+
       const store = useChatStore.getState();
       // Explicit per-chat pick always wins — do not downgrade to Sonnet just
       // because isModelAvailable flickered false (e.g. PAPR_API_KEY not in the
@@ -705,14 +775,9 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
 
       // Create config WITHOUT apiKey - Gateway will fetch it via IPC
       // This keeps keys secure and never sends them over WebSocket
-      const config = {
-        provider: selectedModel.provider,
-        model: selectedModel.id,
-        systemPrompt: DEFAULT_SYSTEM_PROMPT + mergedContext + artifactsContext,
-        reasoning: selectedModel.reasoning,
-        thinkingBudget: selectedModel.defaultThinkingBudget,
-        maxTokens: selectedModel.maxTokens, // Output token limit
-      };
+      const config = makeAgentConfig(
+        DEFAULT_SYSTEM_PROMPT + mergedContext + artifactsContext,
+      );
 
       useChatStore.getState().setLastSelectedModel(chatId, selectedModel.id);
 
@@ -731,7 +796,8 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
           : undefined,
       );
     },
-    [selectedModel, sendMessage, chatId, ensureModel, isModelAvailable, authStatus.paprProxy, setError],
+
+    [selectedModel, makeAgentConfig, sendMessage, chatId, ensureModel, isModelAvailable, authStatus.paprProxy, setError],
   );
 
   const stopAgentAndClearQueue = useCallback(async () => {
@@ -911,20 +977,13 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
         ? `\n\n## Active Context\nThe user has merged this chat with a ${mergedArtifact.type} titled "${mergedArtifact.title}" (${idKey}: "${mergedArtifact.id}"). They are viewing and working on this ${mergedArtifact.type} alongside this conversation. Reference it directly when relevant.`
         : "";
 
-      const config = {
-        provider: selectedModel.provider,
-        model: selectedModel.id,
-        systemPrompt: DEFAULT_SYSTEM_PROMPT + mergedContext,
-        reasoning: selectedModel.reasoning,
-        thinkingBudget: selectedModel.defaultThinkingBudget,
-        maxTokens: selectedModel.maxTokens,
-      };
+      const config = makeAgentConfig(DEFAULT_SYSTEM_PROMPT + mergedContext);
 
       await retryStreamRecovery(chatId, config);
     } finally {
       setIsResumingStream(false);
     }
-  }, [chatId, isResumingStream, retryStreamRecovery, selectedModel]);
+  }, [chatId, isResumingStream, retryStreamRecovery, makeAgentConfig]);
 
   const handleChatDrop = useCallback(
     (e: React.DragEvent<HTMLDivElement>) => {
@@ -1065,6 +1124,9 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
         onOpenSettings={handleOpenSettings}
         onOpenSettingsModels={handleOpenSettingsModels}
         pickerModels={pickerModels}
+        modelSettings={resolvedModelSettings}
+        onChangeModelSettings={handleChangeModelSettings}
+        authType={authType}
       />
 
       {contextInfo !== null ? (

--- a/ui/components/Chat/ChatContainer.tsx
+++ b/ui/components/Chat/ChatContainer.tsx
@@ -46,6 +46,7 @@ import {
   adoptEffortFromVariant,
   readChatSettings,
   readNewChatDefaultSettings,
+  sameSettings,
   writeChatSettings,
   writeNewChatDefaultSettings,
   type ChatModelSettings,
@@ -386,11 +387,15 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ chatId }): React.R
     adoptEffortFromVariant(chatId, resolvedId);
 
     const stored = readChatSettings(chatId);
-    setModelSettings(
+    const next =
       Object.keys(stored).length > 0 || chatHasHistory
         ? stored
-        : readNewChatDefaultSettings(),
-    );
+        : readNewChatDefaultSettings();
+    // Bail out when nothing actually changed. Each read builds a fresh object,
+    // so setting it unconditionally reports a state change on every run of this
+    // effect — and this effect re-runs whenever any dep gets a new identity,
+    // which is enough to loop.
+    setModelSettings((prev) => (sameSettings(prev, next) ? prev : next));
 
     setSelectedModel((prev) => {
 

--- a/ui/components/Chat/InputBar.tsx
+++ b/ui/components/Chat/InputBar.tsx
@@ -15,7 +15,9 @@ import {
 } from "react";
 import { CHAT_MODELS } from "../../constants/models";
 import type { AIModel } from "../../constants/models";
-import { ModelPickerDropdown } from "./ModelPickerDropdown";
+import { ModelSettingsButton } from "./ModelSettingsButton";
+import type { ChatModelSettings } from "../../utils/chatModelSettings";
+import type { ResolvedModelSettings } from "../../utils/buildAgentConfig";
 import { ChatMemoryScopeSelector } from "./ChatMemoryScopeSelector";
 import { ContextDropdown } from "./ContextDropdown";
 import { ContextPills } from "./ContextPills";
@@ -56,6 +58,11 @@ interface InputBarProps {
   onOpenSettingsModels?: () => void;
   /** Models pinned to the chat picker (from Settings) */
   pickerModels?: AIModel[];
+  /** Effective thinking/effort/context/fast for this chat and model. */
+  modelSettings: ResolvedModelSettings;
+  onChangeModelSettings: (patch: ChatModelSettings) => void;
+  /** Fast mode is API-key only — pi-ai carries no `speed` parameter. */
+  authType?: "oauth" | "apiKey";
   /** Fires after file context pills are added (e.g. drag-drop) so parent can clear drag-over UI */
   onFileAttachmentsAdded?: () => void;
 }
@@ -85,6 +92,9 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
       onOpenSettingsModels,
       onFileAttachmentsAdded,
       pickerModels,
+      modelSettings,
+      onChangeModelSettings,
+      authType,
     },
     ref,
   ) => {
@@ -100,8 +110,8 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
 
     const [message, setMessage] = useState(draftMessage);
     const [isFocused, setIsFocused] = useState(false);
-    const [showModelPicker, setShowModelPicker] = useState(false);
     const [showContextDropdown, setShowContextDropdown] = useState(false);
+    const [showModelSettings, setShowModelSettings] = useState(false);
     const [showSlashMenu, setShowSlashMenu] = useState(false);
     const [slashQuery, setSlashQuery] = useState("");
     const [selectedArtifacts, setSelectedArtifacts] = useState<Artifact[]>([]);
@@ -109,9 +119,7 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
     const [attachmentError, setAttachmentError] = useState<string | null>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const inputBarRef = useRef<HTMLDivElement>(null);
-    const modelSelectorBtnRef = useRef<HTMLButtonElement>(null);
     const contextAddBtnRef = useRef<HTMLButtonElement>(null);
-    const modelPickerDropdownRef = useRef<HTMLDivElement>(null);
     const contextDropdownRef = useRef<HTMLDivElement>(null);
     const lastSendAttemptRef = useRef<number>(0);
     const resizeRafRef = useRef<number | null>(null);
@@ -164,7 +172,10 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
         setIsSavingAttachments(true);
         setAttachmentError(null);
         try {
-          const newArtifacts = await createArtifactsFromIncomingFiles(files, chatId);
+          const newArtifacts = await createArtifactsFromIncomingFiles(
+            files,
+            chatId,
+          );
           if (newArtifacts.length === 0) {
             setAttachmentError(
               "Could not attach file. Try again or check that Paprwork can access the file.",
@@ -236,13 +247,6 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
     }, []);
 
     useDismissOnOutsideClick(
-      showModelPicker,
-      () => setShowModelPicker(false),
-      modelSelectorBtnRef,
-      modelPickerDropdownRef,
-    );
-
-    useDismissOnOutsideClick(
       showContextDropdown,
       () => setShowContextDropdown(false),
       contextAddBtnRef,
@@ -280,14 +284,13 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
 
       const messageToSend =
         trimmedMessage ||
-        (hasAttachments
-          ? "Please review the attached file(s)."
-          : "");
+        (hasAttachments ? "Please review the attached file(s)." : "");
       const now = Date.now();
       const timeSinceLastAttempt = now - lastSendAttemptRef.current;
-      
+
       // If agent is working
       if (isSending) {
+
         // Double-enter / double-click within 1s: stop the current turn and send now.
         if (timeSinceLastAttempt < 1000) {
           const sendNow = onInterruptAndSend ?? onSend;
@@ -314,7 +317,7 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
           setMessage("");
           clearDraftMessage(chatId);
           setSelectedArtifacts([]);
-          
+
           if (textareaRef.current) {
             textareaRef.current.style.height = "auto";
           }
@@ -399,7 +402,7 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
       const relatedTarget = e.relatedTarget as Node | null;
       if (!relatedTarget || !inputBarRef.current?.contains(relatedTarget)) {
         setIsFocused(false);
-        setShowModelPicker(false);
+        setShowModelSettings(false);
         setShowContextDropdown(false);
       }
     };
@@ -436,7 +439,7 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
                 artifacts={selectedArtifacts}
                 onRemove={handleRemoveArtifact}
                 onAddClick={() => {
-                  setShowModelPicker(false);
+                  setShowModelSettings(false);
                   setShowContextDropdown(!showContextDropdown);
                 }}
                 addButtonRef={contextAddBtnRef}
@@ -478,52 +481,25 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
           {isFocused && (
             <div className="input-footer">
               <div className="model-controls">
-                <button
-                  ref={modelSelectorBtnRef}
-                  type="button"
-                  className="model-selector-pill"
-                  title="Select model"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => {
-                    setShowModelPicker(!showModelPicker);
-                    setShowContextDropdown(false);
+                <ModelSettingsButton
+                  model={currentModel}
+                  resolved={modelSettings}
+                  authType={authType}
+                  onChangeSettings={onChangeModelSettings}
+                  pickerModels={visiblePickerModels}
+                  isModelAvailable={isModelAvailable}
+                  hasModel={hasModel}
+                  hostTotalRamGb={hostTotalRamGb}
+                  onSelectModel={(model) => onModelChange?.(model)}
+                  onOpenSettings={() => onOpenSettings?.()}
+                  onOpenSettingsModels={() => onOpenSettingsModels?.()}
+                  open={showModelSettings}
+                  onOpenChange={(next) => {
+                    if (next) setShowContextDropdown(false);
+                    setShowModelSettings(next);
                   }}
-                >
-                  <span>{currentModel.name}</span>
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                    <path
-                      d="M6 9l6 6 6-6"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </button>
-                {/* Model Picker Dropdown */}
-                {showModelPicker && (
-                  <ModelPickerDropdown
-                    dropdownRef={modelPickerDropdownRef}
-                    currentModelId={currentModel.id}
-                    pickerModels={visiblePickerModels}
-                    isModelAvailable={isModelAvailable}
-                    hasModel={hasModel}
-                    hostTotalRamGb={hostTotalRamGb}
-                    onSelect={(model) => {
-                      onModelChange?.(model);
-                      setShowModelPicker(false);
-                      textareaRef.current?.focus();
-                    }}
-                    onOpenSettings={() => {
-                      onOpenSettings?.();
-                      setShowModelPicker(false);
-                    }}
-                    onOpenSettingsModels={() => {
-                      onOpenSettingsModels?.();
-                      setShowModelPicker(false);
-                    }}
-                  />
-                )}
+                  onDismissed={() => textareaRef.current?.focus()}
+                />
               </div>
               <div className="input-footer__actions">
                 <ChatMemoryScopeSelector chatId={chatId} compact />
@@ -533,7 +509,9 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
                   onClick={isSending ? handleStop : handleSend}
                   disabled={
                     isSavingAttachments ||
-                    (!isSending && !message.trim() && selectedArtifacts.length === 0)
+                    (!isSending &&
+                      !message.trim() &&
+                      selectedArtifacts.length === 0)
                   }
                   type="button"
                   aria-label={isSending ? "Stop agent" : "Send message"}
@@ -543,30 +521,30 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
                       : "Send message"
                   }
                 >
-                {isSending ? (
-                  // Stop icon (square)
-                  <svg width="16" height="16" viewBox="0 0 20 20" fill="none">
-                    <rect
-                      x="5"
-                      y="5"
-                      width="10"
-                      height="10"
-                      fill="currentColor"
-                      rx="1"
-                    />
-                  </svg>
-                ) : (
-                  // Send icon (paper plane)
-                  <svg width="16" height="16" viewBox="0 0 20 20" fill="none">
-                    <path
-                      d="M2.5 10L17.5 3.33333L10.8333 18.3333L9.16667 11.6667L2.5 10Z"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                )}
+                  {isSending ? (
+                    // Stop icon (square)
+                    <svg width="16" height="16" viewBox="0 0 20 20" fill="none">
+                      <rect
+                        x="5"
+                        y="5"
+                        width="10"
+                        height="10"
+                        fill="currentColor"
+                        rx="1"
+                      />
+                    </svg>
+                  ) : (
+                    // Send icon (paper plane)
+                    <svg width="16" height="16" viewBox="0 0 20 20" fill="none">
+                      <path
+                        d="M2.5 10L17.5 3.33333L10.8333 18.3333L9.16667 11.6667L2.5 10Z"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
                 </button>
               </div>
             </div>
@@ -577,4 +555,4 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
   },
 );
 
-InputBar.displayName = 'InputBar';
+InputBar.displayName = "InputBar";

--- a/ui/components/Chat/InputBar.tsx
+++ b/ui/components/Chat/InputBar.tsx
@@ -99,16 +99,18 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
     ref,
   ) => {
     // Draft lives outside chatStates so debounced saves do not re-render MessageList.
-    const draftMessage = useChatStore(
-      (state) => state.draftByChatId.get(chatId) ?? "",
-    );
     const setDraftMessage = useChatStore((state) => state.setDraftMessage);
     const clearDraftMessage = useChatStore((state) => state.clearDraftMessage);
 
     // Ollama status for showing install indicator
     const { hasModel, hostTotalRamGb } = useOllama();
 
-    const [message, setMessage] = useState(draftMessage);
+    // Seeded through the store's getter, which falls back to the durable copy:
+    // after a reload or a crash the in-memory map is empty, and reading it
+    // directly would paint an empty composer over a draft that still exists.
+    const [message, setMessage] = useState(() =>
+      useChatStore.getState().getDraftMessage(chatId),
+    );
     const [isFocused, setIsFocused] = useState(false);
     const [showContextDropdown, setShowContextDropdown] = useState(false);
     const [showModelSettings, setShowModelSettings] = useState(false);
@@ -165,6 +167,23 @@ export const InputBar = forwardRef<InputBarRef, InputBarProps>(
     useEffect(() => {
       debouncedSaveDraft(chatId, message);
     }, [message, chatId, debouncedSaveDraft]);
+
+    // The debounce leaves a 300ms window in which the newest keystrokes exist
+    // only in component state. Flush on the way out so that window does not
+    // include the moment the pane unmounts or the page goes away.
+    const pendingDraftRef = useRef({ chatId, message });
+    pendingDraftRef.current = { chatId, message };
+    useEffect(() => {
+      const flush = () => {
+        const pending = pendingDraftRef.current;
+        setDraftMessage(pending.chatId, pending.message);
+      };
+      window.addEventListener("pagehide", flush);
+      return () => {
+        window.removeEventListener("pagehide", flush);
+        flush();
+      };
+    }, [setDraftMessage]);
 
     const appendFileArtifacts = useCallback(
       async (files: File[]) => {

--- a/ui/components/Chat/ModelPickerDropdown.tsx
+++ b/ui/components/Chat/ModelPickerDropdown.tsx
@@ -21,6 +21,12 @@ interface ModelPickerDropdownProps {
   onOpenSettings: () => void;
   onOpenSettingsModels: () => void;
   dropdownRef?: React.RefObject<HTMLDivElement | null>;
+  /**
+   * Render as a panel inside an existing popover rather than as its own
+   * positioned surface — the model list is a sub-view of the settings popover,
+   * and two stacked absolutely-positioned layers would fight over placement.
+   */
+  embedded?: boolean;
 }
 
 function ModelPickerRow({
@@ -125,6 +131,7 @@ export function ModelPickerDropdown({
   onOpenSettings,
   onOpenSettingsModels,
   dropdownRef,
+  embedded = false,
 }: ModelPickerDropdownProps): React.ReactElement {
   const [showLocal, setShowLocal] = useState(false);
 
@@ -175,7 +182,11 @@ export function ModelPickerDropdown({
   return (
     <div
       ref={dropdownRef}
-      className="model-picker-dropdown model-picker-dropdown--simple"
+      className={
+        embedded
+          ? "model-picker-list model-picker-list--embedded"
+          : "model-picker-dropdown model-picker-dropdown--simple"
+      }
     >
       {pickerModels.map((model) => renderModel(model, true))}
 

--- a/ui/components/Chat/ModelSettingsButton.tsx
+++ b/ui/components/Chat/ModelSettingsButton.tsx
@@ -1,0 +1,113 @@
+/**
+ * The composer's model pill and the settings popover it opens.
+ *
+ * Split out of `InputBar` to keep the composer's own concerns readable. Open
+ * state stays *there* rather than here: the composer has a second popover
+ * (context pills) and only one of the two may be open at a time, so the choice
+ * of which is open belongs to whoever knows about both.
+ */
+
+import * as React from "react";
+import { useRef } from "react";
+import type { AIModel } from "../../constants/models";
+import type { ChatModelSettings } from "../../utils/chatModelSettings";
+import type { ResolvedModelSettings } from "../../utils/buildAgentConfig";
+import { ModelSettingsPopover } from "./ModelSettingsPopover";
+import { useDismissOnOutsideClick } from "../../hooks/useDismissOnOutsideClick";
+
+interface ModelSettingsButtonProps {
+  model: AIModel;
+  resolved: ResolvedModelSettings;
+  authType?: "oauth" | "apiKey";
+  onChangeSettings: (patch: ChatModelSettings) => void;
+  pickerModels: AIModel[];
+  isModelAvailable?: (model: AIModel) => boolean;
+  hasModel: (modelId: string) => boolean;
+  hostTotalRamGb: number | null;
+  onSelectModel: (model: AIModel) => void;
+  onOpenSettings: () => void;
+  onOpenSettingsModels: () => void;
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  /** Return focus to the composer once the popover is dismissed. */
+  onDismissed: () => void;
+}
+
+export function ModelSettingsButton({
+  model,
+  resolved,
+  authType,
+  onChangeSettings,
+  pickerModels,
+  isModelAvailable,
+  hasModel,
+  hostTotalRamGb,
+  onSelectModel,
+  onOpenSettings,
+  onOpenSettingsModels,
+  open,
+  onOpenChange,
+  onDismissed,
+}: ModelSettingsButtonProps): React.ReactElement {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useDismissOnOutsideClick(
+    open,
+    () => onOpenChange(false),
+    buttonRef,
+    popoverRef,
+  );
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        className="model-selector-pill"
+        title="Model and reasoning settings"
+        aria-expanded={open}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => onOpenChange(!open)}
+      >
+        <span>{model.name}</span>
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
+          <path
+            d="M6 9l6 6 6-6"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      {open && (
+        <ModelSettingsPopover
+          popoverRef={popoverRef}
+          model={model}
+          resolved={resolved}
+          authType={authType}
+          onChangeSettings={onChangeSettings}
+          onClose={() => {
+            onOpenChange(false);
+            onDismissed();
+          }}
+          pickerModels={pickerModels}
+          isModelAvailable={isModelAvailable}
+          hasModel={hasModel}
+          hostTotalRamGb={hostTotalRamGb}
+          onSelectModel={onSelectModel}
+          onOpenSettings={() => {
+            onOpenSettings();
+            onOpenChange(false);
+          }}
+          onOpenSettingsModels={() => {
+            onOpenSettingsModels();
+            onOpenChange(false);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/ui/components/Chat/ModelSettingsPopover.css
+++ b/ui/components/Chat/ModelSettingsPopover.css
@@ -1,0 +1,178 @@
+/**
+ * Settings popover — same surface as the other chat popovers so it reads as
+ * part of the composer rather than a new kind of panel.
+ */
+
+.model-settings-popover {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  min-width: 236px;
+  max-width: 300px;
+  max-height: 420px;
+  overflow-y: auto;
+  padding: 4px;
+  background: var(--popover-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  box-shadow: var(--popover-shadow);
+  z-index: 10000;
+  animation: dropdownSlideIn 0.15s ease-out;
+}
+
+.model-settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s var(--ease);
+}
+
+.model-settings-row:hover {
+  background: var(--hover-bg);
+}
+
+.model-settings-row__label {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+}
+
+/* The one control that costs more — say so where the choice is made. */
+.model-settings-row__hint {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.model-settings-row__value {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-settings-chevron {
+  flex-shrink: 0;
+  opacity: 0.5;
+}
+
+.model-settings-switch {
+  position: relative;
+  flex-shrink: 0;
+  width: 34px;
+  height: 20px;
+  border-radius: 10px;
+  background: var(--border-color);
+  transition: background 0.18s var(--ease);
+}
+
+.model-settings-switch--on {
+  background: var(--success-color, #34c759);
+}
+
+.model-settings-switch__knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  transition: transform 0.18s var(--ease);
+}
+
+.model-settings-switch--on .model-settings-switch__knob {
+  transform: translateX(14px);
+}
+
+.model-settings-divider {
+  height: 1px;
+  margin: 4px 8px;
+  background: var(--border-color, rgba(0, 0, 0, 0.08));
+}
+
+.model-settings-back {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 8px 8px;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.model-settings-back:hover {
+  color: var(--text-primary);
+}
+
+.model-settings-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s var(--ease);
+}
+
+.model-settings-option:hover {
+  background: var(--hover-bg);
+}
+
+.model-settings-option--selected {
+  color: var(--primary-color);
+}
+
+.model-settings-option__label {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.model-settings-note {
+  margin: 6px 10px 4px;
+  font-size: 10.5px;
+  line-height: 1.4;
+  color: var(--text-tertiary);
+}
+
+/* Model list rendered as a panel inside this popover, not its own surface. */
+.model-picker-list--embedded {
+  display: block;
+  max-height: 320px;
+  overflow-y: auto;
+}

--- a/ui/components/Chat/ModelSettingsPopover.tsx
+++ b/ui/components/Chat/ModelSettingsPopover.tsx
@@ -1,0 +1,324 @@
+/**
+ * The four dials that decide what a turn costs, in one popover.
+ *
+ * Thinking, Fast, Context and Effort were all reachable only by picking a
+ * different model — or not at all — so a chat ran at whatever the model
+ * advertised. On a 1M-window model that is a ~636K history budget re-sent on
+ * every step of a turn that can run to 100 steps.
+ *
+ * A row appears only when the request can actually carry it (see
+ * `modelControls`): a switch wired to nothing is worse than no switch. Model
+ * selection is the last row rather than the whole surface, because the model is
+ * the choice you make once and the dials are the ones you revisit.
+ */
+
+import * as React from "react";
+import { useState } from "react";
+import type { AIModel } from "../../constants/models";
+import {
+  EFFORT_LABELS,
+  contextOptionsForModel,
+  effortLevelsForModel,
+  formatContextLimit,
+  modelSupportsContextChoice,
+  modelSupportsEffort,
+  modelSupportsFast,
+  modelSupportsThinkingToggle,
+  type EffortLevel,
+} from "../../constants/modelControls";
+import type { ChatModelSettings } from "../../utils/chatModelSettings";
+import type { ResolvedModelSettings } from "../../utils/buildAgentConfig";
+import { ModelPickerDropdown } from "./ModelPickerDropdown";
+import "./ModelSettingsPopover.css";
+
+type SubView = "root" | "context" | "effort" | "model";
+
+interface ModelSettingsPopoverProps {
+  model: AIModel;
+  /** Effective values after dropping anything this model cannot honour. */
+  resolved: ResolvedModelSettings;
+  authType?: "oauth" | "apiKey";
+  onChangeSettings: (patch: ChatModelSettings) => void;
+  popoverRef?: React.RefObject<HTMLDivElement | null>;
+  onClose: () => void;
+  // Model sub-view
+  pickerModels: AIModel[];
+  isModelAvailable?: (model: AIModel) => boolean;
+  hasModel: (modelId: string) => boolean;
+  hostTotalRamGb: number | null;
+  onSelectModel: (model: AIModel) => void;
+  onOpenSettings: () => void;
+  onOpenSettingsModels: () => void;
+}
+
+function Chevron(): React.ReactElement {
+  return (
+    <svg
+      className="model-settings-chevron"
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M9 6l6 6-6 6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ToggleRow({
+  label,
+  hint,
+  checked,
+  onChange,
+}: {
+  label: string;
+  hint?: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      className="model-settings-row"
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={() => onChange(!checked)}
+    >
+      <span className="model-settings-row__label">
+        {label}
+        {hint && <span className="model-settings-row__hint">{hint}</span>}
+      </span>
+      <span
+        className={`model-settings-switch ${checked ? "model-settings-switch--on" : ""}`}
+      >
+        <span className="model-settings-switch__knob" />
+      </span>
+    </button>
+  );
+}
+
+function ValueRow({
+  label,
+  value,
+  onOpen,
+}: {
+  label: string;
+  value: string;
+  onOpen: () => void;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      className="model-settings-row"
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onOpen}
+    >
+      <span className="model-settings-row__label">{label}</span>
+      <span className="model-settings-row__value">
+        {value}
+        <Chevron />
+      </span>
+    </button>
+  );
+}
+
+function OptionRow({
+  label,
+  hint,
+  selected,
+  onSelect,
+}: {
+  label: string;
+  hint?: string;
+  selected: boolean;
+  onSelect: () => void;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      className={`model-settings-option ${selected ? "model-settings-option--selected" : ""}`}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onSelect}
+    >
+      <span className="model-settings-option__label">
+        {label}
+        {hint && <span className="model-settings-row__hint">{hint}</span>}
+      </span>
+      {selected && (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z" />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+function SubHeader({
+  title,
+  onBack,
+}: {
+  title: string;
+  onBack: () => void;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      className="model-settings-back"
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onBack}
+    >
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
+        <path
+          d="M15 6l-6 6 6 6"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      <span>{title}</span>
+    </button>
+  );
+}
+
+export function ModelSettingsPopover({
+  model,
+  resolved,
+  authType,
+  onChangeSettings,
+  popoverRef,
+  onClose,
+  pickerModels,
+  isModelAvailable,
+  hasModel,
+  hostTotalRamGb,
+  onSelectModel,
+  onOpenSettings,
+  onOpenSettingsModels,
+}: ModelSettingsPopoverProps): React.ReactElement {
+  const [view, setView] = useState<SubView>("root");
+
+  const showThinking = modelSupportsThinkingToggle(model);
+  const showFast = modelSupportsFast(model, authType);
+  const showContext = modelSupportsContextChoice(model);
+  const showEffort = modelSupportsEffort(model) && resolved.thinking;
+
+  const contextOptions = contextOptionsForModel(model);
+  const effortLevels = effortLevelsForModel(model);
+
+  return (
+    <div ref={popoverRef} className="model-settings-popover">
+      {view === "root" && (
+        <>
+          {showThinking && (
+            <ToggleRow
+              label="Thinking"
+              checked={resolved.thinking}
+              onChange={(next) => onChangeSettings({ thinking: next })}
+            />
+          )}
+          {showFast && (
+            <ToggleRow
+              label="Fast"
+              hint="2× cost"
+              checked={resolved.fast}
+              onChange={(next) => onChangeSettings({ fast: next })}
+            />
+          )}
+          {showContext && (
+            <ValueRow
+              label="Context"
+              value={formatContextLimit(resolved.contextLimit)}
+              onOpen={() => setView("context")}
+            />
+          )}
+          {showEffort && resolved.effort && (
+            <ValueRow
+              label="Effort"
+              value={EFFORT_LABELS[resolved.effort]}
+              onOpen={() => setView("effort")}
+            />
+          )}
+
+          <div className="model-settings-divider" role="separator" />
+
+          <ValueRow
+            label="Model"
+            value={model.name}
+            onOpen={() => setView("model")}
+          />
+        </>
+      )}
+
+      {view === "context" && (
+        <>
+          <SubHeader title="Context" onBack={() => setView("root")} />
+          {contextOptions.map((option) => (
+            <OptionRow
+              key={option}
+              label={formatContextLimit(option)}
+              selected={resolved.contextLimit === option}
+              onSelect={() => {
+                onChangeSettings({ contextLimit: option });
+                setView("root");
+              }}
+            />
+          ))}
+          <p className="model-settings-note">
+            Caps how much conversation is carried into each step. Everything in
+            the cap is re-sent every step, so a narrower window costs less.
+          </p>
+        </>
+      )}
+
+      {view === "effort" && (
+        <>
+          <SubHeader title="Effort" onBack={() => setView("root")} />
+          {effortLevels.map((level: EffortLevel) => (
+            <OptionRow
+              key={level}
+              label={EFFORT_LABELS[level]}
+              selected={resolved.effort === level}
+              onSelect={() => {
+                onChangeSettings({ effort: level });
+                setView("root");
+              }}
+            />
+          ))}
+          <p className="model-settings-note">
+            How long the model reasons before answering. Higher effort means
+            more thinking tokens, which are billed as output.
+          </p>
+        </>
+      )}
+
+      {view === "model" && (
+        <>
+          <SubHeader title="Model" onBack={() => setView("root")} />
+          <ModelPickerDropdown
+            embedded
+            currentModelId={model.id}
+            pickerModels={pickerModels}
+            isModelAvailable={isModelAvailable}
+            hasModel={hasModel}
+            hostTotalRamGb={hostTotalRamGb}
+            onSelect={(next) => {
+              onSelectModel(next);
+              onClose();
+            }}
+            onOpenSettings={onOpenSettings}
+            onOpenSettingsModels={onOpenSettingsModels}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/components/Documents/DocumentView.tsx
+++ b/ui/components/Documents/DocumentView.tsx
@@ -13,7 +13,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import Underline from "@tiptap/extension-underline";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Table } from "@tiptap/extension-table";
 import { TableRow } from "@tiptap/extension-table-row";
@@ -73,7 +72,9 @@ function DocumentViewInner({ documentId }: DocumentViewProps) {
       TableHeader,
       TableCell,
       DocumentMarkdownItTables,
-      Underline,
+      // Underline is not listed here: StarterKit v3 bundles it, and registering
+      // it a second time makes Tiptap warn about a duplicate extension name.
+      // The toolbar's toggleUnderline()/isActive("underline") work regardless.
       Placeholder.configure({
         placeholder: 'Start typing or press "/" for commands...',
       }),

--- a/ui/components/Layout/ContentArea.tsx
+++ b/ui/components/Layout/ContentArea.tsx
@@ -28,6 +28,7 @@ import { OnboardingView } from "../Onboarding/OnboardingView";
 import { MemoryView } from "../Memory/MemoryView";
 import { PlatformBrowserTab } from "../Platform/PlatformBrowserTab";
 import { gateway } from "../../src/lib/gateway";
+import { PaneErrorBoundary } from "./PaneErrorBoundary";
 import "./ContentArea.css";
 
 const MemoChatContainer = React.memo(ChatContainer);
@@ -355,8 +356,19 @@ export function ContentArea() {
     </div>
   );
 
-  // Render view based on tab type
+  // Every pane is wrapped, so a render-time throw in one tab shows a recoverable
+  // card in that tab instead of unmounting the whole React tree — which is what
+  // made a single bad render look like the app reloading.
   const renderView = (tabId: string | null, skipAgents = false) => {
+    const view = renderViewForTab(tabId, skipAgents);
+    if (view === null) return null;
+    return (
+      <PaneErrorBoundary paneKey={tabId ?? "unknown"}>{view}</PaneErrorBoundary>
+    );
+  };
+
+  // Render view based on tab type
+  const renderViewForTab = (tabId: string | null, skipAgents = false) => {
     if (!tabId) return null;
 
     const tab = getTab(tabId);
@@ -429,7 +441,9 @@ export function ContentArea() {
               isAgentsActive ? " content-pane__keep-alive--visible" : ""
             }`}
           >
-            <AgentsView />
+            <PaneErrorBoundary paneKey={`agents-keep-alive-${pane}`}>
+              <AgentsView />
+            </PaneErrorBoundary>
           </div>
         )}
         {isAppTab(tab) && mountedAppTabIds.has(tab.id) ? null : isAppTab(tab) ? (

--- a/ui/components/Layout/PaneErrorBoundary.css
+++ b/ui/components/Layout/PaneErrorBoundary.css
@@ -1,0 +1,56 @@
+.pane-error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 48px 24px;
+}
+
+.pane-error__card {
+  max-width: 380px;
+  padding: 28px;
+  text-align: center;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border, var(--border-color));
+  border-radius: 16px;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+.pane-error__title {
+  margin: 0 0 8px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.pane-error__detail {
+  margin: 0 0 16px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  overflow-wrap: anywhere;
+}
+
+.pane-error__reassurance {
+  margin: 0 0 20px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-tertiary);
+}
+
+.pane-error__retry {
+  padding: 8px 20px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  cursor: pointer;
+  background: var(--glass-bg-hover);
+  border: 1px solid var(--glass-border, var(--border-color));
+  border-radius: 8px;
+  transition: background 0.15s ease;
+}
+
+.pane-error__retry:hover {
+  background: var(--glass-bg-active);
+}

--- a/ui/components/Layout/PaneErrorBoundary.tsx
+++ b/ui/components/Layout/PaneErrorBoundary.tsx
@@ -1,0 +1,81 @@
+/**
+ * Contains a render-time throw to the tab it happened in.
+ *
+ * Without a boundary anywhere above them, the panes sat directly under
+ * `AppLayout`, so React's only recourse for a throw in one of them was to
+ * unmount the entire tree. To the user that looks like the whole app
+ * reloading, and it takes every other tab down with it.
+ *
+ * The boundary is deliberately at the pane rather than around a single view:
+ * one tab throwing should never be able to reach another, whichever kind of
+ * view it holds.
+ */
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import "./PaneErrorBoundary.css";
+
+interface PaneErrorBoundaryProps {
+  children: ReactNode;
+  /** Identifies the pane in logs, and resets the boundary when the tab changes. */
+  paneKey: string;
+}
+
+interface PaneErrorBoundaryState {
+  error: Error | null;
+}
+
+export class PaneErrorBoundary extends Component<
+  PaneErrorBoundaryProps,
+  PaneErrorBoundaryState
+> {
+  state: PaneErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): PaneErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidUpdate(previous: PaneErrorBoundaryProps): void {
+    // Switching tabs is a fresh start: keeping the error would leave a healthy
+    // tab showing the previous tab's failure.
+    if (previous.paneKey !== this.props.paneKey && this.state.error) {
+      this.setState({ error: null });
+    }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(
+      `[Pane:${this.props.paneKey}] Render error:`,
+      error,
+      info.componentStack,
+    );
+  }
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (!error) {
+      return this.props.children;
+    }
+
+    return (
+      <div className="pane-error">
+        <div className="pane-error__card">
+          <h2 className="pane-error__title">This tab hit an error</h2>
+          <p className="pane-error__detail">
+            {error.message || "Something went wrong while rendering this view."}
+          </p>
+          <p className="pane-error__reassurance">
+            Your other tabs are unaffected, and any message you were typing has
+            been saved.
+          </p>
+          <button
+            type="button"
+            className="pane-error__retry"
+            onClick={() => this.setState({ error: null })}
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/ui/components/Settings/AIModelsTab.tsx
+++ b/ui/components/Settings/AIModelsTab.tsx
@@ -121,15 +121,21 @@ export function AIModelsTab({ scrollToPickerModels = false }: AIModelsTabProps) 
             <div key={provider.id} className="ai-provider-card">
               <div className="ai-provider-card__header">
                 <h3 className="ai-provider-card__name">{provider.name}</h3>
-                {status.hasKey ? (
-                  <span className="ai-provider-badge ai-provider-badge--connected">
-                    ✓ {status.isOAuth ? "OAuth" : "API Key"}
-                  </span>
-                ) : (
-                  <span className="ai-provider-badge ai-provider-badge--none">
-                    Not configured
-                  </span>
-                )}
+                {/* Only for providers without an OAuth panel. Where there is
+                    one it owns the badge, because this one can only see that a
+                    key row exists — not whether it still authenticates. Two
+                    badges from two sources is how the card came to show
+                    "OAuth" and "Connected" in green over an expired token. */}
+                {!provider.hasOAuth &&
+                  (status.hasKey ? (
+                    <span className="ai-provider-badge ai-provider-badge--connected">
+                      ✓ API Key
+                    </span>
+                  ) : (
+                    <span className="ai-provider-badge ai-provider-badge--none">
+                      Not configured
+                    </span>
+                  ))}
               </div>
 
               {provider.hasOAuth && (

--- a/ui/components/Settings/OAuthSection.tsx
+++ b/ui/components/Settings/OAuthSection.tsx
@@ -9,6 +9,7 @@ import type { OAuthProviderSource } from "../../../src/core/telemetry/oauthProvi
 import { trackOAuthProviderStep } from "../../lib/oauthProviderTelemetry";
 import { getOnboardingState } from "../../utils/onboardingState";
 import { cleanClaudeOAuthToken } from "../../utils/claudeOAuthToken";
+import { useProviderAuthStore } from "../../stores/providerAuthStore";
 import { ClaudeTokenPastePanel } from "./ClaudeTokenPastePanel";
 import { ClaudeManualSetupPanel } from "./ClaudeManualSetupPanel";
 import { useChat } from "../../hooks/useChat";
@@ -52,6 +53,15 @@ export function OAuthSection({
   const { status, loading, startOAuthLogin, disconnect } = useOAuth(provider, {
     source: oauthSource,
   });
+  // A turn that failed on a 401 is the only proof we get that a token the
+  // provider still lists as valid has stopped working. Without it the card can
+  // only report what we stored, which is why it kept counting down while every
+  // request was being refused.
+  const authRejected = useProviderAuthStore(
+    state => state.rejections[provider] !== undefined,
+  );
+  const clearAuthRejection = useProviderAuthStore(state => state.clearRejection);
+  const needsReconnect = authRejected && status.connected;
   // Persisted in the main process: it decides which credential the gateway ever
   // sees, so this is the mode the agent actually runs on, not just which form shows.
   const [useApiKey, setUseApiKey] = useState(false);
@@ -271,6 +281,18 @@ export function OAuthSection({
     }
   };
 
+  // Both remediations retire the recorded rejection: whatever happens next, the
+  // 401 we saw no longer describes the credential now stored.
+  const handleReconnect = async () => {
+    clearAuthRejection(provider);
+    await startOAuthLogin();
+  };
+
+  const handleDisconnect = async () => {
+    clearAuthRejection(provider);
+    await disconnect();
+  };
+
   const formatExpiry = (expiresAt?: string) => {
     if (!expiresAt) return "";
     const date = new Date(expiresAt);
@@ -299,11 +321,16 @@ export function OAuthSection({
             </span>
           )
         ) : (
-          status.connected && (
+          status.connected &&
+          (needsReconnect ? (
+            <span className="oauth-badge oauth-badge--attention">
+              Reconnect needed
+            </span>
+          ) : (
             <span className="oauth-badge oauth-badge--connected">
               ✓ Connected
             </span>
-          )
+          ))
         )}
       </div>
 
@@ -319,7 +346,9 @@ export function OAuthSection({
                   </span>
                 </div>
               )}
-              {status.expiresAt && (
+              {/* Hidden once rejected: the stored expiry is what we know, and
+                  the 401 proves it is no longer what the provider honours. */}
+              {status.expiresAt && !needsReconnect && (
                 <div className="oauth-detail">
                   <span className="oauth-detail-label">Token:</span>
                   <span className="oauth-detail-value">
@@ -327,10 +356,25 @@ export function OAuthSection({
                   </span>
                 </div>
               )}
+              {needsReconnect && (
+                <p className="oauth-reconnect-note" aria-live="polite">
+                  {subscriptionName} rejected this token. Reconnect to continue.
+                </p>
+              )}
+              {needsReconnect && (
+                <button
+                  className="settings-btn settings-btn--primary"
+                  onClick={handleReconnect}
+                  disabled={loading}
+                  style={{ width: "100%", marginBottom: "8px" }}
+                >
+                  {loading ? "Reconnecting..." : "Reconnect"}
+                </button>
+              )}
               <div style={{ display: "flex", gap: "8px" }}>
                 <button
                   className="settings-btn settings-btn--secondary"
-                  onClick={disconnect}
+                  onClick={handleDisconnect}
                   disabled={loading}
                   style={{ flex: 1 }}
                 >

--- a/ui/components/Settings/OAuthSection.tsx
+++ b/ui/components/Settings/OAuthSection.tsx
@@ -10,6 +10,7 @@ import { trackOAuthProviderStep } from "../../lib/oauthProviderTelemetry";
 import { getOnboardingState } from "../../utils/onboardingState";
 import { cleanClaudeOAuthToken } from "../../utils/claudeOAuthToken";
 import { useProviderAuthStore } from "../../stores/providerAuthStore";
+import { deriveProviderConnectionState } from "../../utils/providerConnectionState";
 import { ClaudeTokenPastePanel } from "./ClaudeTokenPastePanel";
 import { ClaudeManualSetupPanel } from "./ClaudeManualSetupPanel";
 import { useChat } from "../../hooks/useChat";
@@ -61,7 +62,6 @@ export function OAuthSection({
     state => state.rejections[provider] !== undefined,
   );
   const clearAuthRejection = useProviderAuthStore(state => state.clearRejection);
-  const needsReconnect = authRejected && status.connected;
   // Persisted in the main process: it decides which credential the gateway ever
   // sees, so this is the mode the agent actually runs on, not just which form shows.
   const [useApiKey, setUseApiKey] = useState(false);
@@ -84,6 +84,26 @@ export function OAuthSection({
   const [apiKeySaved, setApiKeySaved] = useState(false);
   const [apiKeyError, setApiKeyError] = useState("");
   const { keys, addKey, updateKey, getKeyValue, deleteKey } = useCustomKeys();
+
+  // A key row synced from the OAuth token is not a platform key, so it is not
+  // something requests can fall back to — only a key the user supplied is.
+  const platformApiKeyConfigured = useMemo(() => {
+    const stored = keys.find(k => k.name === apiKeyName);
+    return stored !== undefined && stored.managedBy !== "oauth";
+  }, [keys, apiKeyName]);
+
+  const connectionState = useMemo(
+    () =>
+      deriveProviderConnectionState({
+        mode: useApiKey ? "apiKey" : "oauth",
+        platformApiKeyConfigured,
+        status,
+        authRejected,
+      }),
+    [useApiKey, platformApiKeyConfigured, status, authRejected],
+  );
+
+  const needsReconnect = connectionState.kind === "needs_signin";
 
   const handleClaudeConnected = () => {
     window.location.reload();
@@ -293,44 +313,29 @@ export function OAuthSection({
     await disconnect();
   };
 
-  const formatExpiry = (expiresAt?: string) => {
-    if (!expiresAt) return "";
-    const date = new Date(expiresAt);
-    const now = new Date();
-    const diffMs = date.getTime() - now.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-
-    if (diffMins < 0) return "Expired";
-    if (diffMins < 60) return `Expires in ${diffMins}m`;
-    const diffHours = Math.floor(diffMins / 60);
-    if (diffHours < 24) return `Expires in ${diffHours}h`;
-    const diffDays = Math.floor(diffHours / 24);
-    return `Expires in ${diffDays}d`;
-  };
-
   return (
     <div className="oauth-card">
       <div className="oauth-card__header">
         <h3>{title}</h3>
         {/* In API key mode the OAuth token is deliberately unused, so showing it
             as connected is what made the switch look like it hadn't applied. */}
-        {useApiKey ? (
-          apiKeySaved && (
-            <span className="oauth-badge oauth-badge--connected">
-              ✓ Using API key
-            </span>
-          )
-        ) : (
-          status.connected &&
-          (needsReconnect ? (
-            <span className="oauth-badge oauth-badge--attention">
-              Reconnect needed
-            </span>
-          ) : (
-            <span className="oauth-badge oauth-badge--connected">
-              ✓ Connected
-            </span>
-          ))
+        {/* One badge, from one derived state. Rendering "stored" and "usable"
+            as separate green signals is what let the card say Connected while
+            the token was expired. */}
+        {connectionState.kind === "api_key_mode" && connectionState.configured && (
+          <span className="oauth-badge oauth-badge--connected">
+            ✓ Using API key
+          </span>
+        )}
+        {connectionState.kind === "connected" && (
+          <span className="oauth-badge oauth-badge--connected">
+            ✓ Connected
+          </span>
+        )}
+        {connectionState.kind === "needs_signin" && (
+          <span className="oauth-badge oauth-badge--attention">
+            Sign-in expired
+          </span>
         )}
       </div>
 
@@ -346,20 +351,26 @@ export function OAuthSection({
                   </span>
                 </div>
               )}
-              {/* Hidden once rejected: the stored expiry is what we know, and
-                  the 401 proves it is no longer what the provider honours. */}
-              {status.expiresAt && !needsReconnect && (
-                <div className="oauth-detail">
-                  <span className="oauth-detail-label">Token:</span>
-                  <span className="oauth-detail-value">
-                    {formatExpiry(status.expiresAt)}
-                  </span>
+              {/* No expiry countdown while healthy. It is not actionable, and
+                  as the only marker of a dead token it was missed — the badge
+                  beside it said Connected, in green, and won. */}
+              {connectionState.kind === "needs_signin" && (
+                <div className="oauth-state-notice" aria-live="polite">
+                  <p className="oauth-state-notice__headline">
+                    {connectionState.reason === "rejected"
+                      ? `${subscriptionName} rejected this sign-in.`
+                      : `Your ${subscriptionName} sign-in expired and cannot renew itself.`}
+                  </p>
+                  {/* Name the account actually being spent from. Staying quiet
+                      here is how a subscription at 11% usage came to report
+                      that its limits were exhausted: the cap belonged to the
+                      API key that had quietly taken over. */}
+                  <p className="oauth-state-notice__detail">
+                    {connectionState.fallsBackToApiKey
+                      ? `${title} is running on your API key, which is billed separately from your subscription.`
+                      : `${title} requests will fail until you sign in again.`}
+                  </p>
                 </div>
-              )}
-              {needsReconnect && (
-                <p className="oauth-reconnect-note" aria-live="polite">
-                  {subscriptionName} rejected this token. Reconnect to continue.
-                </p>
               )}
               {needsReconnect && (
                 <button
@@ -368,7 +379,7 @@ export function OAuthSection({
                   disabled={loading}
                   style={{ width: "100%", marginBottom: "8px" }}
                 >
-                  {loading ? "Reconnecting..." : "Reconnect"}
+                  {loading ? "Opening sign-in..." : "Sign in again"}
                 </button>
               )}
               <div style={{ display: "flex", gap: "8px" }}>

--- a/ui/components/Settings/SettingsView.css
+++ b/ui/components/Settings/SettingsView.css
@@ -1954,6 +1954,18 @@
   background: rgba(46, 125, 50, 0.1);
 }
 
+.oauth-badge--attention {
+  color: #d32f2f;
+  background: rgba(211, 47, 47, 0.1);
+}
+
+.oauth-reconnect-note {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #d32f2f;
+}
+
 .oauth-card__description {
   font-size: 12px;
   color: var(--text-secondary);

--- a/ui/components/Settings/SettingsView.css
+++ b/ui/components/Settings/SettingsView.css
@@ -1954,16 +1954,59 @@
   background: rgba(46, 125, 50, 0.1);
 }
 
+/* Amber, not red: the state needs the user but is not itself a failure, and
+   red beside a Disconnect button reads as danger rather than attention. */
 .oauth-badge--attention {
-  color: #d32f2f;
-  background: rgba(211, 47, 47, 0.1);
+  color: #92400e;
+  background: rgba(180, 83, 9, 0.12);
 }
 
-.oauth-reconnect-note {
+@media (prefers-color-scheme: dark) {
+  .oauth-badge--attention {
+    color: #fcd34d;
+    background: rgba(252, 211, 77, 0.14);
+  }
+}
+
+/* The one place the card explains itself, so it carries the weight the old
+   12px expiry line could not. Tinted glass rather than a solid banner. */
+.oauth-state-notice {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0 0 4px 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(180, 83, 9, 0.22);
+  border-radius: 10px;
+  background: rgba(180, 83, 9, 0.07);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+}
+
+.oauth-state-notice__headline {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: #92400e;
+}
+
+.oauth-state-notice__detail {
   margin: 0;
   font-size: 12px;
-  line-height: 1.4;
-  color: #d32f2f;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+@media (prefers-color-scheme: dark) {
+  .oauth-state-notice {
+    border-color: rgba(252, 211, 77, 0.22);
+    background: rgba(252, 211, 77, 0.08);
+  }
+
+  .oauth-state-notice__headline {
+    color: #fcd34d;
+  }
 }
 
 .oauth-card__description {

--- a/ui/constants/modelControls.ts
+++ b/ui/constants/modelControls.ts
@@ -1,0 +1,228 @@
+/**
+ * Per-chat model controls: thinking, effort, context, fast.
+ *
+ * These four knobs decide what a turn costs, and until now none of them were
+ * reachable from the composer. Two consequences fell out of that:
+ *
+ * 1. Effort was expressed by shipping a *separate model* per level —
+ *    `gpt-5-6-sol-low` / `gpt-5-6-sol` / `gpt-5-6-sol-high` are one API model
+ *    (`gpt-5.6-sol`) with three different `reasoning.effort` values, and the
+ *    picker listed all three as if they were different models. The variant ids
+ *    are packaging, not models; {@link EFFORT_VARIANT_MODELS} unpacks them.
+ *
+ * 2. Context was whatever the model advertised. On a 1M-window model the
+ *    history budget computes to ~636K tokens, and every token in that budget is
+ *    re-sent on every step of a turn that can run to 100 steps. The window is
+ *    not a price tier — Anthropic dropped the >200K surcharge in March 2026 —
+ *    but input is billed per token, so the budget is a spend dial either way.
+ *
+ * Capability is derived from the model rather than hand-listed per control, so
+ * a row is only ever offered when the underlying request can actually carry it.
+ */
+
+import type { ReasoningEffort } from "../../src/core/types/agents";
+import { anthropicModelUsesAdaptiveThinking } from "../../src/gateway/utils/anthropicAdaptiveThinking";
+import type { AIModel } from "./models";
+
+export type EffortLevel = ReasoningEffort;
+
+/** Ordered low → high. `max` is offered only where the provider accepts it. */
+export const EFFORT_LEVELS: readonly EffortLevel[] = [
+  "low",
+  "medium",
+  "high",
+  "max",
+];
+
+export const EFFORT_LABELS: Record<EffortLevel, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "High",
+  max: "Max",
+};
+
+/**
+ * Context choices, in tokens.
+ *
+ * The floor is 200K deliberately: a real turn carries ~86K of tool schemas
+ * before any conversation, so anything lower starves the tools it is meant to
+ * be budgeting for.
+ */
+export const CONTEXT_OPTIONS: readonly number[] = [200_000, 400_000, 1_000_000];
+
+/** What a chat gets when the user has never touched the control. */
+export const DEFAULT_CONTEXT_LIMIT = 200_000;
+
+export function formatContextLimit(tokens: number): string {
+  return tokens >= 1_000_000
+    ? `${tokens / 1_000_000}M`
+    : `${Math.round(tokens / 1000)}K`;
+}
+
+/**
+ * Retired picker ids that were really one model at a fixed effort.
+ *
+ * Each maps to the base model plus the effort it always implied, so a chat
+ * pinned to `gpt-5-6-sol-high` keeps running at high effort after the picker
+ * stops listing it as its own row.
+ */
+export const EFFORT_VARIANT_MODELS: Readonly<
+  Record<string, { modelId: string; effort: EffortLevel }>
+> = {
+  "gpt-5-6-sol-low": { modelId: "gpt-5-6-sol", effort: "low" },
+  "gpt-5-6-sol-high": { modelId: "gpt-5-6-sol", effort: "high" },
+  "gpt-5.5-low": { modelId: "gpt-5-6-sol", effort: "low" },
+  "gpt-5.5": { modelId: "gpt-5-6-sol", effort: "medium" },
+  "gpt-5.5-high": { modelId: "gpt-5-6-sol", effort: "high" },
+  "glm-5.2-max": { modelId: "glm-5.2", effort: "max" },
+};
+
+/** Base model + implied effort for a possibly-variant id. */
+export function unpackEffortVariant(modelId: string): {
+  modelId: string;
+  effort?: EffortLevel;
+} {
+  const variant = EFFORT_VARIANT_MODELS[modelId];
+  return variant ? { ...variant } : { modelId };
+}
+
+/** Providers whose requests carry a reasoning-effort field. */
+const EFFORT_PROVIDERS = new Set([
+  "anthropic",
+  "openai",
+  "openai-codex",
+  "zai",
+  "groq",
+  "moonshot",
+]);
+
+/** Non-Anthropic providers that accept `max` rather than topping out at `high`. */
+const MAX_EFFORT_PROVIDERS = new Set(["zai", "moonshot"]);
+
+/**
+ * Anthropic tops out at `max` only on the frontier adaptive models.
+ *
+ * Mirrors the gateway's own `xhigh -> max` mapping, which promotes only Fable
+ * and Opus 5; everything else resolves to `high`.
+ */
+function anthropicAcceptsMaxEffort(modelId: string): boolean {
+  return modelId.includes("fable") || modelId.includes("opus-5");
+}
+
+/**
+ * Anthropic fast mode is API-key only and Opus-5 class only.
+ *
+ * pi-ai has no `speed` parameter, so an OAuth turn silently ignores it —
+ * showing the row there would promise something the request cannot carry.
+ * It is also the one control that costs *more* ($10/$50 per M against $5/$25).
+ */
+const FAST_MODEL_IDS = new Set(["claude-opus-5", "claude-opus-4-8"]);
+
+/**
+ * Providers whose request has an actual off switch for reasoning.
+ *
+ * Anthropic takes `thinking: { type: "disabled" }`, Google a zero thinking
+ * budget, Ollama `think: false`. OpenAI-compatible reasoning models have no
+ * such field — reasoning is intrinsic and effort is the only dial — so a
+ * toggle there would be a switch wired to nothing.
+ */
+const THINKING_TOGGLE_PROVIDERS = new Set(["anthropic", "google", "ollama"]);
+
+export function modelSupportsThinking(model: AIModel): boolean {
+  return model.supportsThinking === true;
+}
+
+export function modelSupportsThinkingToggle(model: AIModel): boolean {
+  return (
+    modelSupportsThinking(model) &&
+    THINKING_TOGGLE_PROVIDERS.has(model.provider)
+  );
+}
+
+export function modelSupportsEffort(model: AIModel): boolean {
+  if (!modelSupportsThinking(model)) return false;
+  // On Anthropic, effort is part of the *adaptive* thinking surface. The
+  // budget-thinking models (Sonnet 4.6, Haiku 4.5, Opus 4.6) take
+  // `thinking: { type: "enabled", budgetTokens }` and have no effort field, so
+  // offering the row there would send a parameter the request cannot carry.
+  if (model.provider === "anthropic") {
+    return anthropicModelUsesAdaptiveThinking(model.id);
+  }
+  return EFFORT_PROVIDERS.has(model.provider);
+}
+
+export function modelSupportsFast(
+  model: AIModel,
+  authType: "oauth" | "apiKey" | undefined,
+): boolean {
+  return (
+    model.provider === "anthropic" &&
+    FAST_MODEL_IDS.has(model.id) &&
+    authType === "apiKey"
+  );
+}
+
+/** Effort levels this model will actually honour, low → high. */
+export function effortLevelsForModel(model: AIModel): EffortLevel[] {
+  const levels: EffortLevel[] = ["low", "medium", "high"];
+  const acceptsMax =
+    model.provider === "anthropic"
+      ? anthropicAcceptsMaxEffort(model.id)
+      : MAX_EFFORT_PROVIDERS.has(model.provider);
+  if (acceptsMax) {
+    levels.push("max");
+  }
+  return levels;
+}
+
+/**
+ * Context window per model, in tokens.
+ *
+ * These mirror the gateway's own registry (`ModelFallback`), which is the value
+ * the request is actually budgeted against. They are restated here because the
+ * renderer cannot import that module — its relative imports carry `.js`
+ * specifiers that the Vite build does not resolve back to `.ts`. A drift test
+ * asserts the two stay equal, so the copy cannot quietly go stale.
+ */
+export const MODEL_CONTEXT_WINDOWS: Readonly<Record<string, number>> = {
+  "claude-haiku-4-5": 200_000,
+  "claude-sonnet-4-6": 1_000_000,
+  "claude-sonnet-5": 1_000_000,
+  "claude-opus-4-6": 1_000_000,
+  "claude-opus-5": 1_000_000,
+  "claude-fable-5-1": 1_000_000,
+  "gpt-5.4-mini": 272_000,
+  "gpt-5-6-luna": 1_050_000,
+  "gpt-5-6-terra": 1_050_000,
+  "gpt-5-6-sol": 1_050_000,
+  "gpt-5.5": 1_000_000,
+  "gpt-5.3-codex": 128_000,
+  "gemini-3.5-flash-lite": 1_048_576,
+  "gemini-3.8-flash": 1_048_576,
+  "gemini-3.1-pro-preview": 1_048_576,
+  "glm-5.2": 1_000_000,
+  "qwen/qwen3-32b": 131_072,
+  "openai/gpt-oss-120b": 131_072,
+  "kimi-k3": 1_048_576,
+};
+
+/** Advertised window, or undefined when the model is not in the table. */
+export function contextWindowForModel(model: AIModel): number | undefined {
+  return MODEL_CONTEXT_WINDOWS[model.id];
+}
+
+/** Context choices that fit inside the model's own window. */
+export function contextOptionsForModel(model: AIModel): number[] {
+  const window = contextWindowForModel(model);
+  if (!window) {
+    return [...CONTEXT_OPTIONS];
+  }
+  const fitting = CONTEXT_OPTIONS.filter((option) => option <= window);
+  // A model narrower than the smallest option still needs one honest choice.
+  return fitting.length > 0 ? fitting : [window];
+}
+
+export function modelSupportsContextChoice(model: AIModel): boolean {
+  return contextOptionsForModel(model).length > 1;
+}

--- a/ui/constants/modelPicker.ts
+++ b/ui/constants/modelPicker.ts
@@ -8,13 +8,25 @@ import {
   getModelGroups,
   type AIModel,
 } from "./models";
+import { EFFORT_VARIANT_MODELS } from "./modelControls";
 
-/** Models kept for jobs/runtime but hidden from chat picker. */
+/**
+ * Models kept for jobs/runtime but hidden from chat picker.
+ *
+ * The `-low` / `-high` / `-max` entries are not separate models: each is one
+ * API model at a fixed reasoning effort, and listing them made the picker three
+ * rows deep for one model. Effort is now a control on the model, so these ids
+ * survive only as the thing a saved preference or pinned chat migrates *from*
+ * (see {@link EFFORT_VARIANT_MODELS}, which preserves the effort they implied).
+ */
 export const CHAT_PICKER_EXCLUDED_MODEL_IDS: readonly string[] = [
   "composer-2.5",
   "gpt-5.5-low",
   "gpt-5.5",
   "gpt-5.5-high",
+  "gpt-5-6-sol-low",
+  "gpt-5-6-sol-high",
+  "glm-5.2-max",
 ];
 
 export function isChatPickerModelId(modelId: string): boolean {
@@ -24,8 +36,18 @@ export function isChatPickerModelId(modelId: string): boolean {
   );
 }
 
-/** Map retired picker ids to their successors. */
+/**
+ * Map retired picker ids to their successors.
+ *
+ * Effort variants collapse onto their base model here. The effort itself is not
+ * dropped — {@link unpackEffortVariant} recovers it for a chat that was pinned
+ * to the variant, so the chat keeps reasoning at the depth it was chosen for.
+ */
 export function migratePickerModelId(modelId: string): string {
+  const effortVariant = EFFORT_VARIANT_MODELS[modelId];
+  if (effortVariant) {
+    return effortVariant.modelId;
+  }
   if (
     modelId === "gpt-5.5-low" ||
     modelId === "gpt-5.5" ||
@@ -45,10 +67,7 @@ export function migratePickerModelId(modelId: string): string {
   if (modelId === "gemini-3.5-flash") {
     return "gemini-3.8-flash";
   }
-  if (
-    modelId === "gemini-3.6-flash" ||
-    modelId === "gemini-3.7-flash"
-  ) {
+  if (modelId === "gemini-3.6-flash" || modelId === "gemini-3.7-flash") {
     return "gemini-3.8-flash";
   }
   return modelId;
@@ -60,7 +79,7 @@ export const PICKER_DEFAULT_MODEL_IDS: readonly string[] = [
   "claude-opus-5",
   "claude-fable-5-1",
   "gpt-5-6-sol",
-  "glm-5.2-max",
+  "glm-5.2",
   "qwen/qwen3-32b",
   "gemini-3.5-flash-lite",
   "gemini-3.8-flash",
@@ -118,10 +137,7 @@ export const PRE_GEMINI_36_PICKER_DEFAULT_MODEL_IDS: readonly string[] = [
   "gemini-3.1-pro-preview",
 ];
 
-function sameModelIdSet(
-  a: readonly string[],
-  b: readonly string[],
-): boolean {
+function sameModelIdSet(a: readonly string[], b: readonly string[]): boolean {
   if (a.length !== b.length) return false;
   const setA = new Set(a);
   return b.every((id) => setA.has(id));
@@ -131,7 +147,7 @@ function sameModelIdSet(
 const CROSS_PROVIDER_DEFAULT_MARKERS: readonly string[] = [
   "gpt-5-6-sol",
   "gemini-3.8-flash",
-  "glm-5.2-max",
+  "glm-5.2",
   "qwen/qwen3-32b",
 ];
 

--- a/ui/hooks/useAgent.ts
+++ b/ui/hooks/useAgent.ts
@@ -17,6 +17,11 @@ import type {
 } from "../types/chat";
 import { useChatStore } from "../stores/chatStore";
 import { useTabStore } from "../stores/tabStore";
+import { useProviderAuthStore } from "../stores/providerAuthStore";
+import {
+  isProviderAuthRejection,
+  providerForModelId,
+} from "../utils/providerAuthRejection";
 import { gateway, GATEWAY_DISCONNECTED_ERROR } from "../src/lib/gateway";
 import { fetchChatHistory } from "../utils/chatHistoryApi";
 import { mapHistoryMessages } from "../utils/historyMapper";
@@ -845,6 +850,15 @@ export function useAgent() {
 
         case "done":
           {
+            // A completed turn proves the credentials work again, so retire any
+            // rejection we recorded for this provider.
+            const succeededProvider = providerForModelId(
+              useChatStore.getState().getLastSelectedModel(chatId),
+            );
+            if (succeededProvider) {
+              useProviderAuthStore.getState().clearRejection(succeededProvider);
+            }
+
             // Clear any pending batch update for this chat
             const existingTimeout = updateBatchRef.current.get(chatId);
             if (existingTimeout) {
@@ -1395,13 +1409,20 @@ export function useAgent() {
                   "The cloud agent session expired before your message was processed. Send your message again — Paprwork will start a fresh cloud agent automatically.";
               }
               // Pattern: Invalid API key (specific patterns, not just "API key" anywhere)
-              else if (
-                rawError.includes("Invalid API key") ||
-                rawError.includes("invalid x-api-key") ||
-                rawError.includes("authentication_error") ||
-                rawError.includes("(401)")
-              ) {
+              else if (isProviderAuthRejection(rawError)) {
                 errorMsg = `Invalid API key. Please check your API key in Settings.`;
+
+                // Remember which account was rejected so the AI Models card can
+                // say "reconnect" rather than counting down a stored expiry the
+                // provider has stopped honouring.
+                const rejectedProvider = providerForModelId(
+                  useChatStore.getState().getLastSelectedModel(chatId),
+                );
+                if (rejectedProvider) {
+                  useProviderAuthStore
+                    .getState()
+                    .recordRejection(rejectedProvider, errorMsg);
+                }
               }
               // Pattern: AI SDK tool validation errors (Zod validation failures)
               else if (

--- a/ui/hooks/useAgent.ts
+++ b/ui/hooks/useAgent.ts
@@ -74,6 +74,12 @@ import {
 } from "../lib/streamProfiler";
 
 const RATE_LIMIT_EXHAUSTED_ERROR_CODE = "rate_limit_exhausted";
+/**
+ * A limit that will not clear by waiting, so this deliberately does not reach
+ * for the Resume UI. Offering Resume for a spend cap that lifts in three weeks
+ * invites the user to keep pressing a button that cannot work.
+ */
+const PROVIDER_QUOTA_EXHAUSTED_ERROR_CODE = "provider_quota_exhausted";
 const RATE_LIMIT_WAIT_TEXT_PATTERN =
   /\n\n_Rate limited — waiting \d+s before retrying…_\n\n/g;
 
@@ -1308,6 +1314,31 @@ export function useAgent() {
               if (activeRequestId && activeRequestId !== requestId) {
                 return;
               }
+            }
+
+            if (payload.code === PROVIDER_QUOTA_EXHAUSTED_ERROR_CODE) {
+              console.warn(
+                `[useAgent] Provider quota exhausted for ${chatId} — surfacing the limit, no resume`,
+              );
+              setSending(chatId, false);
+              setConnectionPaused(chatId, false);
+              setFinishingWork(chatId, false);
+              // The gateway already composed a message naming the limit, the
+              // reset time and where to change it, so it is shown as-is rather
+              // than swapped for one of the generic rewrites below.
+              setError(rawError);
+
+              const streamingMessageId =
+                streamingMessageIdRef.current.get(chatId);
+              if (streamingMessageId) {
+                const cleaned = stripRateLimitWaitDeltas(
+                  streamingContentRef.current.get(chatId) || "",
+                );
+                streamingContentRef.current.set(chatId, cleaned);
+                flushStreamingState(chatId, { isStreaming: false });
+              }
+              untrackActiveStream(chatId);
+              break;
             }
 
             if (payload.code === RATE_LIMIT_EXHAUSTED_ERROR_CODE) {

--- a/ui/hooks/useChat.ts
+++ b/ui/hooks/useChat.ts
@@ -10,6 +10,7 @@ import { gateway } from "../src/lib/gateway";
 import { mapHistoryMessages } from "../utils/historyMapper";
 import { fetchChatHistory } from "../utils/chatHistoryApi";
 import { forgetChatModel } from "../utils/chatModelMemory";
+import { forgetChatSettings } from "../utils/chatModelSettings";
 import {
   chatHasLiveStreamBlockingHistory,
   mergeHistoryWithLocal,
@@ -316,6 +317,7 @@ export function useChat() {
       try {
         await gateway.send("chat:delete", { chatId });
         forgetChatModel(chatId);
+        forgetChatSettings(chatId);
         await loadChats(true);
         // Note: Tab management handled by tabStore (closeTab)
       } catch (error) {

--- a/ui/hooks/useChat.ts
+++ b/ui/hooks/useChat.ts
@@ -11,6 +11,7 @@ import { mapHistoryMessages } from "../utils/historyMapper";
 import { fetchChatHistory } from "../utils/chatHistoryApi";
 import { forgetChatModel } from "../utils/chatModelMemory";
 import { forgetChatSettings } from "../utils/chatModelSettings";
+import { forgetDraft } from "../utils/chatDraftStore";
 import {
   chatHasLiveStreamBlockingHistory,
   mergeHistoryWithLocal,
@@ -318,6 +319,7 @@ export function useChat() {
         await gateway.send("chat:delete", { chatId });
         forgetChatModel(chatId);
         forgetChatSettings(chatId);
+        forgetDraft(chatId);
         await loadChats(true);
         // Note: Tab management handled by tabStore (closeTab)
       } catch (error) {

--- a/ui/hooks/useModelPickerSettings.ts
+++ b/ui/hooks/useModelPickerSettings.ts
@@ -2,7 +2,7 @@
  * Loads and persists which models appear in the chat picker.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { gateway } from "../src/lib/gateway";
 import {
   PICKER_DEFAULT_MODEL_IDS,
@@ -105,9 +105,15 @@ export function useModelPickerSettings(): {
     await saveEnabledIds([...PICKER_DEFAULT_MODEL_IDS]);
   }, [saveEnabledIds]);
 
+  // Memoised because this array is a dependency of effects in ChatContainer.
+  // Rebuilding it on every render made those effects re-run on every render,
+  // which is harmless only for as long as every one of them bails out without
+  // setting state — far too sharp an edge to leave in place.
+  const pickerModels = useMemo(() => getPickerModels(enabledIds), [enabledIds]);
+
   return {
     enabledIds,
-    pickerModels: getPickerModels(enabledIds),
+    pickerModels,
     loaded,
     saveEnabledIds,
     resetToDefaults,

--- a/ui/hooks/useOAuth.ts
+++ b/ui/hooks/useOAuth.ts
@@ -17,6 +17,12 @@ export interface OAuthStatus {
   accountId?: string;
   expiresAt?: string;
   isExpired?: boolean;
+  /**
+   * Whether the stored refresh token can mint a new access token. An expired
+   * token that can renew fixes itself on the next request and must not be
+   * reported as broken; one that cannot is the only kind that needs the user.
+   */
+  canRenew?: boolean;
   error?: string;
   timedOut?: boolean;
   /** Set when Claude flow opened a terminal -- UI should show paste field */

--- a/ui/stores/chatStore.ts
+++ b/ui/stores/chatStore.ts
@@ -25,6 +25,7 @@ import {
   writeChatModel,
   writeNewChatDefaultModel,
 } from "../utils/chatModelMemory";
+import { renameChatSettings } from "../utils/chatModelSettings";
 
 // Re-export types for backward compatibility
 export type { ChatMetadata, ChatMessage, ChatState, StreamingState, SequenceItem, MessageAttachment };
@@ -358,9 +359,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     set((state) => {
       if (oldChatId === newChatId) return state;
 
-      // Carry the persisted model across the rename, or the chat loses it the
-      // moment its first message gives it a permanent id.
+      // Carry the persisted model and its dials across the rename, or the chat
+      // loses them the moment its first message gives it a permanent id.
       renameChatModel(oldChatId, newChatId);
+      renameChatSettings(oldChatId, newChatId);
 
       const oldState = state.chatStates.get(oldChatId);
       const newChatStates = new Map(state.chatStates);

--- a/ui/stores/chatStore.ts
+++ b/ui/stores/chatStore.ts
@@ -26,6 +26,12 @@ import {
   writeNewChatDefaultModel,
 } from "../utils/chatModelMemory";
 import { renameChatSettings } from "../utils/chatModelSettings";
+import {
+  forgetDraft,
+  readDraft,
+  renameDraft,
+  writeDraft,
+} from "../utils/chatDraftStore";
 
 // Re-export types for backward compatibility
 export type { ChatMetadata, ChatMessage, ChatState, StreamingState, SequenceItem, MessageAttachment };
@@ -363,6 +369,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       // loses them the moment its first message gives it a permanent id.
       renameChatModel(oldChatId, newChatId);
       renameChatSettings(oldChatId, newChatId);
+      // Reachable: a user can start typing a *second* message while the first
+      // is still streaming, which is exactly when this rename happens.
+      renameDraft(oldChatId, newChatId);
 
       const oldState = state.chatStates.get(oldChatId);
       const newChatStates = new Map(state.chatStates);
@@ -603,10 +612,16 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     }),
 
   // Draft message management (separate map — avoids invalidating message list on save)
-  setDraftMessage: (chatId, draft) =>
+  //
+  // The map is a cache; `chatDraftStore` is the durable copy. Unsent text is
+  // the one piece of chat state that exists nowhere else — messages come back
+  // from the server, a half-typed message does not — so it is also written to
+  // localStorage here, on the same debounce that already fed this map.
+  setDraftMessage: (chatId, draft) => {
+    const prev = get().draftByChatId.get(chatId) ?? "";
+    if (prev === draft) return;
+    writeDraft(chatId, draft);
     set((state) => {
-      const prev = state.draftByChatId.get(chatId) ?? "";
-      if (prev === draft) return state;
       const draftByChatId = new Map(state.draftByChatId);
       if (draft) {
         draftByChatId.set(chatId, draft);
@@ -614,17 +629,26 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         draftByChatId.delete(chatId);
       }
       return { draftByChatId };
-    }),
+    });
+  },
 
-  getDraftMessage: (chatId) => get().draftByChatId.get(chatId) ?? "",
+  // Falls back to the durable copy, so a draft survives anything that empties
+  // the in-memory map: a reload, a renderer crash, a workspace switch.
+  getDraftMessage: (chatId) => {
+    const cached = get().draftByChatId.get(chatId);
+    if (cached !== undefined) return cached;
+    return readDraft(chatId);
+  },
 
-  clearDraftMessage: (chatId) =>
+  clearDraftMessage: (chatId) => {
+    forgetDraft(chatId);
     set((state) => {
       if (!state.draftByChatId.has(chatId)) return state;
       const draftByChatId = new Map(state.draftByChatId);
       draftByChatId.delete(chatId);
       return { draftByChatId };
-    }),
+    });
+  },
 
   setLastSelectedModel: (chatId, modelId) =>
     set((state) => {

--- a/ui/stores/providerAuthStore.ts
+++ b/ui/stores/providerAuthStore.ts
@@ -1,0 +1,47 @@
+/**
+ * Provider Auth Store - remembers that a provider rejected our credentials.
+ *
+ * A 401 surfaces during a chat turn, but the place a user goes to fix it is
+ * Settings, in a different component tree. Both run in the renderer, so the
+ * rejection only needed recording rather than a round trip: the AI Models card
+ * reads this to say "reconnect" instead of showing a countdown that reflects a
+ * stored expiry the provider has already stopped honouring.
+ *
+ * Deliberately not persisted. It records a rejection we actually observed, so
+ * on restart we hold no evidence and should not imply we do.
+ */
+
+import { create } from "zustand";
+import type { Provider } from "../../src/core/types/agents";
+
+export interface ProviderAuthRejection {
+  message: string;
+  /** Epoch ms of the rejection. */
+  at: number;
+}
+
+interface ProviderAuthState {
+  rejections: Partial<Record<Provider, ProviderAuthRejection>>;
+  recordRejection: (provider: Provider, message: string) => void;
+  clearRejection: (provider: Provider) => void;
+}
+
+export const useProviderAuthStore = create<ProviderAuthState>((set) => ({
+  rejections: {},
+
+  recordRejection: (provider, message) =>
+    set((state) => ({
+      rejections: {
+        ...state.rejections,
+        [provider]: { message, at: Date.now() },
+      },
+    })),
+
+  clearRejection: (provider) =>
+    set((state) => {
+      if (!state.rejections[provider]) return state;
+      const rejections = { ...state.rejections };
+      delete rejections[provider];
+      return { rejections };
+    }),
+}));

--- a/ui/utils/buildAgentConfig.ts
+++ b/ui/utils/buildAgentConfig.ts
@@ -1,0 +1,131 @@
+/**
+ * One place that turns "model + the user's choices" into the config a turn runs on.
+ *
+ * `ChatContainer` built this object inline at three separate call sites (send,
+ * auto-continue, stream recovery). Three copies of a shape that decides what a
+ * request costs is how a control ends up applying on send but not on retry, so
+ * the shape lives here now and the call sites pass their differences in.
+ *
+ * Precedence is: the chat's explicit choice, then the model's own default, then
+ * nothing — a field the user never touched is left off the request entirely so
+ * the provider applies its own default rather than one we invented.
+ */
+
+import type { AIModel } from "../constants/models";
+import {
+  DEFAULT_CONTEXT_LIMIT,
+  contextOptionsForModel,
+  effortLevelsForModel,
+  modelSupportsEffort,
+  modelSupportsFast,
+  modelSupportsThinkingToggle,
+  type EffortLevel,
+} from "../constants/modelControls";
+import type { ChatModelSettings } from "./chatModelSettings";
+
+export interface ResolvedModelSettings {
+  thinking: boolean;
+  effort?: EffortLevel;
+  contextLimit: number;
+  fast: boolean;
+}
+
+export interface BuildAgentConfigInput {
+  model: AIModel;
+  settings: ChatModelSettings;
+  systemPrompt: string;
+  /** Fast mode is API-key only; pi-ai has no `speed` parameter. */
+  authType?: "oauth" | "apiKey";
+}
+
+export interface BuiltAgentConfig {
+  provider: AIModel["provider"];
+  model: string;
+  systemPrompt: string;
+  reasoning?: { effort: EffortLevel };
+  thinkingBudget?: number;
+  maxTokens?: number;
+  contextLimit: number;
+  /** Only ever `false`, and only when the user turned reasoning off. */
+  thinking?: false;
+  speed?: "fast";
+}
+
+/**
+ * Effective settings for a model, after dropping anything it cannot honour.
+ *
+ * A stored value is kept only while it remains valid: switching a chat from a
+ * 1M-window model to a 131K one must not keep sending a 1M budget, and a `max`
+ * effort saved under GLM must not survive a move to a provider that tops out
+ * at `high`.
+ */
+export function resolveModelSettings(
+  model: AIModel,
+  settings: ChatModelSettings,
+): ResolvedModelSettings {
+  const allowedEfforts = effortLevelsForModel(model);
+  const requestedEffort = settings.effort;
+  const modelDefaultEffort = model.reasoning?.effort;
+
+  let effort: EffortLevel | undefined;
+  if (modelSupportsEffort(model)) {
+    effort =
+      requestedEffort && allowedEfforts.includes(requestedEffort)
+        ? requestedEffort
+        : modelDefaultEffort;
+  }
+
+  const contextOptions = contextOptionsForModel(model);
+  const requestedContext = settings.contextLimit;
+  const contextLimit =
+    requestedContext && contextOptions.includes(requestedContext)
+      ? requestedContext
+      : // Default to the narrowest offered choice. Every token inside the
+        // budget is re-sent on each step of a turn, so starting wide is what
+        // quietly runs up a bill.
+        Math.min(...contextOptions, DEFAULT_CONTEXT_LIMIT);
+
+  return {
+    thinking: modelSupportsThinkingToggle(model)
+      ? (settings.thinking ?? true)
+      : true,
+    effort,
+    contextLimit,
+    fast: settings.fast === true,
+  };
+}
+
+export function buildAgentConfig(
+  input: BuildAgentConfigInput,
+): BuiltAgentConfig {
+  const { model, settings, systemPrompt, authType } = input;
+  const resolved = resolveModelSettings(model, settings);
+
+  const config: BuiltAgentConfig = {
+    provider: model.provider,
+    model: model.id,
+    systemPrompt,
+    maxTokens: model.maxTokens,
+    contextLimit: resolved.contextLimit,
+  };
+
+  if (resolved.effort) {
+    config.reasoning = { effort: resolved.effort };
+  }
+
+  // `thinkingBudget: 0` cannot mean "off": Opus 5 and Fable 5.1 ship a default
+  // budget of 0 and still think adaptively. So the off state is its own flag,
+  // and it is sent only when the user actually set it.
+  if (resolved.thinking) {
+    config.thinkingBudget = model.defaultThinkingBudget;
+  } else {
+    config.thinking = false;
+    config.thinkingBudget = 0;
+  }
+
+  if (resolved.fast && modelSupportsFast(model, authType)) {
+    config.speed = "fast";
+  }
+
+  return config;
+}

--- a/ui/utils/chatDraftStore.ts
+++ b/ui/utils/chatDraftStore.ts
@@ -1,0 +1,172 @@
+/**
+ * Unsent composer text, kept somewhere it can survive the app dying.
+ *
+ * Drafts lived only in a Zustand `Map`, which meant a renderer crash, a reload
+ * or a workspace switch threw away whatever the user was mid-way through
+ * typing. The type even called the field "Persisted draft message for this
+ * chat" — it was not persisted anywhere.
+ *
+ * A draft is the one piece of chat state the user cannot reproduce: messages
+ * come back from the server, but text that was never sent exists nowhere else.
+ * So it is written straight to `localStorage`, synchronously, on the same
+ * debounce that already fed the store. Nothing here depends on React, so it
+ * still runs when the tree above it has thrown.
+ */
+
+/** chatId -> unsent text. Insertion-ordered; oldest entries evicted first. */
+const DRAFTS_KEY = "paprwork_chat_drafts";
+
+/**
+ * Cap on remembered drafts. Kept well below the model map's 200 because a
+ * draft is a whole message rather than an id, and `localStorage` is a shared
+ * ~5MB budget for the entire renderer.
+ */
+export const MAX_REMEMBERED_DRAFTS = 50;
+
+/**
+ * Cap on one draft, in characters.
+ *
+ * A composer accepts pasted input, so this is attacker-shaped in the ordinary
+ * sense that a user can paste a novel into it. Without a cap one paste could
+ * consume the whole storage budget and start throwing quota errors on every
+ * other key in the app.
+ */
+export const MAX_DRAFT_CHARS = 100_000;
+
+type DraftMap = Record<string, string>;
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch {
+    // Storage can throw outright when disabled by policy.
+    return null;
+  }
+}
+
+function readMap(): DraftMap {
+  const store = storage();
+  if (!store) {
+    return {};
+  }
+  try {
+    const raw = store.getItem(DRAFTS_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const clean: DraftMap = {};
+    for (const [chatId, draft] of Object.entries(parsed)) {
+      if (typeof chatId === "string" && typeof draft === "string" && draft) {
+        clean[chatId] = draft;
+      }
+    }
+    return clean;
+  } catch {
+    return {};
+  }
+}
+
+function writeMap(map: DraftMap): void {
+  const store = storage();
+  if (!store) {
+    return;
+  }
+  try {
+    store.setItem(DRAFTS_KEY, JSON.stringify(map));
+  } catch {
+    // Over quota. Drop everything but the chat we just wrote rather than
+    // leaving the draft unsaved: the newest draft is the one being typed, and
+    // it is the only one the user would notice losing.
+    const chatIds = Object.keys(map);
+    const newest = chatIds[chatIds.length - 1];
+    if (!newest) {
+      return;
+    }
+    try {
+      store.setItem(DRAFTS_KEY, JSON.stringify({ [newest]: map[newest] }));
+    } catch {
+      /* storage is unusable — drafts degrade to in-memory only */
+    }
+  }
+}
+
+/** The unsent text for one chat, or "" when there is none. */
+export function readDraft(chatId: string): string {
+  if (!chatId) {
+    return "";
+  }
+  return readMap()[chatId] ?? "";
+}
+
+/**
+ * Record the unsent text for one chat. Writing an existing chat refreshes its
+ * position, so the chats a user is actively typing in are evicted last.
+ *
+ * An empty draft removes the entry rather than storing "", so a cleared
+ * composer does not occupy a slot.
+ */
+export function writeDraft(chatId: string, draft: string): void {
+  if (!chatId) {
+    return;
+  }
+
+  const map = readMap();
+  delete map[chatId];
+
+  if (draft) {
+    map[chatId] = draft.slice(0, MAX_DRAFT_CHARS);
+  }
+
+  const chatIds = Object.keys(map);
+  if (chatIds.length > MAX_REMEMBERED_DRAFTS) {
+    for (const stale of chatIds.slice(
+      0,
+      chatIds.length - MAX_REMEMBERED_DRAFTS,
+    )) {
+      delete map[stale];
+    }
+  }
+
+  writeMap(map);
+}
+
+/** Forget a chat's draft — on send, or when the chat is deleted. */
+export function forgetDraft(chatId: string): void {
+  if (!chatId) {
+    return;
+  }
+  const map = readMap();
+  if (!(chatId in map)) {
+    return;
+  }
+  delete map[chatId];
+  writeMap(map);
+}
+
+/**
+ * Carry a draft across the temp-id -> permanent-id rename.
+ *
+ * Reachable in practice: the first message of a new chat triggers the rename,
+ * and a user can start typing a *second* message while that first one is still
+ * streaming.
+ */
+export function renameDraft(oldChatId: string, newChatId: string): void {
+  if (!oldChatId || !newChatId || oldChatId === newChatId) {
+    return;
+  }
+  const map = readMap();
+  const draft = map[oldChatId];
+  if (!draft) {
+    return;
+  }
+  delete map[oldChatId];
+  map[newChatId] = draft;
+  writeMap(map);
+}

--- a/ui/utils/chatModelSettings.ts
+++ b/ui/utils/chatModelSettings.ts
@@ -1,0 +1,250 @@
+/**
+ * Thinking / effort / context / fast, remembered per chat.
+ *
+ * Mirrors {@link ./chatModelMemory} deliberately, including its central lesson:
+ * a read for one chat must never fall back to a global value, or one chat's
+ * choices leak into another and silently change what the next turn costs. The
+ * global entry here is only ever the seed for a chat that has none of its own.
+ *
+ * Settings are stored sparsely — a key is written only once the user changes it
+ * — so "unset" stays distinguishable from "set to the default". That matters
+ * because model defaults differ (GLM ships at max effort, GPT at medium), and
+ * an unset chat should follow its model rather than a value we invented.
+ */
+
+import {
+  unpackEffortVariant,
+  type EffortLevel,
+} from "../constants/modelControls";
+
+export interface ChatModelSettings {
+  thinking?: boolean;
+  effort?: EffortLevel;
+  contextLimit?: number;
+  fast?: boolean;
+}
+
+/** chatId -> settings. Insertion-ordered; oldest entries are evicted first. */
+const PER_CHAT_KEY = "paprwork_chat_model_settings";
+
+/** Seed for a brand-new chat. */
+const NEW_CHAT_DEFAULT_KEY = "paprwork_default_model_settings";
+
+/** Matches {@link ./chatModelMemory}: this map is written for the life of the install. */
+export const MAX_REMEMBERED_CHATS = 200;
+
+type SettingsMap = Record<string, ChatModelSettings>;
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch {
+    // Storage can throw outright when disabled by policy.
+    return null;
+  }
+}
+
+const VALID_EFFORTS = new Set<string>([
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
+
+/**
+ * Keep only well-formed fields rather than trusting the stored blob. A bad
+ * value here becomes a request parameter, so it is worth dropping silently.
+ */
+export function sanitizeSettings(value: unknown): ChatModelSettings | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const raw = value as Record<string, unknown>;
+  const clean: ChatModelSettings = {};
+
+  if (typeof raw.thinking === "boolean") {
+    clean.thinking = raw.thinking;
+  }
+  if (typeof raw.effort === "string" && VALID_EFFORTS.has(raw.effort)) {
+    clean.effort = raw.effort as EffortLevel;
+  }
+  if (
+    typeof raw.contextLimit === "number" &&
+    Number.isFinite(raw.contextLimit) &&
+    raw.contextLimit > 0
+  ) {
+    clean.contextLimit = Math.floor(raw.contextLimit);
+  }
+  if (typeof raw.fast === "boolean") {
+    clean.fast = raw.fast;
+  }
+
+  return Object.keys(clean).length > 0 ? clean : null;
+}
+
+function readMap(): SettingsMap {
+  const store = storage();
+  if (!store) {
+    return {};
+  }
+  try {
+    const raw = store.getItem(PER_CHAT_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const clean: SettingsMap = {};
+    for (const [chatId, settings] of Object.entries(parsed)) {
+      const sanitized = sanitizeSettings(settings);
+      if (chatId && sanitized) {
+        clean[chatId] = sanitized;
+      }
+    }
+    return clean;
+  } catch {
+    return {};
+  }
+}
+
+function writeMap(map: SettingsMap): void {
+  const store = storage();
+  if (!store) {
+    return;
+  }
+  try {
+    store.setItem(PER_CHAT_KEY, JSON.stringify(map));
+  } catch {
+    /* quota or disabled storage — settings degrade to in-memory only */
+  }
+}
+
+/** Settings this chat has explicitly established, if any. */
+export function readChatSettings(chatId: string): ChatModelSettings {
+  if (!chatId) {
+    return {};
+  }
+  return readMap()[chatId] ?? {};
+}
+
+/**
+ * Merge a change into one chat's settings. Re-writing refreshes the entry's
+ * position, so chats the user returns to are the last to be evicted.
+ */
+export function writeChatSettings(
+  chatId: string,
+  patch: ChatModelSettings,
+): ChatModelSettings {
+  if (!chatId) {
+    return {};
+  }
+
+  const map = readMap();
+  const merged = sanitizeSettings({ ...map[chatId], ...patch }) ?? {};
+
+  delete map[chatId];
+  map[chatId] = merged;
+
+  const chatIds = Object.keys(map);
+  if (chatIds.length > MAX_REMEMBERED_CHATS) {
+    for (const stale of chatIds.slice(
+      0,
+      chatIds.length - MAX_REMEMBERED_CHATS,
+    )) {
+      delete map[stale];
+    }
+  }
+
+  writeMap(map);
+  return merged;
+}
+
+/** Forget a chat's settings — call when the chat is deleted. */
+export function forgetChatSettings(chatId: string): void {
+  if (!chatId) {
+    return;
+  }
+  const map = readMap();
+  if (!(chatId in map)) {
+    return;
+  }
+  delete map[chatId];
+  writeMap(map);
+}
+
+/**
+ * Carry settings across the temp-id -> permanent-id rename on a chat's first
+ * message, so choices made before sending are not lost when it is persisted.
+ */
+export function renameChatSettings(oldChatId: string, newChatId: string): void {
+  if (!oldChatId || !newChatId || oldChatId === newChatId) {
+    return;
+  }
+  const map = readMap();
+  const settings = map[oldChatId];
+  if (!settings) {
+    return;
+  }
+  delete map[oldChatId];
+  map[newChatId] = settings;
+  writeMap(map);
+}
+
+/**
+ * Carry a retired effort-variant model's effort into the chat's own settings.
+ *
+ * A chat pinned to `gpt-5-6-sol-high` now resolves to `gpt-5-6-sol`, and
+ * without this it would quietly drop from high effort to the model's default.
+ * An effort the user has since set explicitly wins — this only fills the gap.
+ *
+ * @returns the effort that was adopted, or null when there was nothing to do.
+ */
+export function adoptEffortFromVariant(
+  chatId: string,
+  pinnedModelId: string | null | undefined,
+): EffortLevel | null {
+  if (!chatId || !pinnedModelId) {
+    return null;
+  }
+  const { effort } = unpackEffortVariant(pinnedModelId);
+  if (!effort) {
+    return null;
+  }
+  if (readChatSettings(chatId).effort) {
+    return null;
+  }
+  writeChatSettings(chatId, { effort });
+  return effort;
+}
+
+/** What a brand-new chat should open with. Global on purpose. */
+export function readNewChatDefaultSettings(): ChatModelSettings {
+  const store = storage();
+  if (!store) {
+    return {};
+  }
+  try {
+    const raw = store.getItem(NEW_CHAT_DEFAULT_KEY);
+    return raw ? (sanitizeSettings(JSON.parse(raw)) ?? {}) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function writeNewChatDefaultSettings(settings: ChatModelSettings): void {
+  const store = storage();
+  if (!store) {
+    return;
+  }
+  try {
+    store.setItem(NEW_CHAT_DEFAULT_KEY, JSON.stringify(settings));
+  } catch {
+    /* ignore */
+  }
+}

--- a/ui/utils/chatModelSettings.ts
+++ b/ui/utils/chatModelSettings.ts
@@ -24,6 +24,26 @@ export interface ChatModelSettings {
   fast?: boolean;
 }
 
+/**
+ * Do two settings objects mean the same thing?
+ *
+ * Every read here builds a fresh object, so React state holding one of these
+ * cannot be compared by reference: setting it from a re-read would always look
+ * like a change, and an effect that both depends on state and re-reads it would
+ * spin. Callers use this to bail out instead.
+ */
+export function sameSettings(
+  a: ChatModelSettings,
+  b: ChatModelSettings,
+): boolean {
+  return (
+    a.thinking === b.thinking &&
+    a.effort === b.effort &&
+    a.contextLimit === b.contextLimit &&
+    a.fast === b.fast
+  );
+}
+
 /** chatId -> settings. Insertion-ordered; oldest entries are evicted first. */
 const PER_CHAT_KEY = "paprwork_chat_model_settings";
 

--- a/ui/utils/providerAuthRejection.ts
+++ b/ui/utils/providerAuthRejection.ts
@@ -1,0 +1,32 @@
+import type { Provider } from "../../src/core/types/agents";
+import { CHAT_MODELS } from "../constants/models";
+
+/**
+ * Whether a stream error means the provider rejected our credentials, as
+ * opposed to a rate limit, an overload, or a bad tool call.
+ *
+ * The gateway usually rewrites a 401 into "Invalid API key. Please check your
+ * API key in Settings." before it reaches us, but the raw Anthropic body
+ * ("OAuth access token is invalid.") reaches the renderer on some paths, so
+ * both shapes are matched here.
+ */
+export function isProviderAuthRejection(rawError: string): boolean {
+  return (
+    rawError.includes("Invalid API key") ||
+    rawError.includes("invalid x-api-key") ||
+    rawError.includes("authentication_error") ||
+    rawError.includes("OAuth access token") ||
+    rawError.includes("(401)")
+  );
+}
+
+/**
+ * Which provider a model belongs to. Used to attribute a rejection to the
+ * account the user would go fix, since the error itself does not say.
+ */
+export function providerForModelId(
+  modelId: string | undefined,
+): Provider | undefined {
+  if (!modelId) return undefined;
+  return CHAT_MODELS.find((model) => model.id === modelId)?.provider;
+}

--- a/ui/utils/providerConnectionState.ts
+++ b/ui/utils/providerConnectionState.ts
@@ -1,0 +1,97 @@
+/**
+ * One connection state for a provider card, derived from every signal we have.
+ *
+ * The card used to render three signals independently — a badge on the provider
+ * card (does a key row exist), a badge on the OAuth panel (is a token stored),
+ * and an expiry line (when does it lapse) — and nothing reconciled them. They
+ * could each be right on their own terms and still combine into a lie: an
+ * expired Claude token showed "OAuth", "Connected" and "Expired" at once, two
+ * of them green, while requests were quietly being served by the platform API
+ * key instead. Deriving one state in one place is what makes that impossible.
+ */
+
+export type ProviderConnectionState =
+  /** Card is in API-key mode; OAuth is deliberately unused. */
+  | { kind: "api_key_mode"; configured: boolean }
+  /** No OAuth token stored. */
+  | { kind: "disconnected" }
+  /** Token stored and usable — either live, or expired but renewable. */
+  | { kind: "connected" }
+  /** Token stored but cannot authenticate. Needs the user. */
+  | {
+      kind: "needs_signin";
+      /**
+       * `rejected` is observed (a turn came back 401), `expired` is derived
+       * from the stored expiry. Both mean unusable; they differ only in how
+       * we found out, which is worth saying because a rejection can happen
+       * while the clock still looks fine.
+       */
+      reason: "expired" | "rejected";
+      /**
+       * A real platform API key is present, so requests keep succeeding
+       * against a separate account with its own billing and caps rather than
+       * failing. Silence here is what made a subscription at 11% usage report
+       * that its limits were exhausted.
+       */
+      fallsBackToApiKey: boolean;
+    };
+
+export interface ProviderConnectionInputs {
+  /** Which credential the agent actually runs on, persisted in main. */
+  mode: "oauth" | "apiKey";
+  /** A stored key the user supplied, excluding the synced OAuth token. */
+  platformApiKeyConfigured: boolean;
+  status: {
+    connected: boolean;
+    isExpired?: boolean;
+    /** Whether the stored refresh token can mint a new access token. */
+    canRenew?: boolean;
+  };
+  /** A turn failed with 401 since the last reconnect. */
+  authRejected: boolean;
+}
+
+export function deriveProviderConnectionState(
+  inputs: ProviderConnectionInputs,
+): ProviderConnectionState {
+  const { mode, platformApiKeyConfigured, status, authRejected } = inputs;
+
+  if (mode === "apiKey") {
+    return { kind: "api_key_mode", configured: platformApiKeyConfigured };
+  }
+
+  if (!status.connected) return { kind: "disconnected" };
+
+  // Observed rejection outranks the clock: the provider refusing the token is
+  // stronger evidence than our own record of when we thought it lapsed.
+  if (authRejected) {
+    return {
+      kind: "needs_signin",
+      reason: "rejected",
+      fallsBackToApiKey: platformApiKeyConfigured,
+    };
+  }
+
+  // Expired but renewable is not a problem to show anyone — the next request
+  // refreshes it. Only an expiry with no way back needs the user.
+  if (status.isExpired === true && status.canRenew !== true) {
+    return {
+      kind: "needs_signin",
+      reason: "expired",
+      fallsBackToApiKey: platformApiKeyConfigured,
+    };
+  }
+
+  return { kind: "connected" };
+}
+
+/**
+ * Whether the state may be shown in the affirmative (green). Kept as its own
+ * function so the several places that render a badge cannot drift on it.
+ */
+export function isHealthyConnection(state: ProviderConnectionState): boolean {
+  return (
+    state.kind === "connected" ||
+    (state.kind === "api_key_mode" && state.configured)
+  );
+}


### PR DESCRIPTION
Fixes that arrived together from one debugging session. Independent, but they share a branch because they were found and fixed in sequence — each one surfaced the next.

## 1. Claude OAuth — four defects in one credential path

The reported symptom was `OAuth access token is invalid.` on the turn after switching Claude from an API key to OAuth, while Settings said **Connected · Expires in 360d**. Fixing that exposed three more in the same path.

### 1a. A fabricated token lifetime

Adopting Claude Code's credentials read only `accessToken`, then **invented** the other two fields: `refreshToken` was set to a copy of the access token, and `expiresIn` to a flat 365 days. Claude Code's access token lasts about 8 hours, so requests began failing the same day — and neither recovery path could fire. `isTokenExpired()` never returned true because the invented year had not elapsed; had it fired, the refresh grant would have posted an *access* token as a refresh token, which can only fail. Claude Code stores all three fields. We were reading one.

Now parsed as stored, in one place (`claudeCliCredentials.ts`). **Existing installs repair themselves** — `refreshTokenIfNeeded` re-reads Claude Code's storage and adopts its real refresh token and expiry, so no disconnect/reconnect is needed. A pasted setup token, which genuinely has no refresh token, is still accepted.

The badge could not be honest without the data fix: it showed a countdown while every request 401'd. The renderer already sees that error when a turn fails, so no new network call was needed — the AI Models card now swaps the countdown for **Reconnect needed**. Deliberately not persisted: it records a rejection we *observed*, so after a restart we hold no evidence and should not claim any.

### 1b. Refresh posted to a Cloudflare-protected endpoint, and the provider's real error was swallowed

Refresh hit `claude.ai/api/oauth/token` and came back `403` with a `Just a moment...` interstitial. Now posted to the platform endpoint with a JSON body, matching what pi-ai does successfully.

Separately, a plain usage-limit rejection reached the user as `API error (400):` with an empty message, then as a generic "No output generated". Anthropic had said exactly what was wrong — *"You have reached your specified API usage limits. You will regain access on 2026-10-01"* — in `responseBody`/`data`, which nothing read. Extraction now prefers the provider's own message, and `NoOutputGeneratedError` can no longer overwrite a more specific error that was already reported.

### 1c. The card claimed a connection it did not have

Connect short-circuited on *finding* credentials in Claude Code's storage rather than on their being usable, so pressing **Connect** re-adopted the same dead token and reported success. The header stayed green while the only thing actually authenticating was the API key — a silent downgrade that also explains why a "Claude OAuth" session was billing against platform limits.

Connection state is now derived once, as a discriminated union, from every signal that bears on it (mode, key configured, expiry, renewability, observed rejection). Expiry alone is not an alarm — a token that *can* refresh fixes itself on the next request — so `canRenew` is now part of the IPC payload, and only "expired with no way back" asks for the user.

### 1d. An expired Keychain credential overwrote a working one

A manually saved token would work, then silently revert. The refresh timer fired, Anthropic answered `invalid_grant`, and the failure handler adopted Claude Code's Keychain copy as "recovery" — one whose access token had expired **136 days** earlier. Adopting it wrote a negative `expiresIn`, so the replacement was expired on arrival and armed the very next tick to do it again.

The guard at the adoption site checked that a refresh token was *present*, never that anything was still live.

> Worth flagging for review: `claudeCredentialsAreUsable`, added in **1c**, would **not** have fixed this. It counts a refresh token as evidence of usability, so it returns `true` for that expired credential. The two predicates answer different questions. That one asks *"could these ever authenticate?"* — the right test for whether Connect should short-circuit. Adoption asks *"will replacing what I hold with this leave me better off?"*, and there a refresh token earns nothing, because the only moment adoption runs as recovery is immediately after a refresh token was rejected.

- `claudeAccessTokenIsLive` gates adoption on the expiry itself. An *absent* expiry still counts as live, so pasted setup-tokens keep working.
- Adoption cannot trade down: the recovery site passes the stored expiry as the bar to beat.
- A grant the provider answered `invalid_grant` to is remembered and not re-posted — that was what pulled the trigger every tick. Keyed by token value, so a newly issued one is never covered by an older verdict, and held in memory because it records an observed rejection. Only `invalid_grant` condemns a token; a Cloudflare 403 or a timeout says nothing about it and stays retryable.
- `canRenew` consults that record, so the card stops promising a renewal that cannot happen.

## 2. "Today's Brief" showed `database is locked`

The dashboard hung on "Loading today's brief", and startup re-logged the same migration-repair failure every launch. A lock was treated as permanent at every layer it reached:

- **Nothing waited.** `connectTursoReplica` passes no busy timeout and retries only host-not-ready. Every `better-sqlite3` path here waits out a contended file — 3s on the mini-app read worker, 5s on the CDC writer. The replica engine had no equivalent, so a read landing during a push or migration failed on its first attempt.
- **The one retry that existed didn't recognise it.** `runQuery` recovers only for `isReplicaReadTransportError` (checkpoint errors, timeouts, gen drift). `"database is locked"` matches none, so it rethrew straight through `DbRouter` → `/api/db/query-batch` → `data.js`, which renders the raw string. That is the verbatim path from engine to screen.
- **The startup repair gave up for the session**, leaving the drift it exists to heal in place — which is why the same warning returned on every launch.
- **The busy detector was too narrow to fire.** It checked only `code === "SQLITE_BUSY"`, which only one of the two engines on these files sets. Every "defer and retry" branch silently never ran for replica-backed databases — while a second, *correct* copy of the predicate already existed elsewhere in the repo.

The obvious fix would have been destructive: adding the lock to `isReplicaReadTransportError` routes it into recovery that **resets the sync sidecars**. A lock means the previous holder is mid-flight, so the remedy is to wait, not to operate on its files. Contention and damage get separate classifiers, and a test pins them disjoint.

> **Note for review:** this corrects an existing assertion that required the narrow behaviour. It carried no rationale, arrived in a squashed commit, and disagreed with the later sibling implementation — so it pinned the implementation rather than a requirement. Reasoning recorded in the test.

## 3. Turso push livelock, and cutover blocks that outlived their cause

One database logged `Backlog remains — queued follow-up push` continuously, burning CPU while shipping nothing. Two problems, stacked:

- **An unbounded requeue.** A push reporting `all_tables_unchanged` was still re-queued at the front of the queue whenever `linkedSourceNeedsPush` disagreed. The push path and the dirty check used different criteria, so the disagreement was permanent and the loop could never end. Completion now distinguishes "shipped work" from "shipped nothing"; consecutive no-progress rounds hit a cap and fall into the existing failure backoff, which the scan loop now honours.

- **A block that outlived the bug that wrote it.** The record was pinned to the legacy path by `cutoverBlocked` with reason `Migration SQL missing for __schema_drift_heal__…`. Nothing re-examines that verdict — a blocked record short-circuits classification before reaching any real check, and only an explicit user action clears it. That is correct while the cause exists and wrong the moment a fix makes it impossible: synthetic drift-heal ids never have a `.sql` file by design and are now treated as a no-op, so the block was a fossil. Retired blocks are recognised and cleared automatically. Deliberately narrow — a genuine missing migration stays blocked.

## 4. Per-chat model controls — thinking, fast, context, effort

The four things that decide what a turn costs were unreachable from the composer, so a chat ran at whatever the model advertised. On a 1M-window model the history budget computes to ~636K tokens, and everything in that budget is re-sent on **every step** of a turn that can run to 100 steps.

One popover, governed by a single rule: **a row appears only when the request can actually carry it**. Capability is derived from the model, not hand-listed. Context is **200K / 400K / 1M defaulting to 200K** — defaulting low is the part that saves money — and is only ever a cap, never a widener. Effort variants collapse into base + effort (picker: ~11 rows → ~7) with migration for pinned chats.

Two traps worth naming:
- **`thinkingBudget: 0` cannot mean "thinking off".** Opus 5 and Fable 5.1 ship `defaultThinkingBudget: 0` and still think adaptively, so overloading it would have silently disabled reasoning on exactly the models people reach for it on. The off state is its own field.
- **Anthropic `effort` is an adaptive-thinking field.** Sonnet 4.6 / Haiku 4.5 / Opus 4.6 have no such field. The UI gate and the gateway gate call the *same* predicate rather than mirroring a list, so a control can't offer what the request would drop.

## 5. A render error wiped the composer and looked like an app reload

Three defects, only one of which was the crash:

- **Nothing contained a render error.** With no error boundary anywhere in the tree, React unmounted the entire app on any throw — indistinguishable from a reload. React's own console output had been saying so.
- **The draft existed in exactly one place, and it was volatile.** Unsent text is the only chat state with no other copy: messages come back from the server, a half-typed message does not. Now durable per chat, with LRU eviction and a `pagehide` flush to close the debounce window.
- **An infinite render loop.** `pickerModels` was a new array identity every render, and the effect depending on it set a freshly-built object every time. Fixed at **both** ends — memoise the array, and compare settings by content — because fixing one leaves the other as a live trap for the next effect added.

## 6. Duplicate React keys in related memories

Papr search returns a memory once per matching chunk, so the list carried the same id several times. The UI keys by id *and* resolves "which one is open" with a find-by-id, so a repeat broke reconciliation and made the lookup ambiguous. Deduped where the data is produced — the key warning was the symptom, not the bug.

---

## Testing

New: `claude-cli-credentials` (13), `provider-auth-rejection` (10), `provider-connection-state` (16), `provider-error-message` (22), `oauth-credential-adoption` (13), `retired-cutover-blocks`, `model-controls` (40), `chat-draft-store` (21), `render-loop-invariants` (10), `useModelPickerSettings` (3), `wiki-related-memories` (8), `replica-busy-retry` (15).

The OAuth adoption tests are built against the exact expired credential from the report, and one of them pins the distinction in **1d** — that `claudeCredentialsAreUsable` returns `true` where `claudeAccessTokenIsLive` returns `false` — so a future refactor cannot quietly collapse the two predicates back together.

Type-check unchanged at the pre-existing 321 errors, none in touched files. Lint clean. Turso/replica and push-scheduler suites verified against a stashed baseline to confirm **no regressions** — the remaining failures there are pre-existing workspace-isolation harness issues that read the real user workspace, identical before and after.

## Not covered

- Anthropic still rejects the refresh token from the manual setup flow. **1d** stops a manual token being overwritten, but it does not make refresh work — that token sticks until it genuinely expires, then the flow has to be repeated. A stale Claude Code login is the underlying cause and is a user action, not a code fix.
- `src/electron/ipc/oauth.ts` is now ~1050 lines, over the 500-line house rule. It was already 966 before this branch, so it is not split here; worth a separate pass.
- Fable 5.1 producing no output at all is a separate defect (AI SDK v6 `maxOutputTokens` rename + Anthropic `display: "summarized"`) — see #140.
- Token usage from an AI-SDK continuation is still not merged into reported usage, matching the pre-existing wrap-up path.
- The deepest remaining lock risk is unchanged: the startup repair's individually-serialized steps are not atomic as a group, so a push can still interleave between them. Fixing that needs an exclusive per-path lease, and wrapping it in the existing scheduler would deadlock (the inner ops queue on the same key). Left out deliberately rather than risking a gateway hang.
