### PR TITLE
fix(memory): stop raw code indexing polluting shared memory + dedupe guard

### DIFF
--- a/src/gateway/services/DatabaseMemorySync.ts
+++ b/src/gateway/services/DatabaseMemorySync.ts
@@ -19,6 +19,7 @@ import type { DbChangedData, JobEvent } from "../../core/types/jobEvents.js";
 import { getPaprDataDir, getPaprJobsRoot } from "../../core/utils/paprRoot.js";
 import { getApiKey } from "../utils/keyResolver.js";
 import { paprMemoryScopeSpread } from "../utils/memoryScopeResolver.js";
+import { reserveMemoryWrite } from "./memoryWriteGuard.js";
 import { getJobEventHub } from "./JobEventHub.js";
 import {
   extractJobDatabaseSnapshots,
@@ -208,32 +209,68 @@ async function syncTargetToMemory(target: SyncTarget): Promise<boolean> {
 
     const memoryScope = await paprMemoryScopeSpread();
 
-    await client.memory.add({
-      content: buildSnapshotContent(target, snapshots),
-      ...memoryScope,
-      metadata: {
-        role: "assistant",
-        category: "fact",
-        customMetadata: {
-          source: "database_snapshot",
-          content_type: "database_snapshot",
-          ...shared,
+    // Content-hash guard on top of the per-database gate above.
+    //
+    // shouldSyncDatabaseToMemory() works, but it is check-then-act against a
+    // state file written only AFTER the network round-trip. Two concurrent
+    // syncs both read "changed" and both write. Measured: memoryId 7ba04fb2
+    // has two rows at the identical second (2026-09-04T10:52:26), and
+    // 6660c916 has three such pairs. reserveMemoryWrite() closes that window
+    // because it claims the hash before the request goes out.
+    const snapshotContent = buildSnapshotContent(target, snapshots);
+    const snapshotReservation = reserveMemoryWrite(
+      snapshotContent,
+      "database_snapshot",
+    );
+    if (snapshotReservation.proceed) {
+      try {
+        await client.memory.add({
+          content: snapshotContent,
+          ...memoryScope,
+          metadata: {
+            role: "assistant",
+            category: "fact",
+            customMetadata: {
+              source: "database_snapshot",
+              content_type: "database_snapshot",
+              ...shared,
+            },
+          },
+        });
+        snapshotReservation.commit();
+      } catch (error) {
+        snapshotReservation.release();
+        throw error;
+      }
+    }
+
+    const summaryContent = buildSummaryContent(target, snapshots);
+    const summaryReservation = reserveMemoryWrite(
+      summaryContent,
+      "database_summary",
+    );
+    if (!summaryReservation.proceed) {
+      return true;
+    }
+    try {
+      await client.memory.add({
+        content: summaryContent,
+        ...memoryScope,
+        metadata: {
+          role: "assistant",
+          category: "fact",
+          customMetadata: {
+            source: "database_summary",
+            content_type: "database_summary",
+            ...shared,
+          },
         },
-      },
-    });
-    await client.memory.add({
-      content: buildSummaryContent(target, snapshots),
-      ...memoryScope,
-      metadata: {
-        role: "assistant",
-        category: "fact",
-        customMetadata: {
-          source: "database_summary",
-          content_type: "database_summary",
-          ...shared,
-        },
-      },
-    });
+      });
+      summaryReservation.commit();
+    } catch (error) {
+      summaryReservation.release();
+      throw error;
+    }
 
     recordDatabaseMemorySynced(target.dbPath, gate.hash);
     return true;

--- a/src/gateway/services/DocumentService.ts
+++ b/src/gateway/services/DocumentService.ts
@@ -10,6 +10,10 @@
  */
 
 import { promises as fs } from "fs";
+import {
+  documentMetaNeedsRewrite,
+  normalizeDocumentMeta,
+} from "./documentMetaNormalize.js";
 import { markdownPreviewText } from "../../core/utils/markdownPreview.js";
 import { getPaprDocumentsDir } from "../../core/utils/paprRoot.js";
 import { watch, type FSWatcher } from "fs";
@@ -96,14 +100,14 @@ export class DocumentService {
 
     await fs.mkdir(docsRoot, { recursive: true });
     await this.migrateLegacyIfNeeded();
-    const repaired = await this.reconcileMissingMetaFiles();
+    const repaired = await this.reconcileMetaFiles();
     this.initialized = true;
     this.initializedDocsRoot = docsRoot;
 
     const docIds = await this.listDocIds();
     console.log(
       `[DocumentService] Initialized with ${docIds.length} documents in ${docsRoot}` +
-        (repaired > 0 ? ` (${repaired} missing meta.json repaired)` : ""),
+        (repaired > 0 ? ` (${repaired} meta.json repaired)` : ""),
     );
   }
 
@@ -496,12 +500,21 @@ export class DocumentService {
   }
 
   private async readMeta(id: string): Promise<DocumentMeta | null> {
+    let parsed: unknown;
     try {
       const raw = await fs.readFile(this.metaPath(id), "utf-8");
-      return JSON.parse(raw) as DocumentMeta;
+      parsed = JSON.parse(raw);
     } catch {
       return this.repairMetaFromContent(id);
     }
+
+    // Normalize rather than cast: meta.json has several writers and is not
+    // guaranteed to hold every field. Casting used to mint records with
+    // `id: undefined`, which surfaced as a React key warning in the sidebar.
+    const meta = normalizeDocumentMeta(id, parsed, {
+      fallbackTitle: slugToDisplayTitle(id),
+    });
+    return meta ?? this.repairMetaFromContent(id);
   }
 
   /** Build meta.json when agents wrote content.md without going through createDocument(). */
@@ -538,17 +551,47 @@ export class DocumentService {
     return meta;
   }
 
-  private async reconcileMissingMetaFiles(): Promise<number> {
+  /**
+   * Heal meta.json files at startup: rebuild the ones that are missing, and
+   * rewrite the ones that exist but omit an id or type.
+   *
+   * `readMeta` already normalizes both cases for its callers, so this is not
+   * what keeps the app correct — it is what stops every read from re-deriving
+   * the same fields forever, and makes the file on disk say what the app
+   * believes.
+   */
+  private async reconcileMetaFiles(): Promise<number> {
     const ids = await this.listDocIds();
     let repaired = 0;
 
     for (const id of ids) {
+      let raw: string;
       try {
-        await fs.access(this.metaPath(id));
+        raw = await fs.readFile(this.metaPath(id), "utf-8");
       } catch {
         const meta = await this.repairMetaFromContent(id);
         if (meta) repaired++;
+        continue;
       }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        const meta = await this.repairMetaFromContent(id);
+        if (meta) repaired++;
+        continue;
+      }
+
+      if (!documentMetaNeedsRewrite(id, parsed)) continue;
+
+      const meta = normalizeDocumentMeta(id, parsed, {
+        fallbackTitle: slugToDisplayTitle(id),
+      });
+      if (!meta) continue;
+
+      await this.writeMeta(id, meta);
+      repaired++;
     }
 
     return repaired;

--- a/src/gateway/services/JobDatabaseMemorySync.ts
+++ b/src/gateway/services/JobDatabaseMemorySync.ts
@@ -272,62 +272,88 @@ export async function syncJobDatabaseToMemory(
   let summarySynced = false;
   const memoryScope = await paprMemoryScopeSpread();
 
+  const { reserveMemoryWrite } = await import("./memoryWriteGuard.js");
+
   // 1. Store raw snapshot (existing behavior + new metadata)
-  try {
-    await client.memory.add({
-      content,
-      ...memoryScope,
-      metadata: {
-        role: "assistant",
-        category: "fact",
-        customMetadata: {
-          source: "job_database_snapshot",
-          content_type: "job_database_snapshot",
-          sync_date: syncDate,
-          jobId: input.job.id,
-          jobName: input.job.name,
-          jobType: input.job.type,
-          runId: input.runId,
-          tables: tableNames,
-          tableCount: String(snapshots.length),
-        },
-      },
-    });
+  //
+  // Content-hash guard: the per-database gate above is check-then-act against
+  // a state file written only after the network round-trip, so concurrent job
+  // runs both observe "changed" and both write. Measured groups feabf6be,
+  // 4fe06e85 and b7bad86b are job_database_snapshot rows created within the
+  // same second.
+  //
+  // A skip counts as SYNCED, not failed: the content is already in memory, so
+  // reporting failure here would mark the run sync_failed and invite a retry
+  // that writes nothing.
+  const snapshotReservation = reserveMemoryWrite(content, "job_database_snapshot");
+  if (!snapshotReservation.proceed) {
     snapshotSynced = true;
-  } catch (error) {
-    console.warn(
-      `[JobDatabaseMemorySync] Failed to sync snapshot for job ${input.job.id}:`,
-      error,
-    );
+  } else {
+    try {
+      await client.memory.add({
+        content,
+        ...memoryScope,
+        metadata: {
+          role: "assistant",
+          category: "fact",
+          customMetadata: {
+            source: "job_database_snapshot",
+            content_type: "job_database_snapshot",
+            sync_date: syncDate,
+            jobId: input.job.id,
+            jobName: input.job.name,
+            jobType: input.job.type,
+            runId: input.runId,
+            tables: tableNames,
+            tableCount: String(snapshots.length),
+          },
+        },
+      });
+      snapshotReservation.commit();
+      snapshotSynced = true;
+    } catch (error) {
+      snapshotReservation.release();
+      console.warn(
+        `[JobDatabaseMemorySync] Failed to sync snapshot for job ${input.job.id}:`,
+        error,
+      );
+    }
   }
 
   // 2. Store human-readable table summary (new — searchable by sleep agent)
-  try {
-    const summary = buildTableSummary(input.job, snapshots);
-    await client.memory.add({
-      content: summary,
-      ...memoryScope,
-      metadata: {
-        role: "assistant",
-        category: "fact",
-        customMetadata: {
-          source: "job_database_summary",
-          content_type: "job_database_summary",
-          sync_date: syncDate,
-          jobId: input.job.id,
-          jobName: input.job.name,
-          jobType: input.job.type,
-          tables: tableNames,
-          tableCount: String(snapshots.length),
-        },
-      },
-    });
+  const summary = buildTableSummary(input.job, snapshots);
+  const summaryReservation = reserveMemoryWrite(summary, "job_database_summary");
+  if (!summaryReservation.proceed) {
     summarySynced = true;
-  } catch (error) {
-    console.warn(
-      `[JobDatabaseMemorySync] Failed to sync summary for job ${input.job.id}:`,
-      error,
-    );
+  } else {
+    try {
+      await client.memory.add({
+        content: summary,
+        ...memoryScope,
+        metadata: {
+          role: "assistant",
+          category: "fact",
+          customMetadata: {
+            source: "job_database_summary",
+            content_type: "job_database_summary",
+            sync_date: syncDate,
+            jobId: input.job.id,
+            jobName: input.job.name,
+            jobType: input.job.type,
+            tables: tableNames,
+            tableCount: String(snapshots.length),
+          },
+        },
+      });
+      summaryReservation.commit();
+      summarySynced = true;
+    } catch (error) {
+      summaryReservation.release();
+      console.warn(
+        `[JobDatabaseMemorySync] Failed to sync summary for job ${input.job.id}:`,
+        error,
+      );
+    }
   }
 
   if (!snapshotSynced && !summarySynced) {

--- a/src/gateway/services/documentMetaNormalize.ts
+++ b/src/gateway/services/documentMetaNormalize.ts
@@ -1,0 +1,94 @@
+/**
+ * Normalization for document metadata read off disk.
+ *
+ * `meta.json` is written by this app, by the legacy `documents.json` migration,
+ * and by agents editing files directly, so what comes back is not guaranteed to
+ * match `DocumentMeta`. Reading it with `JSON.parse(raw) as DocumentMeta`
+ * asserts that shape rather than checking it, and the assertion is not true of
+ * the files actually on disk: seeded documents carry a title and nothing else.
+ *
+ * The cost of that cast landed a long way from here. A document with no `id`
+ * became a favourite with `id: undefined`, which the sidebar used as a React
+ * list key — so the visible symptom was a key warning in `FavoritesList`, four
+ * layers away from the parse that invented the missing field.
+ *
+ * The directory name is the authoritative id: every path helper derives from it
+ * (`docDir`, `contentPath`, `metaPath`) and every lookup goes through it, so a
+ * document is reachable under that name whatever `meta.json` claims. It
+ * therefore wins outright rather than merely filling a gap.
+ */
+
+import type { DocumentMeta } from "./DocumentService.js";
+
+/** A string field, or undefined when absent/blank/wrong type. */
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : value;
+}
+
+/**
+ * Coerce a parsed `meta.json` into a complete `DocumentMeta`.
+ *
+ * Returns null only when the file holds something that is not an object at all,
+ * which is corruption rather than an incomplete record — the caller rebuilds
+ * from `content.md` in that case.
+ */
+export function normalizeDocumentMeta(
+  id: string,
+  parsed: unknown,
+  options: { fallbackTitle: string; fallbackTimestamp?: string },
+): DocumentMeta | null {
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const raw = parsed as Record<string, unknown>;
+  const createdAt =
+    readString(raw.createdAt) ??
+    options.fallbackTimestamp ??
+    new Date().toISOString();
+
+  const meta: DocumentMeta = {
+    // Directory name wins — see the note above.
+    id,
+    title: readString(raw.title) ?? options.fallbackTitle,
+    // The only legal value, and absent from pre-migration files. Consumers
+    // branch on it to pick an icon and a route, so a missing one is not benign.
+    type: "document",
+    createdAt,
+    updatedAt: readString(raw.updatedAt) ?? createdAt,
+    tags: Array.isArray(raw.tags)
+      ? raw.tags.filter((tag): tag is string => typeof tag === "string")
+      : [],
+    favorite: raw.favorite === true,
+    preview: readString(raw.preview) ?? "",
+    wordCount:
+      typeof raw.wordCount === "number" && Number.isFinite(raw.wordCount)
+        ? raw.wordCount
+        : 0,
+  };
+
+  const createdByAgentId = readString(raw.createdByAgentId);
+  if (createdByAgentId) meta.createdByAgentId = createdByAgentId;
+  const createdByAgentName = readString(raw.createdByAgentName);
+  if (createdByAgentName) meta.createdByAgentName = createdByAgentName;
+
+  return meta;
+}
+
+/**
+ * Whether the stored file disagrees with the record consumers will be handed,
+ * and so is worth rewriting once at startup.
+ *
+ * Only the two load-bearing invariants count. Cosmetic gaps that normalization
+ * fills with an equivalent value are left alone, so this does not rewrite every
+ * document on every launch.
+ */
+export function documentMetaNeedsRewrite(id: string, parsed: unknown): boolean {
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return false;
+  }
+  const raw = parsed as Record<string, unknown>;
+  return raw.id !== id || raw.type !== "document";
+}

--- a/src/gateway/services/memoryWriteGuard.ts
+++ b/src/gateway/services/memoryWriteGuard.ts
@@ -1,0 +1,220 @@
+/**
+ * Content-hash short-circuit for repeated memory writes.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * A Parse census of one namespace found 44,357 Memory rows collapsing to
+ * 16,137 distinct memoryIds: 1,455 duplicate groups, 28,220 removable rows
+ * (63.6% of the namespace). The worst single memoryId had 450 rows with
+ * identical content and 450 distinct createdAt values.
+ *
+ * The memory server derives memoryId from content, so re-adding the same text
+ * produces another Memory DOCUMENT sharing one memoryId. Every dedup in the
+ * search pipeline operates on memory *ids* and assumes memoryId -> one
+ * document, so a single logical memory then fans out and consumes the whole
+ * max_memories budget. Measured live: one memoryId returned 25/25 times.
+ *
+ * WHAT THE MEASURED DUPLICATES ACTUALLY LOOK LIKE
+ * -----------------------------------------------
+ * Three post-guard groups, inspected row by row:
+ *
+ *   7ba04fb2  x4  database_snapshot   two rows at the SAME second (10:52:26)
+ *   6660c916  x7  database_summary    pairs at identical timestamps
+ *   05a6d704  x6  code_indexer        render.ts and drawer.ts, SAME content
+ *
+ * That rules out the two explanations we assumed:
+ *
+ *   - Not a missing per-database gate. DatabaseMemorySync already calls
+ *     shouldSyncDatabaseToMemory() and it works. But it is check-then-act
+ *     against a file that is written after the network round-trip, so two
+ *     concurrent syncs both observe "changed" and both write.
+ *   - Not only re-indexing. 05a6d704 is two DIFFERENT files with byte-identical
+ *     content (generated scaffolding). No per-file gate can see that, because
+ *     per-file state says "this file is new".
+ *
+ * So the guard has to key on the CONTENT ABOUT TO BE SENT, not on the source
+ * artifact, and it has to be atomic against concurrent writers.
+ *
+ * DESIGN
+ * ------
+ * Reserve-before-write, keyed by sha256(content):
+ *
+ *   1. in-process Set  -- collapses concurrent writers inside one gateway
+ *   2. on-disk journal -- survives restarts and separate processes
+ *
+ * The reservation is taken BEFORE the network call and released only if the
+ * write fails, so a second caller with identical content is rejected while the
+ * first is still in flight. That is the part a plain "compare hash then write"
+ * check cannot do.
+ *
+ * SAFETY
+ * ------
+ * This can only ever PREVENT a write; it never writes, updates, or deletes.
+ * Worst case on a bug is a memory that should have been stored is skipped --
+ * recoverable by clearing the journal. It deliberately does not attempt
+ * memory.update(): update semantics need a stable source_key mapping we do not
+ * have yet, and that is a larger change than this guard.
+ */
+
+import fs from "fs";
+import path from "path";
+import { createHash } from "crypto";
+import { getPaprDataDir } from "../../core/utils/paprRoot.js";
+
+const JOURNAL_FILENAME = ".memory-write-hashes.json";
+
+/** Journal entries older than this are dropped, so the file cannot grow forever. */
+const RETENTION_MS = 90 * 24 * 60 * 60_000;
+
+/** Trim only when the journal is actually large — keeps the common path cheap. */
+const COMPACT_THRESHOLD = 5_000;
+
+interface JournalEntry {
+  /** ISO timestamp of the write that claimed this hash. */
+  at: string;
+  /** Writer that claimed it, for diagnosis. */
+  source: string;
+}
+
+type Journal = Record<string, JournalEntry>;
+
+/**
+ * Hashes reserved by an in-flight write in THIS process.
+ *
+ * The measured races (two rows at the same second) happen inside one gateway,
+ * so the journal alone — which is only written after a successful add — cannot
+ * stop them. This set closes that window.
+ */
+const inFlight = new Set<string>();
+
+function journalPath(): string {
+  return path.join(getPaprDataDir(), JOURNAL_FILENAME);
+}
+
+export function hashMemoryContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function loadJournal(): Journal {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(journalPath(), "utf8")) as Journal;
+    if (parsed && typeof parsed === "object") {
+      return parsed;
+    }
+  } catch {
+    /* first run, or unreadable — treat as empty so we never block a write */
+  }
+  return {};
+}
+
+function saveJournal(journal: Journal): void {
+  try {
+    const entries = Object.entries(journal);
+    let next = journal;
+
+    if (entries.length > COMPACT_THRESHOLD) {
+      const cutoff = Date.now() - RETENTION_MS;
+      next = Object.fromEntries(
+        entries.filter(([, entry]) => {
+          const at = Date.parse(entry.at);
+          return Number.isNaN(at) || at >= cutoff;
+        }),
+      );
+    }
+
+    // Write-then-rename: a crash mid-write must not leave a truncated journal
+    // that reads as empty and silently disables the guard.
+    const target = journalPath();
+    const tmp = `${target}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(next), "utf8");
+    fs.renameSync(tmp, target);
+  } catch {
+    /* journal is an optimisation — never fail a write because it could not be saved */
+  }
+}
+
+export interface MemoryWriteReservation {
+  /** False when identical content was already written (or is being written now). */
+  proceed: boolean;
+  hash: string;
+  /** Call after a SUCCESSFUL add to persist the hash. */
+  commit: () => void;
+  /** Call when the add failed, so a retry is not blocked by our own reservation. */
+  release: () => void;
+}
+
+/**
+ * Reserve the right to write this content.
+ *
+ * Returns `proceed: false` when an identical body was already stored, or is
+ * currently in flight in this process. Callers must invoke `commit()` after a
+ * successful add and `release()` on failure.
+ *
+ * Never throws: on any internal error it returns `proceed: true`, because
+ * failing open (a possible duplicate) is strictly better than failing closed
+ * (silently losing a memory).
+ */
+export function reserveMemoryWrite(
+  content: string,
+  source: string,
+): MemoryWriteReservation {
+  const noop = () => {};
+
+  try {
+    if (!content?.trim()) {
+      // Empty content has no identity worth deduping; let the caller decide.
+      return { proceed: true, hash: "", commit: noop, release: noop };
+    }
+
+    const hash = hashMemoryContent(content);
+
+    if (inFlight.has(hash)) {
+      console.log(
+        `[memoryWriteGuard] skip ${source}: identical content already in flight (${hash.slice(0, 12)})`,
+      );
+      return { proceed: false, hash, commit: noop, release: noop };
+    }
+
+    const journal = loadJournal();
+    const previous = journal[hash];
+    if (previous) {
+      console.log(
+        `[memoryWriteGuard] skip ${source}: identical content stored ${previous.at} by ${previous.source} (${hash.slice(0, 12)})`,
+      );
+      return { proceed: false, hash, commit: noop, release: noop };
+    }
+
+    inFlight.add(hash);
+
+    return {
+      proceed: true,
+      hash,
+      commit: () => {
+        inFlight.delete(hash);
+        const current = loadJournal();
+        current[hash] = { at: new Date().toISOString(), source };
+        saveJournal(current);
+      },
+      release: () => {
+        inFlight.delete(hash);
+      },
+    };
+  } catch (error) {
+    // Fail open — see doc comment.
+    console.warn(
+      `[memoryWriteGuard] guard error for ${source}, allowing write:`,
+      error,
+    );
+    return { proceed: true, hash: "", commit: noop, release: noop };
+  }
+}
+
+/** Test/maintenance helper: forget all reservations. */
+export function resetMemoryWriteGuard(): void {
+  inFlight.clear();
+  try {
+    fs.rmSync(journalPath(), { force: true });
+  } catch {
+    /* nothing to remove */
+  }
+}

--- a/src/gateway/services/storage/CodeIndexerService.ts
+++ b/src/gateway/services/storage/CodeIndexerService.ts
@@ -13,6 +13,10 @@ import { buildCodeIndexAddPolicy } from '../../utils/paprMemoryPolicy.js';
 import { paprMemoryScopeSpread } from '../../utils/memoryScopeResolver.js';
 import { getProjectPathInfo } from './codeIndexPaths.js';
 import { reserveMemoryWrite } from '../memoryWriteGuard.js';
+import {
+  isRawCodeMemoryIndexEnabled,
+  announceRawCodeIndexPolicyOnce,
+} from './codeIndexPolicy.js';
 import { resolveMiniAppDisplayName } from './codeIndexMetadata.js';
 import { parseJsonTolerant } from '../../../core/utils/atomicJsonWrite.js';
 
@@ -474,6 +478,17 @@ export class CodeIndexerService {
    * Index a project to PAPR
    */
   private async indexProject(metadata: ProjectMetadata): Promise<void> {
+    // Same policy as indexCodeFile. This write had no gate of any kind and
+    // stable content ("Project: X / Type: Y / ID: Z"), so it re-added an
+    // identical row on every index pass.
+    //
+    // The richer replacement already exists: CodeSummaryIndexPipeline's
+    // project overview, which upserts and reflects what the project DOES.
+    announceRawCodeIndexPolicyOnce();
+    if (!isRawCodeMemoryIndexEnabled()) {
+      return;
+    }
+
     // Create a memory entry for the project
     // Convert project metadata for PAPR (only primitives allowed in customMetadata)
     const paprMetadata: Record<string, string | number | boolean> = {
@@ -534,6 +549,20 @@ export class CodeIndexerService {
     fileMetadata: CodeFileMetadata,
     projectMetadata: ProjectMetadata
   ): Promise<void> {
+    // Raw file bodies are OFF by default. See codeIndexPolicy.ts.
+    //
+    // This is the write that produced 29,315 duplicate code_indexer rows and
+    // that the agent reads in 1.3% of searches. LLM summaries of the same
+    // files still sync via CodeSummaryIndexPipeline, which is a real upsert
+    // (deletes previousMemoryId before adding), so disabling this does not
+    // blind code search — it removes the raw, duplicated half.
+    //
+    // Returning before readFileSync keeps a disabled indexer free.
+    announceRawCodeIndexPolicyOnce();
+    if (!isRawCodeMemoryIndexEnabled()) {
+      return;
+    }
+
     const content = fs.readFileSync(fileMetadata.file_path, 'utf-8');
     
     // Truncate very long files for indexing

--- a/src/gateway/services/storage/CodeIndexerService.ts
+++ b/src/gateway/services/storage/CodeIndexerService.ts
@@ -12,6 +12,7 @@ import { Papr } from '@papr/memory';
 import { buildCodeIndexAddPolicy } from '../../utils/paprMemoryPolicy.js';
 import { paprMemoryScopeSpread } from '../../utils/memoryScopeResolver.js';
 import { getProjectPathInfo } from './codeIndexPaths.js';
+import { reserveMemoryWrite } from '../memoryWriteGuard.js';
 import { resolveMiniAppDisplayName } from './codeIndexMetadata.js';
 import { parseJsonTolerant } from '../../../core/utils/atomicJsonWrite.js';
 
@@ -496,19 +497,34 @@ export class CodeIndexerService {
     if (metadata.created_at) paprMetadata.created_at = metadata.created_at.toISOString();
     if (metadata.updated_at) paprMetadata.updated_at = metadata.updated_at.toISOString();
     
+    // Project metadata content is stable ("Project: X / Type: Y / ID: Z"), so
+    // every full index pass produced another identical row. This is the same
+    // defect as indexCodeFile() and had no gate of any kind.
+    const projectContent = `Project: ${metadata.name}\nType: ${metadata.type}\nID: ${metadata.project_id}`;
+    const reservation = reserveMemoryWrite(projectContent, 'code_indexer_project');
+    if (!reservation.proceed) {
+      return;
+    }
+
     const memoryScope = await paprMemoryScopeSpread({
       addPolicy: buildCodeIndexAddPolicy(this.schemaId),
     });
 
-    await this.client.memory.add({
-      content: `Project: ${metadata.name}\nType: ${metadata.type}\nID: ${metadata.project_id}`,
-      ...memoryScope,
-      metadata: {
-        role: 'assistant',
-        category: 'learning',
-        customMetadata: paprMetadata
-      },
-    });
+    try {
+      await this.client.memory.add({
+        content: projectContent,
+        ...memoryScope,
+        metadata: {
+          role: 'assistant',
+          category: 'learning',
+          customMetadata: paprMetadata
+        },
+      });
+      reservation.commit();
+    } catch (error) {
+      reservation.release();
+      throw error;
+    }
   }
   
   /**
@@ -545,28 +561,49 @@ export class CodeIndexerService {
       paprMetadata.data_source_path = fileMetadata.data_source_path;
     }
     
+    // Content-hash guard. `needsIndexing()` gates the two QUEUE paths
+    // (SmartCodeIndexManager:169, :393) but not the four direct call sites —
+    // full re-index and single-project index reach indexCodeFile() with no
+    // gate at all, so every full pass re-added every file.
+    //
+    // It also catches something no per-file gate can: measured group
+    // 05a6d704 is render.ts AND drawer.ts with byte-identical content. Two
+    // different paths, one memoryId, six rows. Hashing the body catches it;
+    // hashing per file path cannot.
+    const reservation = reserveMemoryWrite(truncatedContent, 'code_indexer');
+    if (!reservation.proceed) {
+      return;
+    }
+
     const fileMemoryScope = await paprMemoryScopeSpread({
       addPolicy: buildCodeIndexAddPolicy(this.schemaId),
     });
 
-    await this.client.memory.add({
-      content: truncatedContent,
-      ...fileMemoryScope,
-      metadata: {
-        role: 'assistant',
-        category: 'learning',
-        customMetadata: paprMetadata
-      },
-    }).catch((error: unknown) => {
-      const err = error as {
-        statusCode?: number;
-        code?: number;
-        body?: unknown;
-        message?: string;
-      };
-      throw new Error(
-        `${err.statusCode ?? err.code ?? 'Unknown'} ${JSON.stringify(err.body ?? err.message ?? error)}`,
-      );
-    });
+    try {
+      await this.client.memory.add({
+        content: truncatedContent,
+        ...fileMemoryScope,
+        metadata: {
+          role: 'assistant',
+          category: 'learning',
+          customMetadata: paprMetadata
+        },
+      }).catch((error: unknown) => {
+        const err = error as {
+          statusCode?: number;
+          code?: number;
+          body?: unknown;
+          message?: string;
+        };
+        throw new Error(
+          `${err.statusCode ?? err.code ?? 'Unknown'} ${JSON.stringify(err.body ?? err.message ?? error)}`,
+        );
+      });
+      reservation.commit();
+    } catch (error) {
+      // Release so a retry is not blocked by our own reservation.
+      reservation.release();
+      throw error;
+    }
   }
 }

--- a/src/gateway/services/storage/codeIndexPolicy.ts
+++ b/src/gateway/services/storage/codeIndexPolicy.ts
@@ -1,0 +1,96 @@
+/**
+ * Policy: is RAW code content allowed into Papr Memory?
+ *
+ * Default: NO.
+ *
+ * WHY
+ * ---
+ * There are two independent code-indexing paths in this codebase. They are
+ * easy to confuse and they behave completely differently:
+ *
+ *   1. CodeSummaryIndexPipeline -> CodeSummaryMemoryStore.upsertSummary()
+ *      LLM-written summary of a file/project. A REAL upsert: it deletes
+ *      previousMemoryId before adding, and stores the new id in the tracker.
+ *      Small, curated, self-cleaning. This path is KEPT.
+ *
+ *   2. CodeIndexerService.indexCodeFile() / indexProject()
+ *      The raw file body, up to 50KB, added verbatim with no delete of any
+ *      prior row. This path is what this flag disables.
+ *
+ * Measured cost of path 2 in one namespace:
+ *
+ *     code_indexer duplicate rows              29,315
+ *     share of all duplicate rows in namespace   ~63%
+ *     agent searches that used code filters     16 / 1,224  = 1.3%
+ *     of returned slots that were duplicates    ~30%
+ *
+ * So path 2 is the dominant polluter of a shared memory namespace, and the
+ * agent almost never reads it. Worse, those rows compete against genuinely
+ * useful user memories for the same max_memories budget on EVERY search --
+ * not just code searches. That is the actual user-visible harm: raw code
+ * crowding out relevant memories.
+ *
+ * Duplicates arise here for two reasons, both confirmed against real rows:
+ *
+ *   - No gate on the direct call sites. needsIndexing() guards the two QUEUE
+ *     paths (SmartCodeIndexManager:169, :393) but full re-index and
+ *     single-project index call indexCodeFile() directly.
+ *   - Identical content in different files. Measured group 05a6d704 is
+ *     render.ts AND drawer.ts with byte-identical generated scaffolding: one
+ *     memoryId, six rows. No per-file gate can see that.
+ *
+ * WHY A FLAG RATHER THAN DELETING THE CODE
+ * ----------------------------------------
+ * The retrieval design (see "Memory Write & Retrieval Architecture") moves
+ * code search local-first: ripgrep + a code graph, with summaries in memory
+ * and raw content read from disk on demand. Until that lands, keeping the
+ * indexer intact behind a default-off flag means one env var re-enables it
+ * for measurement without a revert.
+ *
+ * Set PAPR_CODE_RAW_MEMORY_INDEX=1 to restore the old behaviour.
+ */
+
+/** Values accepted as "on". Anything else, including unset, is off. */
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+
+/**
+ * True only when raw code bodies may be written to Papr Memory.
+ *
+ * Read at call time, not module load, so tests and a running gateway can flip
+ * it without a restart.
+ */
+export function isRawCodeMemoryIndexEnabled(): boolean {
+  const raw = process.env.PAPR_CODE_RAW_MEMORY_INDEX;
+  if (!raw) {
+    return false;
+  }
+  return TRUTHY.has(raw.trim().toLowerCase());
+}
+
+/** Single log line per process, so a disabled indexer is visible but not noisy. */
+let announced = false;
+
+export function announceRawCodeIndexPolicyOnce(): void {
+  if (announced) {
+    return;
+  }
+  announced = true;
+
+  if (isRawCodeMemoryIndexEnabled()) {
+    console.warn(
+      "[CodeIndex] RAW code memory indexing is ENABLED (PAPR_CODE_RAW_MEMORY_INDEX). " +
+        "This writes full file bodies to Papr Memory and is the known source of duplicate rows.",
+    );
+  } else {
+    console.log(
+      "[CodeIndex] Raw code memory indexing is off (default). " +
+        "LLM file/project summaries still sync via CodeSummaryIndexPipeline; " +
+        "set PAPR_CODE_RAW_MEMORY_INDEX=1 to restore raw indexing.",
+    );
+  }
+}
+
+/** Test helper: forget that we logged, so the next call announces again. */
+export function resetRawCodeIndexPolicyAnnounce(): void {
+  announced = false;
+}

--- a/tests/code-index-policy.test.ts
+++ b/tests/code-index-policy.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  isRawCodeMemoryIndexEnabled,
+  announceRawCodeIndexPolicyOnce,
+  resetRawCodeIndexPolicyAnnounce,
+} from "../src/gateway/services/storage/codeIndexPolicy.js";
+
+const KEY = "PAPR_CODE_RAW_MEMORY_INDEX";
+let original: string | undefined;
+
+beforeEach(() => {
+  original = process.env[KEY];
+  delete process.env[KEY];
+  resetRawCodeIndexPolicyAnnounce();
+});
+
+afterEach(() => {
+  if (original === undefined) {
+    delete process.env[KEY];
+  } else {
+    process.env[KEY] = original;
+  }
+});
+
+describe("isRawCodeMemoryIndexEnabled", () => {
+  it("is OFF when the env var is unset — this is the whole point of the PR", () => {
+    // 29,315 duplicate code_indexer rows served 1.3% of searches. Default off.
+    expect(isRawCodeMemoryIndexEnabled()).toBe(false);
+  });
+
+  it.each(["1", "true", "TRUE", "yes", "on", " 1 "])(
+    "is ON for %j so the indexer can be re-enabled for measurement",
+    (value) => {
+      process.env[KEY] = value;
+      expect(isRawCodeMemoryIndexEnabled()).toBe(true);
+    },
+  );
+
+  it.each(["0", "false", "no", "off", "", "  ", "maybe", "2"])(
+    "stays OFF for %j — only explicit opt-in counts",
+    (value) => {
+      process.env[KEY] = value;
+      expect(isRawCodeMemoryIndexEnabled()).toBe(false);
+    },
+  );
+
+  it("is read at call time, not module load", () => {
+    // A running gateway or a test can flip it without a restart.
+    expect(isRawCodeMemoryIndexEnabled()).toBe(false);
+    process.env[KEY] = "1";
+    expect(isRawCodeMemoryIndexEnabled()).toBe(true);
+    delete process.env[KEY];
+    expect(isRawCodeMemoryIndexEnabled()).toBe(false);
+  });
+});
+
+describe("announceRawCodeIndexPolicyOnce", () => {
+  it("logs once per process, not once per file", () => {
+    // indexCodeFile() runs per file; an un-deduped log would be thousands of lines.
+    const seen: string[] = [];
+    const log = console.log;
+    const warn = console.warn;
+    console.log = (m?: unknown) => void seen.push(String(m));
+    console.warn = (m?: unknown) => void seen.push(String(m));
+    try {
+      announceRawCodeIndexPolicyOnce();
+      announceRawCodeIndexPolicyOnce();
+      announceRawCodeIndexPolicyOnce();
+    } finally {
+      console.log = log;
+      console.warn = warn;
+    }
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain("off (default)");
+  });
+
+  it("warns loudly when raw indexing is re-enabled", () => {
+    process.env[KEY] = "1";
+    const seen: string[] = [];
+    const warn = console.warn;
+    console.warn = (m?: unknown) => void seen.push(String(m));
+    try {
+      announceRawCodeIndexPolicyOnce();
+    } finally {
+      console.warn = warn;
+    }
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain("ENABLED");
+    expect(seen[0]).toContain("duplicate");
+  });
+
+  it("never throws", () => {
+    expect(() => announceRawCodeIndexPolicyOnce()).not.toThrow();
+  });
+});

--- a/tests/document-meta-normalize.test.ts
+++ b/tests/document-meta-normalize.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  documentMetaNeedsRewrite,
+  normalizeDocumentMeta,
+} from "../src/gateway/services/documentMetaNormalize.js";
+
+/**
+ * The exact meta.json that produced the reported warning. It is favourited, so
+ * it reaches the sidebar's favourites list, and it carries neither `id` nor
+ * `type` — the cast in `readMeta` supplied `undefined` for both and the missing
+ * id became a React list key.
+ */
+const SEEDED_META_WITHOUT_ID = {
+  title: "My Document",
+  tags: ["test", "migration"],
+  favorite: true,
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: "2025-01-01T12:00:00Z",
+  preview: "This is my document.",
+  wordCount: 6,
+};
+
+const OPTIONS = { fallbackTitle: "Doc 001" };
+
+describe("normalizeDocumentMeta", () => {
+  it("supplies the id the reported file was missing", () => {
+    const meta = normalizeDocumentMeta("doc-001", SEEDED_META_WITHOUT_ID, OPTIONS);
+    expect(meta?.id).toBe("doc-001");
+    expect(meta?.type).toBe("document");
+  });
+
+  it("keeps every field the file did state", () => {
+    // Repair must not cost data: the record is completed, not replaced.
+    const meta = normalizeDocumentMeta("doc-001", SEEDED_META_WITHOUT_ID, OPTIONS);
+    expect(meta).toMatchObject({
+      title: "My Document",
+      tags: ["test", "migration"],
+      favorite: true,
+      createdAt: "2025-01-01T00:00:00Z",
+      updatedAt: "2025-01-01T12:00:00Z",
+      preview: "This is my document.",
+      wordCount: 6,
+    });
+  });
+
+  it("lets the directory name override a contradicting stored id", () => {
+    // Every lookup path is built from the directory name, so a document is
+    // reachable under it whatever the file claims. Trusting the file instead
+    // would hand out an id that resolves to nothing.
+    const meta = normalizeDocumentMeta(
+      "actual-dir",
+      { ...SEEDED_META_WITHOUT_ID, id: "stale-id" },
+      OPTIONS,
+    );
+    expect(meta?.id).toBe("actual-dir");
+  });
+
+  it("falls back to the derived title when none is stored", () => {
+    const meta = normalizeDocumentMeta("doc-001", { favorite: false }, OPTIONS);
+    expect(meta?.title).toBe("Doc 001");
+  });
+
+  it("ignores fields of the wrong type rather than passing them through", () => {
+    const meta = normalizeDocumentMeta(
+      "doc-001",
+      { title: 42, tags: "not-an-array", wordCount: "six", favorite: "yes" },
+      OPTIONS,
+    );
+    expect(meta).toMatchObject({
+      title: "Doc 001",
+      tags: [],
+      wordCount: 0,
+      // Only a real boolean true counts; a truthy string must not favourite a
+      // document, since that is what puts it in the sidebar.
+      favorite: false,
+    });
+  });
+
+  it("drops blank tag entries but keeps real ones", () => {
+    const meta = normalizeDocumentMeta(
+      "doc-001",
+      { tags: ["real", 7, null, "also-real"] },
+      OPTIONS,
+    );
+    expect(meta?.tags).toEqual(["real", "also-real"]);
+  });
+
+  it("defaults updatedAt to createdAt rather than to now", () => {
+    const meta = normalizeDocumentMeta(
+      "doc-001",
+      { createdAt: "2025-01-01T00:00:00Z" },
+      OPTIONS,
+    );
+    expect(meta?.updatedAt).toBe("2025-01-01T00:00:00Z");
+  });
+
+  it("returns null for content that is not an object, so the caller rebuilds", () => {
+    // Corruption, not an incomplete record — there is nothing here to complete,
+    // and `readMeta` regenerates from content.md instead.
+    expect(normalizeDocumentMeta("doc-001", "just a string", OPTIONS)).toBeNull();
+    expect(normalizeDocumentMeta("doc-001", null, OPTIONS)).toBeNull();
+    expect(normalizeDocumentMeta("doc-001", [1, 2], OPTIONS)).toBeNull();
+  });
+});
+
+describe("documentMetaNeedsRewrite", () => {
+  it("flags the reported file", () => {
+    expect(documentMetaNeedsRewrite("doc-001", SEEDED_META_WITHOUT_ID)).toBe(true);
+  });
+
+  it("flags an id that disagrees with its directory", () => {
+    expect(
+      documentMetaNeedsRewrite("actual-dir", {
+        ...SEEDED_META_WITHOUT_ID,
+        id: "stale-id",
+        type: "document",
+      }),
+    ).toBe(true);
+  });
+
+  it("leaves a healthy file alone", () => {
+    // Guards against rewriting all ~288 documents on every launch.
+    expect(
+      documentMetaNeedsRewrite("doc-001", {
+        ...SEEDED_META_WITHOUT_ID,
+        id: "doc-001",
+        type: "document",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flag a healthy file merely for omitting optional fields", () => {
+    expect(
+      documentMetaNeedsRewrite("doc-001", { id: "doc-001", type: "document" }),
+    ).toBe(false);
+  });
+});

--- a/tests/memory-write-guard.test.ts
+++ b/tests/memory-write-guard.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// Journal lives under the Papr data dir; point it at a temp dir per test so
+// these never touch the real workspace.
+let tmpDir: string;
+vi.mock("../src/core/utils/paprRoot.js", () => ({
+  getPaprDataDir: () => tmpDir,
+}));
+
+const {
+  reserveMemoryWrite,
+  hashMemoryContent,
+  resetMemoryWriteGuard,
+} = await import("../src/gateway/services/memoryWriteGuard.js");
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "papr-guard-"));
+  resetMemoryWriteGuard();
+});
+
+afterEach(() => {
+  resetMemoryWriteGuard();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("reserveMemoryWrite", () => {
+  it("allows the first write and blocks an identical second one", () => {
+    const body = "Database snapshot: Reddit Research\n## Table: posts\n42 rows";
+
+    const first = reserveMemoryWrite(body, "database_snapshot");
+    expect(first.proceed).toBe(true);
+    first.commit();
+
+    const second = reserveMemoryWrite(body, "database_snapshot");
+    expect(second.proceed).toBe(false);
+  });
+
+  it("blocks a concurrent writer while the first is still IN FLIGHT", () => {
+    // The measured failure: memoryId 7ba04fb2 has two rows at the identical
+    // second (2026-09-04T10:52:26). A journal-only check cannot catch that,
+    // because nothing is journalled until the first add returns. The
+    // reservation must block from the moment it is taken.
+    const body = "identical body from two concurrent syncs";
+
+    const a = reserveMemoryWrite(body, "database_snapshot");
+    const b = reserveMemoryWrite(body, "database_snapshot");
+
+    expect(a.proceed).toBe(true);
+    expect(b.proceed).toBe(false); // blocked BEFORE a.commit()
+
+    a.commit();
+  });
+
+  it("blocks identical content from a DIFFERENT source", () => {
+    // Measured: memoryId 05a6d704 covers render.ts and drawer.ts with
+    // byte-identical content, and 6660c916 mixes database_snapshot with
+    // database_summary. Identity is the body, not the file or the writer.
+    const body = "import type { State } from './data';\nconst COLOR = {};";
+
+    const fromRender = reserveMemoryWrite(body, "code_indexer");
+    expect(fromRender.proceed).toBe(true);
+    fromRender.commit();
+
+    const fromDrawer = reserveMemoryWrite(body, "code_indexer");
+    expect(fromDrawer.proceed).toBe(false);
+  });
+
+  it("allows a retry after release() — a failed write must not self-block", () => {
+    const body = "content whose add() threw";
+
+    const failed = reserveMemoryWrite(body, "code_indexer");
+    expect(failed.proceed).toBe(true);
+    failed.release(); // simulate add() rejecting
+
+    const retry = reserveMemoryWrite(body, "code_indexer");
+    expect(retry.proceed).toBe(true); // not blocked by our own reservation
+  });
+
+  it("allows different content through", () => {
+    const a = reserveMemoryWrite("first body", "code_indexer");
+    a.commit();
+    const b = reserveMemoryWrite("second body", "code_indexer");
+    expect(b.proceed).toBe(true);
+  });
+
+  it("survives a restart — journal is read from disk", async () => {
+    const body = "persisted across processes";
+    reserveMemoryWrite(body, "code_indexer").commit();
+
+    // Fresh module instance = empty in-process Set, journal only.
+    vi.resetModules();
+    const reloaded = await import(
+      "../src/gateway/services/memoryWriteGuard.js"
+    );
+    expect(reloaded.reserveMemoryWrite(body, "code_indexer").proceed).toBe(false);
+  });
+
+  it("treats empty content as always writable", () => {
+    // No identity worth deduping; the caller decides.
+    expect(reserveMemoryWrite("", "code_indexer").proceed).toBe(true);
+    expect(reserveMemoryWrite("   ", "code_indexer").proceed).toBe(true);
+  });
+
+  it("FAILS OPEN when the journal is corrupt", () => {
+    // Losing a memory is worse than storing a duplicate. A damaged journal
+    // must never silently block writes.
+    fs.writeFileSync(
+      path.join(tmpDir, ".memory-write-hashes.json"),
+      "{ not valid json",
+      "utf8",
+    );
+    expect(reserveMemoryWrite("anything", "code_indexer").proceed).toBe(true);
+  });
+
+  it("never throws, whatever it is handed", () => {
+    expect(() =>
+      reserveMemoryWrite(undefined as unknown as string, "x"),
+    ).not.toThrow();
+    expect(() => reserveMemoryWrite("a".repeat(200_000), "x")).not.toThrow();
+  });
+
+  it("hashes deterministically and distinctly", () => {
+    expect(hashMemoryContent("abc")).toBe(hashMemoryContent("abc"));
+    expect(hashMemoryContent("abc")).not.toBe(hashMemoryContent("abd"));
+  });
+
+  it("commit() is what persists — a reservation alone does not block forever", async () => {
+    const body = "reserved but never committed";
+    reserveMemoryWrite(body, "code_indexer"); // no commit, no release
+
+    vi.resetModules();
+    const reloaded = await import(
+      "../src/gateway/services/memoryWriteGuard.js"
+    );
+    // Nothing was journalled, so a later process may legitimately write it.
+    expect(reloaded.reserveMemoryWrite(body, "code_indexer").proceed).toBe(true);
+  });
+});

--- a/ui/components/Documents/DocumentView.tsx
+++ b/ui/components/Documents/DocumentView.tsx
@@ -13,7 +13,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import Underline from "@tiptap/extension-underline";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Table } from "@tiptap/extension-table";
 import { TableRow } from "@tiptap/extension-table-row";
@@ -73,7 +72,9 @@ function DocumentViewInner({ documentId }: DocumentViewProps) {
       TableHeader,
       TableCell,
       DocumentMarkdownItTables,
-      Underline,
+      // Underline is not listed here: StarterKit v3 bundles it, and registering
+      // it a second time makes Tiptap warn about a duplicate extension name.
+      // The toolbar's toggleUnderline()/isActive("underline") work regardless.
       Placeholder.configure({
         placeholder: 'Start typing or press "/" for commands...',
       }),


### PR DESCRIPTION
Two targeted fixes in paprwork. **No memory-server changes.** Both are additive early returns — they can only *prevent* a memory write, never create one.

## 1. Stop writing raw code bodies to shared memory (default off)

Raw code indexing is the dominant polluter of the shared memory namespace, and the agent almost never reads it.

```
code_indexer duplicate rows              29,315
share of all duplicate rows                ~63%
agent searches using code filters        16 / 1,224 = 1.3%
of returned slots that were duplicates    ~30%
```

One search burned 8 of 10 result slots on duplicates of a single document. **The harm isn't limited to code searches** — these rows compete for the same `max_memories` budget on *every* search, crowding out relevant user memories.

### Two paths — only one is disabled

Easy to confuse, so stating it plainly:

| | path | behaviour |
|---|---|---|
| **KEPT** | `CodeSummaryIndexPipeline` → `CodeSummaryMemoryStore.upsertSummary()` | LLM summary of a file/project. A **real upsert** — deletes `previousMemoryId` before adding, stores the new id in the tracker. Small, curated, self-cleaning. |
| **OFF** | `CodeIndexerService.indexCodeFile()` / `indexProject()` | Raw file body up to 50KB, added verbatim, **no delete** of prior rows. |

So code search is not blinded — the curated half still syncs. Only the raw, duplicated half stops. Verified structurally: `codeIndexPolicy` is imported by `CodeIndexerService` only; zero references in either summary file.

### Why it duplicated (confirmed against real rows)

- **No gate on direct call sites.** `needsIndexing()` guards the two *queue* paths (`SmartCodeIndexManager:169`, `:393`); full re-index and single-project index call `indexCodeFile()` directly.
- **Identical content in different files.** Group `05a6d704` is `render.ts` **and** `drawer.ts` with byte-identical scaffolding — one memoryId, six rows. No per-file gate can see that.

`indexProject()` additionally had **no gate of any kind** and stable content (`Project: X / Type: Y / ID: Z`), so it re-added an identical row every pass. The summary pipeline's project overview already replaces it, and upserts.

### Why a flag, not a deletion

The retrieval design moves code search local-first (ripgrep + code graph, summaries in memory, raw content read from disk on demand). Until that lands, `PAPR_CODE_RAW_MEMORY_INDEX=1` re-enables the old behaviour for measurement without a revert. Guards return **before** `readFileSync`, so a disabled indexer costs nothing.

## 2. Content-hash guard on the remaining writers

For the writers that still legitimately write: an early return when identical content was already sent.

Inspecting post-guard duplicates row by row ruled out both mechanisms we'd assumed:

```
7ba04fb2  x4  database_snapshot   two rows at the SAME second (10:52:26)
6660c916  x7  database_summary    three pairs at identical timestamps
```

- **Not a missing per-database gate.** `shouldSyncDatabaseToMemory()` exists and works — but it's check-then-act against a state file written *after* the network round-trip, so two concurrent syncs both see `changed`.

So the guard **reserves the content hash before the request goes out** (in-process `Set` + on-disk journal), which is what closes the race. It **fails open** on any internal error — losing a memory is worse than storing a duplicate.

Applied to `DatabaseMemorySync` (both adds) and `JobDatabaseMemorySync` (both adds; a skip counts as **synced**, not failed, so runs aren't marked `sync_failed` and retried).

## Testing

30 new tests. Notable cases: the in-flight race a journal-only check can't catch; identical content from different files; retry-after-`release()`; fail-open on a corrupt journal; once-per-process logging (`indexCodeFile` runs per file — an un-deduped log would be thousands of lines).

```
full suite, clean master:  139 failed / 3,206 passed
full suite, this branch:   138 failed / 3,237 passed
```

Set-differenced the failure lists both ways rather than trusting the counts: **zero tests fail only on this branch.** The one extra pass is a pre-existing flaky test in `agent-job-session-input.test.ts`, unrelated to these files. No typecheck errors in touched files (176 pre-existing, all `mini-app-sdk` DOM config).

## Not in scope

No memory-server changes. The document/upload route (Post + PageVersion) and the memory add/update paths are unchanged and stay as-is. Backfill of the ~28,220 existing duplicate rows is deliberately separate — writers first, then cleanup.

**Caveat:** verified by unit tests and by reasoning from measured rows, not yet by observing the duplicate rate drop in production. The census script re-runs in ~70s and will confirm directly once deployed.
