### PR TITLE
feat(context-meter): show the turn that is happening now

### DIFF
--- a/src/gateway/services/AgentService.ts
+++ b/src/gateway/services/AgentService.ts
@@ -115,6 +115,12 @@ import {
   setToolCallCount,
   summarizeTurnMetrics,
 } from "./agent/turnMetrics.js";
+import {
+  beginLiveTurn,
+  endLiveTurn,
+  readFreshLiveTurn,
+  updateLiveTurn,
+} from "./agent/liveTurn.js";
 import { RATE_LIMIT_EXHAUSTED_ERROR_CODE } from "../utils/providerRateLimitRetry.js";
 import { streamCursorAgentTurn } from "./providers/cursorAgentStream.js";
 import {
@@ -593,6 +599,10 @@ export class AgentService {
     // Mark streaming only after a slot is acquired — pi-ai / AI SDK work has not started yet.
     this.sessionManager.setStreaming(chatId, true);
     clearInFlightToolResults(chatId);
+
+    // Declared out here so the outer `finally` can close the live meter. The
+    // turn itself is opened deeper in, once tool context exists.
+    let liveTurnToken: number | null = null;
 
     // Track response state for error recovery
     let assistantText = "";
@@ -1125,6 +1135,12 @@ export class AgentService {
       // against the turn that provoked it.
       const turnMetrics = createTurnMetrics();
       const turnStartedAt = Date.now();
+      // Opens the live snapshot the context meter polls. Registered before the
+      // first step rather than after it so the panel has an elapsed clock and a
+      // 0-step reading immediately — the first step of a long turn can take
+      // thirty seconds, and that is exactly the window where a frozen meter
+      // reads as broken.
+      liveTurnToken = beginLiveTurn(chatId, config.model);
       setToolContext(chatId, {
         turnMetrics,
         ...(Object.keys(mergedJobEnv).length > 0
@@ -1555,6 +1571,13 @@ export class AgentService {
 
         onStepFinish: async (step: StepResult<any>) => {
           cumulativeSteps++;
+          // Published before the usage guard below: a provider that reports no
+          // usage still ran a step, and the step count is the one number the
+          // meter can always honestly show.
+          updateLiveTurn(chatId, {
+            steps: cumulativeSteps,
+            toolCalls: toolCalls.length,
+          });
 
           // Debug: log the actual step structure to see what we're getting
           if (!step.usage || step.usage.inputTokens === undefined) {
@@ -1599,6 +1622,17 @@ export class AgentService {
           // is what makes `turn_peak_context_tokens` the billed prompt rather
           // than the chars/4 estimate, which runs ~1.9× low on real turns.
           recordObservedContext(turnMetrics, cumulativePromptTokens);
+
+          // Same numbers, published where a mid-turn read can see them. This
+          // is the only write path for the live meter; everything else about
+          // the turn is persisted once, at the end.
+          updateLiveTurn(chatId, {
+            steps: cumulativeSteps,
+            toolCalls: toolCalls.length,
+            peakContextTokens,
+            billedPromptTokens: cumulativePromptTokens,
+            billedCompletionTokens: outputTokens ?? 0,
+          });
 
           console.log(
             `[AgentService] 📈 Step ${cumulativeSteps} - input: ${inputTokens} tokens, output: ${outputTokens} tokens (full context: ${cumulativePromptTokens})`,
@@ -2975,6 +3009,9 @@ export class AgentService {
       // the controller already — don't clobber its state.
       this.sessionManager.clearStreamingStateIfOwner(chatId, abortController);
       clearInFlightToolResults(chatId);
+      // Token-guarded for the same reason as the line above: by the time this
+      // runs, the next turn may already own the chat.
+      if (liveTurnToken !== null) endLiveTurn(chatId, liveTurnToken);
 
       if (!options?.isSubAgentTrigger) {
         void import("./SubAgentResponseTrigger.js")
@@ -3442,7 +3479,7 @@ ${last15.substring(0, 8_000)}`;
     // step, so using it here would report the invoice as fullness and peg the
     // ring at 100% on any long turn.
     const measuredPeak = lastTurn?.peakContextTokens ?? 0;
-    const fillSource: "measured" | "billed" | "none" = !lastTurn
+    let fillSource: "live" | "measured" | "billed" | "none" = !lastTurn
       ? "none"
       : measuredPeak > 0
         ? "measured"
@@ -3454,9 +3491,28 @@ ${last15.substring(0, 8_000)}`;
     // older rows also predate the turn total being summed, so their
     // `prompt_tokens` still is one request and must NOT be divided by steps.
     // Clamped because a stale row may name a window the current model lacks.
-    const fallback = lastTurn
-      ? Math.min(lastTurn.promptTokens, effectiveWindow)
+    //
+    // `prompt_tokens` alone is not the request size on Anthropic: cached
+    // prefixes are billed and reported separately, so a well-cached turn
+    // records 32 input tokens against 3.1M cache reads. Reading only the
+    // first is how a full window measured 0%. Adding them back is what
+    // `resolveStepContextTokens` does for the live path, for the same reason.
+    const billedRequestTokens = lastTurn
+      ? lastTurn.promptTokens +
+        lastTurn.cacheReadTokens +
+        lastTurn.cacheWriteTokens
       : 0;
+    const fallback = Math.min(billedRequestTokens, effectiveWindow);
+
+    // An in-flight turn outranks the last finished one: it is the context the
+    // user is watching fill. Same measurement as `turn_peak_context_tokens`,
+    // so the number does not jump when the turn lands and the row is written.
+    // Before the first step lands there is nothing measured yet, and showing 0%
+    // would be a visible drop from whatever the ring read a second ago. Hold
+    // the previous turn's fill until the live number exists.
+    const restingFill = fillSource === "measured" ? measuredPeak : fallback;
+    const live = readFreshLiveTurn(chatId);
+    if (live?.peakContextTokens) fillSource = "live";
 
     return {
       model,
@@ -3464,10 +3520,22 @@ ${last15.substring(0, 8_000)}`;
       modelWindow,
       effectiveWindow,
       userCap: contextLimit ?? null,
-      usedTokens: fillSource === "measured" ? measuredPeak : fallback,
+      usedTokens: live?.peakContextTokens
+        ? Math.min(live.peakContextTokens, effectiveWindow)
+        : restingFill,
       fillSource,
       lastTurn,
       totals,
+      liveTurn: live
+        ? {
+            model: live.model,
+            startedAt: new Date(live.startedAt).toISOString(),
+            elapsedMs: Date.now() - live.startedAt,
+            steps: live.steps,
+            toolCalls: live.toolCalls,
+            peakContextTokens: live.peakContextTokens,
+          }
+        : null,
     };
   }
 

--- a/src/gateway/services/agent/liveTurn.ts
+++ b/src/gateway/services/agent/liveTurn.ts
@@ -1,0 +1,113 @@
+/**
+ * The turn that is happening right now.
+ *
+ * Everything else in the context meter reads `messages` — which is written
+ * once, after the turn is over. That is correct for billing and useless for
+ * feedback: a 107-step turn showed the user a frozen ring and four em-dashes
+ * for nine minutes, then jumped. The numbers the meter wants already exist
+ * mid-flight as locals inside the streaming loop (`cumulativeSteps`,
+ * `peakContextTokens`); this module is the only thing missing, a place to put
+ * them where a read can find them.
+ *
+ * In-memory and per-process on purpose. A live turn is not history — if the
+ * gateway restarts mid-turn the turn is gone too, and persisting a snapshot of
+ * it would leave a permanent "in progress" row that nothing ever closes.
+ */
+
+export interface LiveTurnSnapshot {
+  chatId: string;
+  model: string;
+  /** Identity of this turn, so a late `finally` cannot end the next one. */
+  token: number;
+  startedAt: number;
+  /** Steps the provider has finished, not steps attempted. */
+  steps: number;
+  toolCalls: number;
+  /**
+   * Size of the largest single request so far — the same measurement
+   * `turn_peak_context_tokens` stores when the turn ends, so the ring does not
+   * jump when live hands over to recorded.
+   */
+  peakContextTokens: number;
+  /** Cumulative billed prompt across steps, for a mid-turn cost estimate. */
+  billedPromptTokens: number;
+  billedCompletionTokens: number;
+}
+
+const liveTurns = new Map<string, LiveTurnSnapshot>();
+
+/**
+ * Returns a token identifying this turn. `endLiveTurn` requires it, for the
+ * same reason `clearStreamingStateIfOwner` exists: the auto-send queue can
+ * start the next turn before the previous one finishes unwinding, and an
+ * unconditional delete in the loser's `finally` would erase the winner's
+ * live state — leaving a running turn with a dead meter.
+ */
+export function beginLiveTurn(chatId: string, model: string): number {
+  const token = ++turnToken;
+  liveTurns.set(chatId, {
+    chatId,
+    model,
+    token,
+    startedAt: Date.now(),
+    steps: 0,
+    toolCalls: 0,
+    peakContextTokens: 0,
+    billedPromptTokens: 0,
+    billedCompletionTokens: 0,
+  });
+  return token;
+}
+
+let turnToken = 0;
+
+/**
+ * Monotonic by construction: every numeric field only ever moves up within a
+ * turn. A continuation stream restarts its own counters from zero (see
+ * turnUsageAccounting), and letting that reset the live snapshot would make
+ * the ring visibly fall backwards mid-turn.
+ */
+export function updateLiveTurn(
+  chatId: string,
+  patch: Partial<
+    Omit<LiveTurnSnapshot, "chatId" | "model" | "startedAt" | "token">
+  >,
+): void {
+  const current = liveTurns.get(chatId);
+  if (!current) return;
+  for (const [key, value] of Object.entries(patch)) {
+    if (typeof value !== "number") continue;
+    const field = key as keyof LiveTurnSnapshot;
+    const previous = current[field];
+    if (typeof previous === "number" && value > previous) {
+      (current as unknown as Record<string, number>)[field] = value;
+    }
+  }
+}
+
+export function endLiveTurn(chatId: string, token: number): void {
+  if (liveTurns.get(chatId)?.token !== token) return;
+  liveTurns.delete(chatId);
+}
+
+export function readLiveTurn(chatId: string): LiveTurnSnapshot | null {
+  return liveTurns.get(chatId) ?? null;
+}
+
+/**
+ * Guards against a turn that died without unwinding — a hard provider abort or
+ * a swallowed throw leaves the entry behind, and a stuck "live" meter is worse
+ * than a stale one because it claims to be current. Nothing in this codebase
+ * runs a single turn for an hour.
+ */
+const LIVE_TURN_MAX_AGE_MS = 60 * 60 * 1000;
+
+export function readFreshLiveTurn(chatId: string): LiveTurnSnapshot | null {
+  const turn = liveTurns.get(chatId);
+  if (!turn) return null;
+  if (Date.now() - turn.startedAt > LIVE_TURN_MAX_AGE_MS) {
+    liveTurns.delete(chatId);
+    return null;
+  }
+  return turn;
+}

--- a/src/gateway/services/storage/turnMetricsStore.ts
+++ b/src/gateway/services/storage/turnMetricsStore.ts
@@ -147,8 +147,15 @@ const TURN_USAGE_SELECT = `
          turn_context_budget_tokens
   FROM messages
   WHERE chat_id = ? AND role = 'assistant' AND COALESCE(prompt_tokens, 0) > 0
-  ORDER BY sequence DESC, timestamp DESC
+  ORDER BY timestamp DESC, rowid DESC
   LIMIT 1`;
+// `sequence` looks like an ordinal and is not one: the column holds the turn's
+// parts array as JSON (`[{"type":"thinking",...}]`, ~100-300KB a row). Sorting
+// by it compared those blobs as text, so "last turn" was whichever turn began
+// with the alphabetically largest thinking block — in this workspace a turn
+// from nine days earlier, which is why the meter read 32 tokens and 0% while
+// showing a $2.74 cost from a different turn. Timestamps are ISO-8601, so
+// lexical DESC is chronological; rowid breaks ties inside the same second.
 
 /** Last billed assistant turn in a chat, or null before the first reply. */
 export function readLastTurnUsage(

--- a/ui/components/Chat/ContextMeter.css
+++ b/ui/components/Chat/ContextMeter.css
@@ -500,3 +500,89 @@
   cursor: not-allowed;
   opacity: 0.5;
 }
+
+/* ── live turn ────────────────────────────────────────────── */
+
+/*
+ * Motion is the whole point of this block. Steps land seconds apart, so
+ * between them every number on the panel is legitimately unchanged — and a
+ * panel of unchanging numbers is exactly what "it's frozen" looks like. The
+ * sweep and the pulse carry the "still working" signal so the figures don't
+ * have to fake it.
+ */
+
+.ctx-ring__sweep {
+  stroke: var(--accent);
+  opacity: 0.35;
+  transform-origin: 50% 50%;
+  animation: ctx-sweep 1.6s linear infinite;
+}
+
+@keyframes ctx-sweep {
+  from {
+    transform: rotate(-90deg);
+  }
+  to {
+    transform: rotate(270deg);
+  }
+}
+
+/* The dial is 20px in a dense composer row: a scale/opacity pulse reads at
+   that size where a colour change does not. */
+.ctx-ring.is-live .ctx-ring__label {
+  animation: ctx-breathe 1.8s var(--ease) infinite;
+}
+
+@keyframes ctx-breathe {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+.ctx-panel__live {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  animation: ctx-breathe 1.8s var(--ease) infinite;
+}
+
+.ctx-turn__running {
+  font-size: 10px;
+  color: var(--accent);
+  animation: ctx-breathe 1.8s var(--ease) infinite;
+}
+
+/* Live figures are provisional — every one of them is still going up. Tabular
+   numerals keep the row from reflowing as digits are added, which is its own
+   kind of flicker. */
+.ctx-turn--live .ctx-stat__value {
+  font-variant-numeric: tabular-nums;
+  transition: color var(--dur-2) var(--ease);
+}
+
+.ctx-turn__note {
+  margin: 8px 0 0;
+  font-size: 10px;
+  color: var(--text-tertiary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ctx-ring__sweep,
+  .ctx-ring.is-live .ctx-ring__label,
+  .ctx-panel__live,
+  .ctx-turn__running {
+    animation: none;
+  }
+  .ctx-ring__sweep {
+    opacity: 0.5;
+  }
+}

--- a/ui/components/Chat/ContextMeter.tsx
+++ b/ui/components/Chat/ContextMeter.tsx
@@ -20,6 +20,13 @@ import {
 } from "./contextMeterModel";
 import "./ContextMeter.css";
 
+/**
+ * Cheap enough to run every second: one indexed SQLite row plus an in-memory
+ * map read, over a local socket. The ceiling on freshness is the agent's step
+ * boundary, not this.
+ */
+const LIVE_POLL_MS = 1000;
+
 interface ContextMeterProps {
   chatId: string;
   model: string;
@@ -41,6 +48,7 @@ export const ContextMeter: React.FC<ContextMeterProps> = ({
   const [info, setInfo] = useState<ContextInfo | null>(null);
   const [infoLoading, setInfoLoading] = useState(false);
   const [infoError, setInfoError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
   const wasSending = useRef(isSending);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -60,10 +68,40 @@ export const ContextMeter: React.FC<ContextMeterProps> = ({
     void loadMeter();
   }, [loadMeter]);
 
+  /**
+   * While the agent works, re-read on a timer.
+   *
+   * The turn is the thing the user is watching and it is the one thing the
+   * old meter could not see: everything about a turn is written to SQLite
+   * once, at the end, so a refresh keyed only to the end of streaming left the
+   * dial frozen for the entire time it had something to say. A step boundary
+   * is seconds apart at best, so a 1s poll is never the limiting factor —
+   * `getContextMeter` is a single indexed row plus an in-memory read.
+   */
   useEffect(() => {
+    if (!isSending) return;
+    void loadMeter();
+    const timer = window.setInterval(() => void loadMeter(), LIVE_POLL_MS);
+    return () => window.clearInterval(timer);
+  }, [isSending, loadMeter]);
+
+  useEffect(() => {
+    // One final read after the turn lands, to swap the live figures for the
+    // billed ones — cost only exists once the provider closes the turn.
     if (wasSending.current && !isSending) void loadMeter();
     wasSending.current = isSending;
   }, [isSending, loadMeter]);
+
+  /**
+   * The elapsed clock ticks on its own rather than waiting for a poll: time is
+   * the one number that advances with no server involvement, and a "time" stat
+   * that jumps in one-second steps looks stalled next to a spinner.
+   */
+  useEffect(() => {
+    if (!meter?.liveTurn) return;
+    const timer = window.setInterval(() => setTick((n) => n + 1), 1000);
+    return () => window.clearInterval(timer);
+  }, [meter?.liveTurn]);
 
   /**
    * Unlike `loadMeter`, this answers an explicit click, so a failure has to be
@@ -131,12 +169,27 @@ export const ContextMeter: React.FC<ContextMeterProps> = ({
 
   const fraction = fillFraction(meter);
   const status = meterStatus(fraction);
+  // `tick` exists only to force this render; its value is never used. Elapsed
+  // is recomputed from the start time rather than accumulated, so a missed
+  // interval — a backgrounded window throttling timers — corrects itself
+  // instead of drifting permanently behind.
+  void tick;
+  const live = meter.liveTurn
+    ? {
+        ...meter.liveTurn,
+        elapsedMs: Math.max(
+          meter.liveTurn.elapsedMs,
+          Date.now() - new Date(meter.liveTurn.startedAt).getTime(),
+        ),
+      }
+    : null;
 
   return (
     <div className="ctx-meter" ref={containerRef}>
       {open ? (
         <ContextUsagePanel
           meter={meter}
+          live={live}
           info={info}
           infoLoading={infoLoading}
           infoError={infoError}
@@ -159,7 +212,10 @@ export const ContextMeter: React.FC<ContextMeterProps> = ({
         <ContextMeterRing
           fraction={fraction}
           status={status}
-          showLabel={status !== "calm"}
+          live={Boolean(live)}
+          // A running turn is the moment the number matters most, so the label
+          // stops being conditional on the window being nearly full.
+          showLabel={status !== "calm" || Boolean(live)}
         />
       </button>
     </div>

--- a/ui/components/Chat/ContextMeterRing.tsx
+++ b/ui/components/Chat/ContextMeterRing.tsx
@@ -15,6 +15,12 @@ interface ContextMeterRingProps {
   size?: number;
   /** Render the percentage beside the ring. */
   showLabel?: boolean;
+  /**
+   * A turn is running. Steps land seconds apart, so between them the fill is
+   * genuinely unchanged — without this the dial is indistinguishable from a
+   * dead one during exactly the wait it is supposed to narrate.
+   */
+  live?: boolean;
 }
 
 const STROKE = 2.5;
@@ -24,6 +30,7 @@ export const ContextMeterRing: React.FC<ContextMeterRingProps> = ({
   status,
   size = 20,
   showLabel = false,
+  live = false,
 }) => {
   const radius = (size - STROKE) / 2;
   const circumference = 2 * Math.PI * radius;
@@ -31,7 +38,7 @@ export const ContextMeterRing: React.FC<ContextMeterRingProps> = ({
   const percent = Math.round(clamped * 100);
 
   return (
-    <span className={`ctx-ring ctx-ring--${status}`}>
+    <span className={`ctx-ring ctx-ring--${status}${live ? " is-live" : ""}`}>
       <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
         <circle
           className="ctx-ring__track"
@@ -41,6 +48,22 @@ export const ContextMeterRing: React.FC<ContextMeterRingProps> = ({
           strokeWidth={STROKE}
           fill="none"
         />
+        {/* Painted after the track and before the fill, so it reads as motion
+            *in* the empty part of the dial. It reports activity and nothing
+            else — deliberately not tied to progress, because the one thing a
+            running turn cannot know is how many steps are left. */}
+        {live ? (
+          <circle
+            className="ctx-ring__sweep"
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            strokeWidth={STROKE}
+            fill="none"
+            strokeLinecap="round"
+            strokeDasharray={`${circumference * 0.22} ${circumference}`}
+          />
+        ) : null}
         <circle
           className="ctx-ring__fill"
           cx={size / 2}

--- a/ui/components/Chat/ContextUsagePanel.tsx
+++ b/ui/components/Chat/ContextUsagePanel.tsx
@@ -15,15 +15,19 @@ import {
   deriveSegments,
   fillFraction,
   formatCost,
+  formatDuration,
   formatTokens,
   meterStatus,
   rawFillFraction,
   type ContextMeter,
+  type LiveTurn,
 } from "./contextMeterModel";
 import "./ContextMeter.css";
 
 interface ContextUsagePanelProps {
   meter: ContextMeter;
+  /** Non-null while a turn is running, with a client-ticked elapsed clock. */
+  live: LiveTurn | null;
   info: ContextInfo | null;
   infoLoading: boolean;
   infoError: string | null;
@@ -34,6 +38,7 @@ interface ContextUsagePanelProps {
 
 export const ContextUsagePanel: React.FC<ContextUsagePanelProps> = ({
   meter,
+  live,
   info,
   infoLoading,
   infoError,
@@ -52,6 +57,7 @@ export const ContextUsagePanel: React.FC<ContextUsagePanelProps> = ({
     <div className="ctx-panel" role="dialog" aria-label="Context usage">
       <header className="ctx-panel__head">
         <span className="ctx-panel__title">Context</span>
+        {live ? <span className="ctx-panel__live">Live</span> : null}
         <span className="ctx-panel__model">{meter.model}</span>
         <button
           type="button"
@@ -76,10 +82,16 @@ export const ContextUsagePanel: React.FC<ContextUsagePanelProps> = ({
           </div>
         </div>
         <div className="ctx-panel__hero-right">
+          {/* A running turn has no cost yet — the provider reports it when the
+              turn closes. The elapsed clock takes the slot instead, because
+              repeating the *previous* turn's price next to a "Live" badge is
+              the one reading that would be actively wrong. */}
           <div className="ctx-panel__cost">
-            {formatCost(meter.lastTurn?.cost ?? 0)}
+            {live
+              ? formatDuration(live.elapsedMs)
+              : formatCost(meter.lastTurn?.cost ?? 0)}
           </div>
-          <div className="ctx-panel__sub">last turn</div>
+          <div className="ctx-panel__sub">{live ? "running" : "last turn"}</div>
         </div>
       </div>
 
@@ -143,7 +155,7 @@ export const ContextUsagePanel: React.FC<ContextUsagePanelProps> = ({
         })}
       </ul>
 
-      <TurnCostStrip meter={meter} />
+      <TurnCostStrip meter={meter} live={live} />
 
       <footer className="ctx-panel__foot">
         <span>

--- a/ui/components/Chat/TurnCostStrip.tsx
+++ b/ui/components/Chat/TurnCostStrip.tsx
@@ -13,6 +13,7 @@ import {
   formatDuration,
   formatTokens,
   type ContextMeter,
+  type LiveTurn,
 } from "./contextMeterModel";
 
 const Stat: React.FC<{ label: string; value: string }> = ({ label, value }) => (
@@ -22,9 +23,46 @@ const Stat: React.FC<{ label: string; value: string }> = ({ label, value }) => (
   </div>
 );
 
-export const TurnCostStrip: React.FC<{ meter: ContextMeter }> = ({ meter }) => {
+export const TurnCostStrip: React.FC<{
+  meter: ContextMeter;
+  live: LiveTurn | null;
+}> = ({ meter, live }) => {
   const [open, setOpen] = useState(false);
   const turn = meter.lastTurn;
+
+  /**
+   * A running turn takes over the strip. The alternative — showing the
+   * previous turn's figures under the heading "This turn" — is what made the
+   * panel look broken: four em-dashes and a stale price, while the agent was
+   * visibly doing work.
+   */
+  if (live) {
+    return (
+      <div className="ctx-turn ctx-turn--live">
+        <div className="ctx-turn__head">
+          <span className="ctx-turn__title">This turn</span>
+          <span className="ctx-turn__running">running</span>
+        </div>
+        <div className="ctx-turn__stats">
+          <Stat label="steps" value={String(live.steps)} />
+          <Stat label="tools" value={String(live.toolCalls)} />
+          <Stat label="time" value={formatDuration(live.elapsedMs)} />
+          <Stat
+            label="context"
+            value={
+              live.peakContextTokens
+                ? formatTokens(live.peakContextTokens)
+                : "—"
+            }
+          />
+        </div>
+        {/* Cost is the one figure with no honest live value: providers report
+            it when the turn closes. Naming the omission beats a placeholder
+            number that silently changes. */}
+        <p className="ctx-turn__note">Cost is billed when the turn finishes.</p>
+      </div>
+    );
+  }
 
   if (!turn) {
     return (

--- a/ui/components/Chat/contextMeterModel.ts
+++ b/ui/components/Chat/contextMeterModel.ts
@@ -34,6 +34,21 @@ export interface TurnUsage {
   contextBudgetTokens: number | null;
 }
 
+/**
+ * The turn currently running. Present only while the agent is working, and
+ * deliberately thinner than `TurnUsage`: cost and cache splits are not known
+ * until the provider closes the turn, and inventing them mid-flight would put
+ * a number on screen that later changes for no reason the user can see.
+ */
+export interface LiveTurn {
+  model: string;
+  startedAt: string;
+  elapsedMs: number;
+  steps: number;
+  toolCalls: number;
+  peakContextTokens: number;
+}
+
 export interface ContextMeter {
   model: string;
   provider: string;
@@ -42,11 +57,12 @@ export interface ContextMeter {
   userCap: number | null;
   usedTokens: number;
   /**
-   * Where fill came from. "billed" means the turn predates the peak
-   * measurement and the number is a per-step average, so the UI says so
-   * rather than implying a precision it does not have.
+   * Where fill came from. "live" is the turn in progress; "billed" means the
+   * turn predates the peak measurement and the number is a per-step average,
+   * so the UI says so rather than implying a precision it does not have.
    */
-  fillSource: "measured" | "billed" | "none";
+  fillSource: "live" | "measured" | "billed" | "none";
+  liveTurn?: LiveTurn | null;
   lastTurn: TurnUsage | null;
   totals: {
     turns: number;


### PR DESCRIPTION
## What

The context meter could only see **finished** turns. Everything about a turn is written to SQLite once, at the end, so while the agent was working the ring sat frozen and "This turn" showed four em-dashes plus the *previous* turn's price — for nine minutes on a 107-step turn — then jumped.

This adds a live read path, and fixes two correctness bugs found on the way.

## Live turn

- **`src/gateway/services/agent/liveTurn.ts`** (new) — per-process, in-memory snapshot of the running turn: steps, tool calls, peak context, billed tokens. In-memory on purpose: a live turn isn't history, and persisting it would leave a permanent "in progress" row nothing ever closes.
  - `begin`/`end` are **token-guarded** for the same reason `clearStreamingStateIfOwner` exists — the auto-send queue can start the next turn before the previous one finishes unwinding, and an unconditional delete in the loser's `finally` would kill the winner's meter.
  - Updates are **monotonic**: a continuation stream restarts its own counters at zero, and letting that through would make the ring visibly fall backwards mid-turn.
  - 1h staleness guard, so a hard provider abort can't leave a meter permanently claiming to be live.
- **`AgentService`** — publishes from `onStepFinish` (the numbers already existed there as locals), opens the snapshot *before* the first step so a slow first step still shows an elapsed clock, closes it in the outer `finally`.
- **`getContextMeter`** — an in-flight turn outranks the last finished one, and reports the same measurement `turn_peak_context_tokens` stores, so the ring doesn't jump when the row lands. Before the first step exists, it holds the previous fill rather than dropping to 0%.

## UI

- 1s poll while `isSending` (one indexed row + a map read over a local socket; the step boundary is the real freshness ceiling, not the poll).
- Elapsed clock ticks client-side and is recomputed from `startedAt`, so a throttled background tab corrects itself instead of drifting.
- Ring gets a sweep arc + breathing label; panel gets a `Live` badge; `TurnCostStrip` gets a live variant. Motion carries the "still working" signal so the numbers — which are legitimately unchanged between steps — don't have to fake it.
- Cost stays **absent** with a one-line note. Providers bill at turn close; a placeholder that silently changes is worse than an honest gap.
- Full `prefers-reduced-motion` block.

## Two bugs fixed on the way

**`readLastTurnUsage` ordered by `sequence`, which is not an ordinal.** That column holds the turn's parts array as JSON (~100–300KB/row). The sort compared those blobs as *text*, so "last turn" was whichever turn began with the alphabetically largest thinking block — in my workspace, a turn from nine days earlier. That's why the meter read 32 tokens / 0% while quoting a $2.74 cost from a different turn. Now ordered by `timestamp DESC` (ISO-8601, so lexical is chronological) with `rowid` as tiebreak.

**The billed fallback read `prompt_tokens` alone.** On Anthropic, cached prefixes are billed and reported separately — a well-cached turn records 32 input tokens against 3.1M cache reads. Reading only the first is how a full window measured 0%. Cache read + write are added back, same as `resolveStepContextTokens` already does on the live path.

## Testing

- `npm run type-check` — no new errors in any touched file (339 pre-existing repo-wide, unchanged).
- Prettier clean on every file that was clean at HEAD.
- Manually exercised: long multi-step turns (ring animates, steps/tools/context climb, elapsed ticks), turn completion (live figures hand off to billed without a jump), back-to-back sends (no meter death from the token guard), idle chat (unchanged behaviour).
